### PR TITLE
iq-cli: New init() API with InitOpts

### DIFF
--- a/iq-cli/src/init.rs
+++ b/iq-cli/src/init.rs
@@ -1,0 +1,62 @@
+//! `iq-cli` framework initialization
+
+#[cfg(feature = "simplelog")]
+use simplelog::{self, CombinedLogger, LevelFilter, TermLogger};
+
+use shell::{self, ColorConfig};
+
+/// `iq-cli` framework options which can be supplied when initializing
+#[derive(Debug)]
+pub struct InitOpts {
+    /// Color configuration
+    pub color_config: ColorConfig,
+
+    /// Enable logging subsystem
+    #[cfg(feature = "simplelog")]
+    pub enable_logging: bool,
+
+    /// Enable verbose logging
+    pub verbose: bool,
+}
+
+/// Framework default options
+impl Default for InitOpts {
+    fn default() -> InitOpts {
+        InitOpts {
+            color_config: ColorConfig::default(),
+            #[cfg(feature = "simplelog")]
+            enable_logging: true,
+            verbose: false,
+        }
+    }
+}
+
+/// Initialize a command-line app with the given options
+pub fn init<I: Into<InitOpts>>(into_opts: I) {
+    let opts = into_opts.into();
+
+    // Initialize the shell
+    shell::config(opts.color_config);
+
+    // Initialize the logging subsystem
+    #[cfg(feature = "simplelog")]
+    {
+        if opts.enable_logging {
+            init_logging(Default::default(), opts.verbose);
+        }
+    }
+}
+
+/// Initialize the logging subsystem (i.e. simplelog)
+#[cfg(feature = "simplelog")]
+fn init_logging(config: simplelog::Config, verbose: bool) {
+    let level_filter = if verbose {
+        LevelFilter::Debug
+    } else {
+        LevelFilter::Info
+    };
+
+    if let Some(logger) = TermLogger::new(level_filter, config) {
+        CombinedLogger::init(vec![logger]).unwrap()
+    }
+}

--- a/iq-cli/src/lib.rs
+++ b/iq-cli/src/lib.rs
@@ -51,11 +51,10 @@ extern crate term;
 #[macro_use]
 extern crate assert_matches;
 
-#[cfg(feature = "simplelog")]
-use simplelog::{CombinedLogger, LevelFilter, TermLogger};
 pub use term::color::{self, Color};
 
 mod error;
+mod init;
 #[cfg(any(feature = "errors", feature = "status"))]
 pub mod macros;
 #[cfg(feature = "options")]
@@ -63,31 +62,7 @@ pub mod options;
 mod shell;
 
 pub use error::Error;
+pub use init::{init, InitOpts};
 #[cfg(feature = "options")]
 pub use options::Options;
-pub use shell::{config, status, ColorConfig, Stream};
-
-/// Initialize a command-line app with the given options
-// TODO: better API for this
-#[allow(unused_variables)]
-pub fn init(color_config: ColorConfig, verbose: bool) {
-    config(color_config);
-    #[cfg(feature = "simplelog")]
-    init_logging(verbose);
-}
-
-/// Initialize the logging subsystem (i.e. simplelog)
-#[cfg(feature = "simplelog")]
-fn init_logging(verbose: bool) {
-    let level_filter = if verbose {
-        LevelFilter::Debug
-    } else {
-        LevelFilter::Info
-    };
-
-    let config = simplelog::Config::default();
-
-    if let Some(logger) = TermLogger::new(level_filter, config) {
-        CombinedLogger::init(vec![logger]).unwrap()
-    }
-}
+pub use shell::{status, ColorConfig, Stream};


### PR DESCRIPTION
Moves all framework configuration to a struct, and makes `iq_cli::init` take `Into<InitOpts>` as an argument.

This allows commands to `impl Into<InitOpts>` so that `InitOpts` can be created from given command-line options easily.