### PR TITLE
subtle-encoding: Initial crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,6 +279,7 @@ name = "subtle-encoding"
 version = "0.0.0"
 dependencies = [
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,6 +277,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "subtle-encoding"
 version = "0.0.0"
+dependencies = [
+ "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,6 +280,7 @@ version = "0.0.0"
 dependencies = [
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -410,6 +411,14 @@ dependencies = [
  "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[[package]]
+name = "zeroize"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [metadata]
 "checksum aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "68f56c7353e5a9547cbd76ed90f7bb5ffc3ba09d4ea9bd1d8c06c8b1142eeb5a"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
@@ -459,3 +468,4 @@ dependencies = [
 "checksum winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "afc5508759c5bf4285e61feb862b6083c8480aec864fa17a81fdec6f69b461ab"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "561ed901ae465d6185fa7864d63fbd5720d0ef718366c9a4dc83cf6170d7e9ba"
+"checksum zeroize 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8df90d68a3894cf28c5cda32eef28d3394596478ef321ea671a1cc19093e4afe"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,6 +275,10 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "subtle-encoding"
+version = "0.0.0"
+
+[[package]]
 name = "syn"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,7 @@ members = [
     "canonical-path",
     "iq-bech32",
     "tai64",
-    "zeroize"
+    "subtle-encoding",
+    "tai64",
+    "zeroize",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,5 @@ members = [
     "tai64",
     "subtle-encoding",
     "tai64",
-    "zeroize",
+    "zeroize"
 ]

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ This repository contains the following crates:
 * [iq-bech32:](https://github.com/iqlusioninc/crates/tree/master/iq-bech32)
   Bech32 (BIP-173) human-friendly base32 encoding for binary data intended for
   use with cryptographic keys.
+* [subtle-encoding:](https://github.com/iqlusioninc/crates/tree/master/subtle-encoding)
+  Base64 and hexadecimal encoder/decoder with "constant time-ish" implementation.
 * [tai64:](https://github.com/iqlusioninc/crates/tree/master/tai64)
   TAI64(N) timestamp format (Temps Atomique International).
 * [zeroize:](https://github.com/iqlusioninc/crates/tree/master/zeroize)

--- a/subtle-encoding/Cargo.toml
+++ b/subtle-encoding/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name        = "subtle-encoding"
 description = """
-              Encoders and decoders for common data encodings (WIP) which avoid
-              branching or performing table lookups based on their inputs
-              (a.k.a. constant time-ish). Useful for encoding/decoding secret
+              Encoders and decoders for common data encodings (i.e. hex, identity)
+              which avoid data-dependent branching/table lookups and therefore
+              "best effort" constant time. Useful for encoding/decoding secret
               values such as cryptographic keys.
               """
 version     = "0.0.0" # Also update html_root_url in lib.rs when bumping this
@@ -13,15 +13,16 @@ homepage    = "https://github.com/iqlusioninc/crates/"
 repository  = "https://github.com/iqlusioninc/crates/tree/master/subtle-encoding"
 readme      = "README.md"
 categories  = ["cryptography", "encoding", "no-std"]
-keywords    = ["constant-time", "keys", "secrets", "security"]
+keywords    = ["constant-time", "hex", "keys", "secrets", "security"]
 
 [dependencies]
 failure = "0.1"
 failure_derive = "0.1"
 
 [features]
-default = ["std"]
+default = ["hex", "std"]
 alloc = []
+hex = []
 std = ["alloc"]
 
 [badges]

--- a/subtle-encoding/Cargo.toml
+++ b/subtle-encoding/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name        = "subtle-encoding"
+description = """
+              Encoders and decoders for common data encodings (WIP) which avoid
+              branching or performing table lookups based on their inputs
+              (a.k.a. constant time-ish). Useful for encoding/decoding secret
+              values such as cryptographic keys.
+              """
+version     = "0.0.0" # Also update html_root_url in lib.rs when bumping this
+authors     = ["Tony Arcieri <tony@iqlusion.io>"]
+license     = "Apache-2.0 OR MIT"
+homepage    = "https://github.com/iqlusioninc/crates/"
+repository  = "https://github.com/iqlusioninc/crates/tree/master/subtle-encoding"
+readme      = "README.md"
+categories  = ["cryptography", "encoding", "no-std"]
+keywords    = ["constant-time", "keys", "secrets", "security"]
+
+[badges]
+circle-ci = { repository = "iqlusioninc/crates" }

--- a/subtle-encoding/Cargo.toml
+++ b/subtle-encoding/Cargo.toml
@@ -26,7 +26,7 @@ alloc = []
 base64 = ["zeroize"]
 hex = []
 nightly = []
-std = ["alloc"]
+std = ["alloc", "zeroize"]
 
 [badges]
 circle-ci = { repository = "iqlusioninc/crates" }

--- a/subtle-encoding/Cargo.toml
+++ b/subtle-encoding/Cargo.toml
@@ -17,6 +17,7 @@ keywords    = ["constant-time", "keys", "secrets", "security"]
 
 [dependencies]
 failure = "0.1"
+failure_derive = "0.1"
 
 [features]
 default = ["std"]

--- a/subtle-encoding/Cargo.toml
+++ b/subtle-encoding/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name        = "subtle-encoding"
 description = """
-              Encoders and decoders for common data encodings (i.e. hex, identity)
+              Encoders and decoders for common data encodings (base64, hex)
               which avoid data-dependent branching/table lookups and therefore
-              "best effort" constant time. Useful for encoding/decoding secret
-              values such as cryptographic keys.
+              provide "best effort" constant time. Useful for encoding/decoding
+              secret values such as cryptographic keys.
               """
 version     = "0.0.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
@@ -13,16 +13,19 @@ homepage    = "https://github.com/iqlusioninc/crates/"
 repository  = "https://github.com/iqlusioninc/crates/tree/master/subtle-encoding"
 readme      = "README.md"
 categories  = ["cryptography", "encoding", "no-std"]
-keywords    = ["constant-time", "hex", "keys", "secrets", "security"]
+keywords    = ["base64", "constant-time", "hex", "secrets", "security"]
 
 [dependencies]
 failure = "0.1"
 failure_derive = "0.1"
+zeroize = { version = "0.1", optional = true }
 
 [features]
-default = ["hex", "std"]
+default = ["base64", "hex", "std"]
 alloc = []
+base64 = ["zeroize"]
 hex = []
+nightly = []
 std = ["alloc"]
 
 [badges]

--- a/subtle-encoding/Cargo.toml
+++ b/subtle-encoding/Cargo.toml
@@ -15,5 +15,13 @@ readme      = "README.md"
 categories  = ["cryptography", "encoding", "no-std"]
 keywords    = ["constant-time", "keys", "secrets", "security"]
 
+[dependencies]
+failure = "0.1"
+
+[features]
+default = ["std"]
+alloc = []
+std = ["alloc"]
+
 [badges]
 circle-ci = { repository = "iqlusioninc/crates" }

--- a/subtle-encoding/LICENSE-MIT
+++ b/subtle-encoding/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 iqlusion
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/subtle-encoding/README.md
+++ b/subtle-encoding/README.md
@@ -2,28 +2,25 @@
 
 [![Crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
-![MIT/Apache 2.0 Licensed][license-image]
+![Apache 2.0/MIT Licensed][license-image]
 [![Build Status][build-image]][build-link]
+<img src="https://rustsec.org/assets/img/badges/unsafe/forbidden.svg" height="20" alt="unsafe: forbidden">
 
 [crate-image]: https://img.shields.io/crates/v/subtle-encoding.svg
 [crate-link]: https://crates.io/crates/subtle-encoding
 [docs-image]: https://docs.rs/subtle-encoding/badge.svg
 [docs-link]: https://docs.rs/subtle-encoding/
-[license-image]: https://img.shields.io/badge/license-MIT/Apache2.0-blue.svg
+[license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [build-image]: https://circleci.com/gh/iqlusioninc/crates.svg?style=shield
 [build-link]: https://circleci.com/gh/iqlusioninc/crates
 
-Rust crate for encoding/decoding binary data to/from **hex** and **identity**
+Rust crate for encoding/decoding binary data to/from **base64** and **hex**
 encodings while avoiding data-dependent branching/table lookups, and therefore
 providing "best effort" constant-time operation.
 
 Useful for encoding/decoding secret values such as cryptographic keys.
 
 [Documentation]
-
-## Status
-
-Not ready to use.
 
 ## Security Notice
 

--- a/subtle-encoding/README.md
+++ b/subtle-encoding/README.md
@@ -13,9 +13,11 @@
 [build-image]: https://circleci.com/gh/iqlusioninc/crates.svg?style=shield
 [build-link]: https://circleci.com/gh/iqlusioninc/crates
 
-Rust crate for encoding/decoding binary data in (TBD) formats which avoids
-data-dependent branching/table lookups. Useful for encoding/decoding secret
-values such as cryptographic keys.
+Rust crate for encoding/decoding binary data to/from **hex** and **identity**
+encodings while avoiding data-dependent branching/table lookups, and therefore
+providing "best effort" constant-time operation.
+
+Useful for encoding/decoding secret values such as cryptographic keys.
 
 [Documentation]
 

--- a/subtle-encoding/README.md
+++ b/subtle-encoding/README.md
@@ -1,0 +1,47 @@
+# subtle-encoding <a href="https://www.iqlusion.io"><img src="https://storage.googleapis.com/iqlusion-prod-web-assets/img/logo/iqlusion-rings-sm.png" alt="iqlusion" width="24" height="24"></a>
+
+[![Crate][crate-image]][crate-link]
+[![Docs][docs-image]][docs-link]
+![MIT/Apache 2.0 Licensed][license-image]
+[![Build Status][build-image]][build-link]
+
+[crate-image]: https://img.shields.io/crates/v/subtle-encoding.svg
+[crate-link]: https://crates.io/crates/subtle-encoding
+[docs-image]: https://docs.rs/subtle-encoding/badge.svg
+[docs-link]: https://docs.rs/subtle-encoding/
+[license-image]: https://img.shields.io/badge/license-MIT/Apache2.0-blue.svg
+[build-image]: https://circleci.com/gh/iqlusioninc/crates.svg?style=shield
+[build-link]: https://circleci.com/gh/iqlusioninc/crates
+
+Rust crate for encoding/decoding binary data in (TBD) formats which avoids
+data-dependent branching/table lookups. Useful for encoding/decoding secret
+values such as cryptographic keys.
+
+[Documentation]
+
+## Status
+
+Not ready to use.
+
+## Security Notice
+
+While this crate takes care to avoid data-dependent branching, that does not
+actually make it "constant time", which is an architecture-dependent property.
+
+This crate is a "best effort" attempt at providing a constant time encoding
+library, however it presently provides no guarantees, nor has it been
+independently audited for security vulnerabilities.
+
+Use at your own risk.
+
+## License
+
+**subtle-encoding** is distributed under the terms of either the MIT license
+or the Apache License (Version 2.0), at your option.
+
+See [LICENSE] (Apache License, Version 2.0) file in the `iqlusioninc/crates`
+toplevel directory of this repository or [LICENSE-MIT] for details.
+
+[Documentation]: https://docs.rs/subtle-encoding/
+[LICENSE]: https://github.com/iqlusioninc/crates/blob/master/LICENSE
+[LICENSE-MIT]: https://github.com/iqlusioninc/crates/blob/master/subtle-encoding/LICENSE-MIT

--- a/subtle-encoding/src/base64.rs
+++ b/subtle-encoding/src/base64.rs
@@ -1,0 +1,268 @@
+//! Adapted from this C++ implementation:
+//!
+//! <https://github.com/Sc00bz/ConstTimeEncoding/blob/master/base64.cpp>
+//!
+//! Copyright (c) 2014 Steve "Sc00bz" Thomas (steve at tobtu dot com)
+//! Derived code is dual licensed MIT + Apache 2 (with permission)
+
+use super::{
+    Encoding,
+    Error::{self, EncodingInvalid},
+};
+#[cfg(feature = "alloc")]
+use prelude::*;
+use zeroize::secure_zero_memory;
+
+/// Base64 `Encoding` (traditional non-URL-safe RFC 4648 version)
+///
+/// Character set: `[A-Z]`, `[a-z]`, `[0-9]`, `+`, `/`
+#[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub struct Base64 {}
+
+/// Encode the given data as Base64, returning a `Vec<u8>`
+#[cfg(feature = "alloc")]
+pub fn encode<B: AsRef<[u8]>>(bytes: B) -> Vec<u8> {
+    Base64::default().encode(bytes)
+}
+
+/// Decode the given data from Base64, returning a `Vec<u8>`
+#[cfg(feature = "alloc")]
+pub fn decode<B: AsRef<[u8]>>(encoded_bytes: B) -> Result<Vec<u8>, Error> {
+    Base64::default().decode(encoded_bytes)
+}
+
+impl Encoding for Base64 {
+    fn encode_to_slice(&self, src: &[u8], dst: &mut [u8]) -> Result<usize, Error> {
+        let mut src_offset: usize = 0;
+        let mut dst_offset: usize = 0;
+        let mut src_length: usize = src.len();
+
+        while src_length >= 3 {
+            encode_3bytes(
+                &src[src_offset..add!(src_offset, 3)],
+                &mut dst[dst_offset..add!(dst_offset, 4)],
+            );
+
+            src_offset = add!(src_offset, 3);
+            dst_offset = add!(dst_offset, 4);
+            src_length = sub!(src_length, 3);
+        }
+
+        if src_length > 0 {
+            let mut tmp = [0u8; 3];
+            tmp[..src_length].copy_from_slice(&src[src_offset..add!(src_offset, src_length)]);
+
+            encode_3bytes(&tmp, &mut dst[dst_offset..]);
+            dst[add!(dst_offset, 3)] = b'=';
+
+            if src_length == 1 {
+                dst[add!(dst_offset, 2)] = b'=';
+            }
+
+            dst_offset = add!(dst_offset, 4);
+            secure_zero_memory(&mut tmp);
+        }
+
+        Ok(dst_offset)
+    }
+
+    fn encoded_len(&self, _bytes: &[u8]) -> usize {
+        panic!("unimplemented");
+    }
+
+    fn decode_to_slice(&self, src: &[u8], dst: &mut [u8]) -> Result<usize, Error> {
+        let mut src_offset: usize = 0;
+        let mut dst_offset: usize = 0;
+        let mut src_length: usize = src.len();
+        let mut err: isize = 0;
+
+        while src_length > 4 {
+            err |= decode_3bytes(
+                &src[src_offset..add!(src_offset, 4)],
+                &mut dst[dst_offset..add!(dst_offset, 3)],
+            );
+
+            src_offset = add!(src_offset, 4);
+            dst_offset = add!(dst_offset, 3);
+            src_length = sub!(src_length, 4);
+        }
+
+        if src_length > 0 {
+            let mut i = 0;
+            let mut tmp_out = [0u8; 3];
+            let mut tmp_in = [b'A'; 4];
+
+            while i < src_length && src[add!(src_offset, i)] != b'=' {
+                tmp_in[i] = src[add!(src_offset, i)];
+                i = add!(i, 1);
+            }
+
+            if i < 2 {
+                err = 1;
+            }
+
+            src_length = sub!(i, 1);
+            err |= decode_3bytes(&tmp_in, &mut tmp_out);
+
+            dst[dst_offset..add!(dst_offset, src_length)].copy_from_slice(&tmp_out[..src_length]);
+            dst_offset = add!(dst_offset, sub!(i, 1));
+
+            secure_zero_memory(&mut tmp_out);
+            secure_zero_memory(&mut tmp_in);
+        }
+
+        if err == 0 {
+            Ok(dst_offset)
+        } else {
+            Err(EncodingInvalid)
+        }
+    }
+
+    fn decoded_len(&self, _bytes: &[u8]) -> Result<usize, Error> {
+        panic!("unimplemented");
+    }
+}
+
+// Base64 character set:
+// [A-Z]      [a-z]      [0-9]      +     /
+// 0x41-0x5a, 0x61-0x7a, 0x30-0x39, 0x2b, 0x2f
+
+#[inline]
+fn encode_3bytes(src: &[u8], dst: &mut [u8]) {
+    let b0 = src[0] as isize;
+    let b1 = src[1] as isize;
+    let b2 = src[2] as isize;
+
+    dst[0] = encode_6bits(shr!(b0, 2));
+    dst[1] = encode_6bits((shl!(b0, 4) | shr!(b1, 4)) & 63);
+    dst[2] = encode_6bits((shl!(b1, 2) | shr!(b2, 6)) & 63);
+    dst[3] = encode_6bits(b2 & 63);
+}
+
+#[inline]
+fn encode_6bits(src: isize) -> u8 {
+    let mut diff: isize = 0x41;
+
+    // if (in > 25) diff += 0x61 - 0x41 - 26; // 6
+    diff = add!(diff, shr!(sub!(25isize, src), 8) & 6);
+
+    // if (in > 51) diff += 0x30 - 0x61 - 26; // -75
+    diff = sub!(diff, shr!(sub!(51isize, src), 8) & 75);
+
+    // if (in > 61) diff += 0x2b - 0x30 - 10; // -15
+    diff = sub!(diff, shr!(sub!(61isize, src), 8) & 15);
+
+    // if (in > 62) diff += 0x2f - 0x2b - 1; // 3
+    diff = add!(diff, shr!(sub!(62isize, src), 8) & 3);
+
+    add!(src, diff) as u8
+}
+
+#[inline]
+fn decode_3bytes(src: &[u8], dst: &mut [u8]) -> isize {
+    let c0 = decode_6bits(src[0]);
+    let c1 = decode_6bits(src[1]);
+    let c2 = decode_6bits(src[2]);
+    let c3 = decode_6bits(src[3]);
+
+    dst[0] = (shl!(c0, 2) | shr!(c1, 4)) as u8;
+    dst[1] = (shl!(c1, 4) | shr!(c2, 2)) as u8;
+    dst[2] = (shl!(c2, 6) | c3) as u8;
+
+    shr!(c0 | c1 | c2 | c3, 8) & 1
+}
+
+#[inline]
+fn decode_6bits(src: u8) -> isize {
+    let ch = src as isize;
+    let mut ret: isize = -1;
+
+    // if (ch > 0x40 && ch < 0x5b) ret += ch - 0x41 + 1; // -64
+    ret = add!(
+        ret,
+        shr!(sub!(0x40isize, ch) & sub!(ch, 0x5bisize), 8) & sub!(ch, 64isize)
+    );
+
+    // if (ch > 0x60 && ch < 0x7b) ret += ch - 0x61 + 26 + 1; // -70
+    ret = add!(
+        ret,
+        shr!(sub!(0x60isize, ch) & sub!(ch, 0x7bisize), 8) & sub!(ch, 70isize)
+    );
+
+    // if (ch > 0x2f && ch < 0x3a) ret += ch - 0x30 + 52 + 1; // 5
+    ret = add!(
+        ret,
+        shr!(sub!(0x2fisize, ch) & sub!(ch, 0x3aisize), 8) & add!(ch, 5isize)
+    );
+
+    // if (ch == 0x2b) ret += 62 + 1;
+    ret = add!(ret, shr!(sub!(0x2aisize, ch) & sub!(ch, 0x2cisize), 8) & 63);
+
+    // if (ch == 0x2f) ret += 63 + 1;
+    add!(ret, shr!(sub!(0x2eisize, ch) & sub!(ch, 0x30isize), 8) & 64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Base64 test vectors
+    struct Base64Vector {
+        /// Raw bytes
+        raw: &'static [u8],
+
+        /// Hex encoded
+        base64: &'static [u8],
+    }
+
+    const BASE64_TEST_VECTORS: &[Base64Vector] = &[
+        Base64Vector {
+            raw: b"",
+            base64: b"",
+        },
+        Base64Vector {
+            raw: b"\0",
+            base64: b"AA==",
+        },
+        Base64Vector {
+            raw: b"***",
+            base64: b"Kioq",
+        },
+        Base64Vector {
+            raw: b"\x01\x02\x03\x04",
+            base64: b"AQIDBA==",
+        },
+        Base64Vector {
+            raw: b"\xAD\xAD\xAD\xAD\xAD",
+            base64: b"ra2tra0=",
+        },
+        Base64Vector {
+            raw: b"\xFF\xFF\xFF\xFF\xFF",
+            base64: b"//////8=",
+        },
+    ];
+
+    #[test]
+    fn encode_test_vectors() {
+        for vector in BASE64_TEST_VECTORS {
+            // 8 is the size of the largest encoded test vector
+            let mut out = [0u8; 8];
+            let out_len = Base64::default()
+                .encode_to_slice(vector.raw, &mut out)
+                .unwrap();
+            assert_eq!(vector.base64, &out[..out_len]);
+        }
+    }
+
+    #[test]
+    fn decode_test_vectors() {
+        for vector in BASE64_TEST_VECTORS {
+            // 5 is the size of the largest decoded test vector
+            let mut out = [0u8; 5];
+            let out_len = Base64::default()
+                .decode_to_slice(vector.base64, &mut out)
+                .unwrap();
+            assert_eq!(vector.raw, &out[..out_len]);
+        }
+    }
+}

--- a/subtle-encoding/src/encoding.rs
+++ b/subtle-encoding/src/encoding.rs
@@ -1,0 +1,101 @@
+use super::Error;
+use prelude::*;
+
+/// All encoding types in this crate implement this trait
+pub trait Encoding: Send + Sync {
+    /// Encode the given slice into the destination buffer.
+    ///
+    /// Returns the size of the encoded output, or `Error` if the destination
+    /// buffer was too small to hold the encoded output.
+    fn encode_to_slice(&self, src: &[u8], dst: &mut [u8]) -> Result<usize, Error>;
+
+    /// Calculate the length of the given data after encoding.
+    fn encoded_length(&self, bytes: &[u8]) -> usize;
+
+    /// Encode the given buffer, returning a `Vec<u8>`
+    #[cfg(feature = "alloc")]
+    fn encode<B: AsRef<[u8]>>(&self, bytes: B) -> Vec<u8> {
+        let length = self.encoded_length(bytes.as_ref());
+        let mut result = vec![0u8; length];
+
+        debug_assert_eq!(
+            self.encode_to_slice(bytes.as_ref(), &mut result),
+            Ok(length)
+        );
+
+        result
+    }
+
+    /// Decode hexadecimal (upper or lower case) with branchless / secret-independent logic
+    fn decode_to_slice(&self, src: &[u8], dst: &mut [u8]) -> Result<usize, Error>;
+
+    /// Calculate the length of the given data after decoding.
+    fn decoded_length(&self, encoded_bytes: &[u8]) -> Result<usize, Error>;
+
+    /// Decode the given buffer, returning a `Vec<u8>`
+    #[cfg(feature = "alloc")]
+    fn decode<B: AsRef<[u8]>>(&self, encoded_bytes: B) -> Result<Vec<u8>, Error> {
+        let length = self.decoded_length(encoded_bytes.as_ref())?;
+        let mut result = vec![0u8; length];
+
+        debug_assert_eq!(
+            self.decode_to_slice(encoded_bytes.as_ref(), &mut result),
+            Ok(length)
+        );
+
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Test input for encoding/decoding cases
+    const TEST_DATA: &[u8] = b"Testing 1, 2, 3...";
+
+    /// Dummy encoding we use to test `Encoding` methods
+    struct TestEncoding {}
+
+    impl Default for TestEncoding {
+        fn default() -> Self {
+            Self {}
+        }
+    }
+
+    impl Encoding for TestEncoding {
+        fn encode_to_slice(&self, src: &[u8], dst: &mut [u8]) -> Result<usize, Error> {
+            let length = self.encoded_length(src);
+            assert_eq!(dst.len(), length);
+            Ok(length)
+        }
+
+        fn encoded_length(&self, bytes: &[u8]) -> usize {
+            bytes.len() * 4 / 3
+        }
+
+        fn decode_to_slice(&self, src: &[u8], dst: &mut [u8]) -> Result<usize, Error> {
+            let length = self.decoded_length(src)?;
+            assert_eq!(dst.len(), length);
+            Ok(length)
+        }
+
+        fn decoded_length(&self, bytes: &[u8]) -> Result<usize, Error> {
+            Ok(bytes.len() * 3 / 4)
+        }
+    }
+
+    /// Make sure `encode()` doesn't panic
+    #[test]
+    fn test_encode() {
+        TestEncoding::default().encode(TEST_DATA);
+    }
+
+    /// Make sure `decode()` doesn't panic
+    #[test]
+    fn test_decode() {
+        let encoding = TestEncoding::default();
+        let encoded = encoding.encode(TEST_DATA);
+        encoding.decode(&encoded).unwrap();
+    }
+}

--- a/subtle-encoding/src/encoding.rs
+++ b/subtle-encoding/src/encoding.rs
@@ -1,7 +1,23 @@
 //! The `Encoding` trait: common operations across all encoders
 
+#[cfg(feature = "std")]
+use std::{
+    fs::File,
+    io::{Read, Write},
+    path::Path,
+};
+#[cfg(unix)]
+use std::{fs::OpenOptions, os::unix::fs::OpenOptionsExt};
+#[cfg(feature = "std")]
+use zeroize::secure_zero_memory;
+
 use super::Error;
 use prelude::*;
+
+/// Mode to use for newly created files
+// TODO: make this configurable?
+#[cfg(unix)]
+pub const FILE_MODE: u32 = 0o600;
 
 /// All encoding types in this crate implement this trait
 pub trait Encoding: Send + Sync {
@@ -28,6 +44,67 @@ pub trait Encoding: Send + Sync {
         result
     }
 
+    /// Encode the given slice to a `String` with this `Encoding`.
+    ///
+    /// Returns an `Error` in the event this encoding does not produce a
+    /// well-formed UTF-8 string.
+    #[cfg(feature = "alloc")]
+    fn encode_to_string<B: AsRef<[u8]>>(&self, bytes: B) -> Result<String, Error> {
+        Ok(String::from_utf8(self.encode(bytes))?)
+    }
+
+    /// Encode the given slice with this `Encoding`, writing the result to the
+    /// supplied `io::Write` type, returning the number of bytes written or a `Error`.
+    #[cfg(feature = "std")]
+    fn encode_to_writer<B, W>(&self, bytes: B, writer: &mut W) -> Result<usize, Error>
+    where
+        B: AsRef<[u8]>,
+        W: Write,
+    {
+        let mut encoded_bytes = self.encode(bytes);
+        writer.write_all(encoded_bytes.as_ref())?;
+        secure_zero_memory(&mut encoded_bytes);
+        Ok(encoded_bytes.len())
+    }
+
+    /// Encode `self` and write it to a file at the given path, returning the
+    /// resulting `File` or a `Error`.
+    ///
+    /// If the file does not exist, it will be created with a mode of
+    /// `FILE_MODE` (i.e. `600`). If the file does exist, it will be erased
+    /// and replaced.
+    #[cfg(all(unix, feature = "std"))]
+    fn encode_to_file<B, P>(&self, bytes: B, path: P) -> Result<File, Error>
+    where
+        B: AsRef<[u8]>,
+        P: AsRef<Path>,
+    {
+        let mut file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .mode(FILE_MODE)
+            .open(path)?;
+
+        self.encode_to_writer(bytes, &mut file)?;
+        Ok(file)
+    }
+
+    /// Encode `self` and write it to a file at the given path, returning the
+    /// resulting `File` or a `Error`.
+    ///
+    /// If the file does not exist, it will be created.
+    #[cfg(all(not(unix), feature = "std"))]
+    fn encode_to_file<B, P>(&self, bytes: B, path: P) -> Result<File, Error>
+    where
+        B: AsRef<[u8]>,
+        P: AsRef<Path>,
+    {
+        let mut file = File::create(path.as_ref())?;
+        self.encode_to_writer(bytes, &mut file)?;
+        Ok(file)
+    }
+
     /// Decode hexadecimal (upper or lower case) with branchless / secret-independent logic
     fn decode_to_slice(&self, src: &[u8], dst: &mut [u8]) -> Result<usize, Error>;
 
@@ -46,6 +123,30 @@ pub trait Encoding: Send + Sync {
         );
 
         Ok(result)
+    }
+
+    /// Decode the given string-alike type with this `Encoding`, returning the
+    /// decoded value or a `Error`.
+    fn decode_from_str<S: AsRef<str>>(&self, encoded: S) -> Result<Vec<u8>, Error> {
+        self.decode(encoded.as_ref().as_bytes())
+    }
+
+    /// Decode the data read from the given `io::Read` type with this
+    /// `Encoding`, returning the decoded value or a `Error`.
+    #[cfg(feature = "std")]
+    fn decode_from_reader<R: Read>(&self, reader: &mut R) -> Result<Vec<u8>, Error> {
+        let mut bytes = vec![];
+        reader.read_to_end(bytes.as_mut())?;
+        let result = self.decode(&bytes);
+        secure_zero_memory(&mut bytes);
+        result
+    }
+
+    /// Read a file at the given path, decoding the data it contains using
+    /// the provided `Encoding`, returning the decoded value or a `Error`.
+    #[cfg(feature = "std")]
+    fn decode_from_file<P: AsRef<Path>>(&self, path: P) -> Result<Vec<u8>, Error> {
+        self.decode_from_reader(&mut File::open(path.as_ref())?)
     }
 }
 

--- a/subtle-encoding/src/encoding.rs
+++ b/subtle-encoding/src/encoding.rs
@@ -10,12 +10,12 @@ pub trait Encoding: Send + Sync {
     fn encode_to_slice(&self, src: &[u8], dst: &mut [u8]) -> Result<usize, Error>;
 
     /// Calculate the length of the given data after encoding.
-    fn encoded_length(&self, bytes: &[u8]) -> usize;
+    fn encoded_len(&self, bytes: &[u8]) -> usize;
 
     /// Encode the given buffer, returning a `Vec<u8>`
     #[cfg(feature = "alloc")]
     fn encode<B: AsRef<[u8]>>(&self, bytes: B) -> Vec<u8> {
-        let length = self.encoded_length(bytes.as_ref());
+        let length = self.encoded_len(bytes.as_ref());
         let mut result = vec![0u8; length];
 
         debug_assert_eq!(
@@ -30,12 +30,12 @@ pub trait Encoding: Send + Sync {
     fn decode_to_slice(&self, src: &[u8], dst: &mut [u8]) -> Result<usize, Error>;
 
     /// Calculate the length of the given data after decoding.
-    fn decoded_length(&self, encoded_bytes: &[u8]) -> Result<usize, Error>;
+    fn decoded_len(&self, encoded_bytes: &[u8]) -> Result<usize, Error>;
 
     /// Decode the given buffer, returning a `Vec<u8>`
     #[cfg(feature = "alloc")]
     fn decode<B: AsRef<[u8]>>(&self, encoded_bytes: B) -> Result<Vec<u8>, Error> {
-        let length = self.decoded_length(encoded_bytes.as_ref())?;
+        let length = self.decoded_len(encoded_bytes.as_ref())?;
         let mut result = vec![0u8; length];
 
         debug_assert_eq!(
@@ -65,22 +65,22 @@ mod tests {
 
     impl Encoding for TestEncoding {
         fn encode_to_slice(&self, src: &[u8], dst: &mut [u8]) -> Result<usize, Error> {
-            let length = self.encoded_length(src);
+            let length = self.encoded_len(src);
             assert_eq!(dst.len(), length);
             Ok(length)
         }
 
-        fn encoded_length(&self, bytes: &[u8]) -> usize {
+        fn encoded_len(&self, bytes: &[u8]) -> usize {
             bytes.len() * 4 / 3
         }
 
         fn decode_to_slice(&self, src: &[u8], dst: &mut [u8]) -> Result<usize, Error> {
-            let length = self.decoded_length(src)?;
+            let length = self.decoded_len(src)?;
             assert_eq!(dst.len(), length);
             Ok(length)
         }
 
-        fn decoded_length(&self, bytes: &[u8]) -> Result<usize, Error> {
+        fn decoded_len(&self, bytes: &[u8]) -> Result<usize, Error> {
             Ok(bytes.len() * 3 / 4)
         }
     }

--- a/subtle-encoding/src/encoding.rs
+++ b/subtle-encoding/src/encoding.rs
@@ -1,3 +1,5 @@
+//! The `Encoding` trait: common operations across all encoders
+
 use super::Error;
 use prelude::*;
 

--- a/subtle-encoding/src/error.rs
+++ b/subtle-encoding/src/error.rs
@@ -4,4 +4,17 @@ pub enum Error {
     /// Data is not encoded correctly
     #[fail(display = "bad encoding")]
     EncodingInvalid,
+
+    /// Input or output buffer is an incorrect length
+    #[fail(display = "invalid length")]
+    LengthInvalid,
+}
+
+/// Assert that the provided condition is true, or else return the given error
+macro_rules! ensure {
+    ($condition:expr, $err:ident) => {
+        if !($condition) {
+            Err($err)?;
+        }
+    };
 }

--- a/subtle-encoding/src/error.rs
+++ b/subtle-encoding/src/error.rs
@@ -1,0 +1,7 @@
+/// Error type
+#[derive(Clone, Eq, PartialEq, Debug, Fail)]
+pub enum Error {
+    /// Data is not encoded correctly
+    #[fail(display = "bad encoding")]
+    EncodingInvalid,
+}

--- a/subtle-encoding/src/error.rs
+++ b/subtle-encoding/src/error.rs
@@ -1,9 +1,17 @@
+#[cfg(feature = "std")]
+use std::{io, string::FromUtf8Error};
+
 /// Error type
 #[derive(Clone, Eq, PartialEq, Debug, Fail)]
 pub enum Error {
     /// Data is not encoded correctly
     #[fail(display = "bad encoding")]
     EncodingInvalid,
+
+    /// Error performing I/O operation
+    #[cfg(feature = "std")]
+    #[fail(display = "I/O error")]
+    IoError,
 
     /// Input or output buffer is an incorrect length
     #[fail(display = "invalid length")]
@@ -17,4 +25,20 @@ macro_rules! ensure {
             Err($err)?;
         }
     };
+}
+
+#[cfg(feature = "std")]
+impl From<io::Error> for Error {
+    fn from(_err: io::Error) -> Error {
+        // TODO: preserve cause or error message?
+        Error::IoError
+    }
+}
+
+#[cfg(feature = "std")]
+impl From<FromUtf8Error> for Error {
+    fn from(_err: FromUtf8Error) -> Error {
+        // TODO: preserve cause or error message?
+        Error::EncodingInvalid
+    }
 }

--- a/subtle-encoding/src/hex.rs
+++ b/subtle-encoding/src/hex.rs
@@ -9,13 +9,24 @@ use super::{
     Encoding,
     Error::{self, EncodingInvalid, LengthInvalid},
 };
+#[cfg(feature = "alloc")]
+use prelude::*;
 
 /// Hexadecimal `Encoding` (a.k.a. Base16)
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub struct Hex {}
 
-/// Constant `Hex` encoding that can be used in lieu of calling `default()`
-pub const HEX: &Hex = &Hex {};
+/// Encode the given data as hexadecimal, returning a `Vec<u8>`
+#[cfg(feature = "alloc")]
+pub fn encode<B: AsRef<[u8]>>(bytes: B) -> Vec<u8> {
+    Hex::default().encode(bytes)
+}
+
+/// Decode the given data from hexadecimal, returning a `Vec<u8>`
+#[cfg(feature = "alloc")]
+pub fn decode<B: AsRef<[u8]>>(encoded_bytes: B) -> Result<Vec<u8>, Error> {
+    Hex::default().decode(encoded_bytes)
+}
 
 impl Encoding for Hex {
     fn encode_to_slice(&self, src: &[u8], dst: &mut [u8]) -> Result<usize, Error> {
@@ -145,7 +156,9 @@ mod tests {
         for vector in HEX_TEST_VECTORS {
             // 10 is the size of the largest encoded test vector
             let mut out = [0u8; 10];
-            let out_len = HEX.encode_to_slice(vector.raw, &mut out).unwrap();
+            let out_len = Hex::default()
+                .encode_to_slice(vector.raw, &mut out)
+                .unwrap();
             assert_eq!(vector.hex, &out[..out_len]);
         }
     }
@@ -155,7 +168,9 @@ mod tests {
         for vector in HEX_TEST_VECTORS {
             // 5 is the size of the largest decoded test vector
             let mut out = [0u8; 5];
-            let out_len = HEX.decode_to_slice(vector.hex, &mut out).unwrap();
+            let out_len = Hex::default()
+                .decode_to_slice(vector.hex, &mut out)
+                .unwrap();
             assert_eq!(vector.raw, &out[..out_len]);
         }
     }
@@ -165,7 +180,10 @@ mod tests {
         let mut out = [0u8; 3];
         assert_eq!(
             LengthInvalid,
-            HEX.decode_to_slice(b"12345", &mut out).err().unwrap(),
+            Hex::default()
+                .decode_to_slice(b"12345", &mut out)
+                .err()
+                .unwrap(),
         )
     }
 }

--- a/subtle-encoding/src/hex.rs
+++ b/subtle-encoding/src/hex.rs
@@ -1,0 +1,171 @@
+//! Adapted from this C++ implementation:
+//!
+//! <https://github.com/Sc00bz/ConstTimeEncoding/blob/master/hex.cpp>
+//!
+//! Copyright (c) 2014 Steve "Sc00bz" Thomas (steve at tobtu dot com)
+//! Derived code is dual licensed MIT + Apache 2 (with permission from @Sc00bz)
+
+use super::{
+    Encoding,
+    Error::{self, EncodingInvalid, LengthInvalid},
+};
+
+/// Hexadecimal `Encoding` (a.k.a. Base16)
+#[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub struct Hex {}
+
+/// Constant `Hex` encoding that can be used in lieu of calling `default()`
+pub const HEX: &Hex = &Hex {};
+
+impl Encoding for Hex {
+    fn encode_to_slice(&self, src: &[u8], dst: &mut [u8]) -> Result<usize, Error> {
+        for (i, src_byte) in src.iter().enumerate() {
+            let offset = mul!(i, 2);
+            dst[offset] = encode_nibble(shr!(src_byte, 4));
+            dst[add!(offset, 1)] = encode_nibble(src_byte & 0x0f);
+        }
+
+        Ok(mul!(src.len(), 2))
+    }
+
+    fn encoded_len(&self, bytes: &[u8]) -> usize {
+        mul!(bytes.len(), 2)
+    }
+
+    fn decode_to_slice(&self, src: &[u8], dst: &mut [u8]) -> Result<usize, Error> {
+        let dst_length = self.decoded_len(src)?;
+        ensure!(dst_length <= dst.len(), LengthInvalid);
+
+        let mut err: usize = 0;
+        for (i, dst_byte) in dst.iter_mut().enumerate().take(dst_length) {
+            let src_offset = mul!(i, 2);
+            let byte =
+                shl!(decode_nibble(src[src_offset]), 4) | decode_nibble(src[add!(src_offset, 1)]);
+            err |= shr!(byte, 8);
+            *dst_byte = byte as u8;
+        }
+
+        if err == 0 {
+            Ok(dst_length)
+        } else {
+            Err(EncodingInvalid)
+        }
+    }
+
+    fn decoded_len(&self, bytes: &[u8]) -> Result<usize, Error> {
+        let encoded_length = bytes.len();
+
+        if encoded_length == 0 {
+            return Ok(0);
+        } else {
+            ensure!(encoded_length & 1 == 0, LengthInvalid);
+        }
+
+        Ok(shr!(encoded_length, 1))
+    }
+}
+
+/// Decode a single nibble of hex
+#[inline]
+fn decode_nibble(src: u8) -> usize {
+    // 0-9  0x30-0x39
+    // A-F  0x41-0x46 or a-f  0x61-0x66
+    let mut byte = src as isize;
+    let mut ret: isize = -1;
+
+    // if (byte > 0x2f && byte < 0x3a) ret += byte - 0x30 + 1; // -47
+    ret = add!(
+        ret,
+        shr!((sub!(0x2fisize, byte) & sub!(byte, 0x3a)), 8) & sub!(byte, 47)
+    );
+
+    // case insensitive decode
+    byte |= 0x20;
+
+    // if (byte > 0x60 && byte < 0x67) ret += byte - 0x61 + 10 + 1; // -86
+    add!(
+        ret,
+        shr!(sub!(0x60isize, byte) & sub!(byte, 0x67), 8) & sub!(byte, 86)
+    ) as usize
+}
+
+/// Encode a single nibble of hex
+#[inline]
+fn encode_nibble(src: u8) -> u8 {
+    let mut ret: isize = src as isize;
+
+    // 0-9  0x30-0x39
+    // a-f  0x61-0x66
+    ret = add!(ret, 0x30);
+
+    // if (in > 0x39) in += 0x61 - 0x3a;
+    add!(ret, shr!(sub!(0x39isize, ret), 8) & sub!(0x61isize, 0x3a)) as u8
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use error::Error::*;
+
+    /// Hexadecimal test vectors
+    struct HexVector {
+        /// Raw bytes
+        raw: &'static [u8],
+
+        /// Hex encoded
+        hex: &'static [u8],
+    }
+
+    const HEX_TEST_VECTORS: &[HexVector] = &[
+        HexVector { raw: b"", hex: b"" },
+        HexVector {
+            raw: b"\0",
+            hex: b"00",
+        },
+        HexVector {
+            raw: b"***",
+            hex: b"2a2a2a",
+        },
+        HexVector {
+            raw: b"\x01\x02\x03\x04",
+            hex: b"01020304",
+        },
+        HexVector {
+            raw: b"\xAD\xAD\xAD\xAD\xAD",
+            hex: b"adadadadad",
+        },
+        HexVector {
+            raw: b"\xFF\xFF\xFF\xFF\xFF",
+            hex: b"ffffffffff",
+        },
+    ];
+
+    #[test]
+    fn encode_test_vectors() {
+        for vector in HEX_TEST_VECTORS {
+            // 10 is the size of the largest encoded test vector
+            let mut out = [0u8; 10];
+            let out_len = HEX.encode_to_slice(vector.raw, &mut out).unwrap();
+            assert_eq!(vector.hex, &out[..out_len]);
+        }
+    }
+
+    #[test]
+    fn decode_test_vectors() {
+        for vector in HEX_TEST_VECTORS {
+            // 5 is the size of the largest decoded test vector
+            let mut out = [0u8; 5];
+            let out_len = HEX.decode_to_slice(vector.hex, &mut out).unwrap();
+            assert_eq!(vector.raw, &out[..out_len]);
+        }
+    }
+
+    #[test]
+    fn decode_odd_size_input() {
+        let mut out = [0u8; 3];
+        assert_eq!(
+            LengthInvalid,
+            HEX.decode_to_slice(b"12345", &mut out).err().unwrap(),
+        )
+    }
+}

--- a/subtle-encoding/src/identity.rs
+++ b/subtle-encoding/src/identity.rs
@@ -1,0 +1,50 @@
+use super::{
+    Encoding,
+    Error::{self, LengthInvalid},
+};
+
+/// `Encoding` which does not transform data and returns the original input.
+#[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub struct Identity {}
+
+/// Constant `Identity` encoding that can be used in lieu of calling `default()`
+pub const IDENTITY: &Identity = &Identity {};
+
+impl Encoding for Identity {
+    fn encode_to_slice(&self, src: &[u8], dst: &mut [u8]) -> Result<usize, Error> {
+        ensure!(self.encoded_length(src) == dst.len(), LengthInvalid);
+        dst.copy_from_slice(src);
+        Ok(src.len())
+    }
+
+    fn encoded_length(&self, bytes: &[u8]) -> usize {
+        bytes.len()
+    }
+
+    fn decode_to_slice(&self, src: &[u8], dst: &mut [u8]) -> Result<usize, Error> {
+        ensure!(self.decoded_length(src)? == dst.len(), LengthInvalid);
+        dst.copy_from_slice(src);
+        Ok(src.len())
+    }
+
+    fn decoded_length(&self, bytes: &[u8]) -> Result<usize, Error> {
+        Ok(bytes.len())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_DATA: &[u8] = b"Testing 1, 2, 3...";
+
+    #[test]
+    fn test_encode() {
+        assert_eq!(IDENTITY.encode(TEST_DATA), TEST_DATA);
+    }
+
+    #[test]
+    fn test_decode() {
+        assert_eq!(IDENTITY.decode(TEST_DATA).unwrap(), TEST_DATA);
+    }
+}

--- a/subtle-encoding/src/identity.rs
+++ b/subtle-encoding/src/identity.rs
@@ -12,22 +12,22 @@ pub const IDENTITY: &Identity = &Identity {};
 
 impl Encoding for Identity {
     fn encode_to_slice(&self, src: &[u8], dst: &mut [u8]) -> Result<usize, Error> {
-        ensure!(self.encoded_length(src) == dst.len(), LengthInvalid);
+        ensure!(self.encoded_len(src) == dst.len(), LengthInvalid);
         dst.copy_from_slice(src);
         Ok(src.len())
     }
 
-    fn encoded_length(&self, bytes: &[u8]) -> usize {
+    fn encoded_len(&self, bytes: &[u8]) -> usize {
         bytes.len()
     }
 
     fn decode_to_slice(&self, src: &[u8], dst: &mut [u8]) -> Result<usize, Error> {
-        ensure!(self.decoded_length(src)? == dst.len(), LengthInvalid);
+        ensure!(self.decoded_len(src)? == dst.len(), LengthInvalid);
         dst.copy_from_slice(src);
         Ok(src.len())
     }
 
-    fn decoded_length(&self, bytes: &[u8]) -> Result<usize, Error> {
+    fn decoded_len(&self, bytes: &[u8]) -> Result<usize, Error> {
         Ok(bytes.len())
     }
 }

--- a/subtle-encoding/src/identity.rs
+++ b/subtle-encoding/src/identity.rs
@@ -1,3 +1,5 @@
+//! Identity `Encoding`: output is identical to input
+
 use super::{
     Encoding,
     Error::{self, LengthInvalid},

--- a/subtle-encoding/src/lib.rs
+++ b/subtle-encoding/src/lib.rs
@@ -22,11 +22,15 @@
 #[macro_use]
 extern crate std;
 
-#[macro_use]
 extern crate failure;
+#[macro_use]
+extern crate failure_derive;
+
+#[macro_use]
+mod error;
 
 mod encoding;
-mod error;
+mod identity;
 mod prelude;
 
-pub use self::{encoding::Encoding, error::Error};
+pub use self::{encoding::Encoding, error::Error, identity::*};

--- a/subtle-encoding/src/lib.rs
+++ b/subtle-encoding/src/lib.rs
@@ -4,6 +4,11 @@
 
 #![crate_name = "subtle_encoding"]
 #![crate_type = "rlib"]
+#![no_std]
+#![cfg_attr(
+    all(feature = "nightly", not(feature = "std")),
+    feature(alloc)
+)]
 #![deny(
     warnings,
     missing_docs,
@@ -12,3 +17,16 @@
 )]
 #![forbid(unsafe_code)]
 #![doc(html_root_url = "https://docs.rs/subtle-encoding/0.0.0")]
+
+#[cfg(any(feature = "std", test))]
+#[macro_use]
+extern crate std;
+
+#[macro_use]
+extern crate failure;
+
+mod encoding;
+mod error;
+mod prelude;
+
+pub use self::{encoding::Encoding, error::Error};

--- a/subtle-encoding/src/lib.rs
+++ b/subtle-encoding/src/lib.rs
@@ -1,0 +1,14 @@
+//! Encoders and decoders for common data encodings (WIP) which avoid
+//! branching or performing table lookups based on their inputs
+//! (a.k.a. constant time-ish).
+
+#![crate_name = "subtle_encoding"]
+#![crate_type = "rlib"]
+#![deny(
+    warnings,
+    missing_docs,
+    unused_import_braces,
+    unused_qualifications
+)]
+#![forbid(unsafe_code)]
+#![doc(html_root_url = "https://docs.rs/subtle-encoding/0.0.0")]

--- a/subtle-encoding/src/lib.rs
+++ b/subtle-encoding/src/lib.rs
@@ -1,6 +1,6 @@
-//! Encoders and decoders for common data encodings (WIP) which avoid
+//! Encoders and decoders for common data encodings (hex, identity) which avoid
 //! branching or performing table lookups based on their inputs
-//! (a.k.a. constant time-ish).
+//! (a.k.a. "constant time-ish").
 
 #![crate_name = "subtle_encoding"]
 #![crate_type = "rlib"]
@@ -28,9 +28,17 @@ extern crate failure_derive;
 
 #[macro_use]
 mod error;
+#[macro_use]
+mod macros;
 
 mod encoding;
+#[cfg(feature = "hex")]
+mod hex;
 mod identity;
 mod prelude;
 
-pub use self::{encoding::Encoding, error::Error, identity::*};
+pub use encoding::Encoding;
+pub use error::Error;
+#[cfg(feature = "hex")]
+pub use hex::*;
+pub use identity::*;

--- a/subtle-encoding/src/lib.rs
+++ b/subtle-encoding/src/lib.rs
@@ -1,4 +1,4 @@
-//! Encoders and decoders for common data encodings (hex, identity) which avoid
+//! Encoders and decoders for common data encodings (base64, hex) which avoid
 //! branching or performing table lookups based on their inputs
 //! (a.k.a. "constant time-ish").
 
@@ -13,7 +13,7 @@
     warnings,
     missing_docs,
     unused_import_braces,
-    unused_qualifications
+    unused_qualifications,
 )]
 #![forbid(unsafe_code)]
 #![doc(html_root_url = "https://docs.rs/subtle-encoding/0.0.0")]
@@ -25,20 +25,26 @@ extern crate std;
 extern crate failure;
 #[macro_use]
 extern crate failure_derive;
+#[cfg(feature = "zeroize")]
+extern crate zeroize;
 
 #[macro_use]
 mod error;
 #[macro_use]
 mod macros;
 
-mod encoding;
+#[cfg(feature = "base64")]
+pub mod base64;
+pub mod encoding;
 #[cfg(feature = "hex")]
-mod hex;
-mod identity;
+pub mod hex;
+pub mod identity;
 mod prelude;
 
+#[cfg(feature = "base64")]
+pub use base64::Base64;
 pub use encoding::Encoding;
 pub use error::Error;
 #[cfg(feature = "hex")]
-pub use hex::*;
-pub use identity::*;
+pub use hex::Hex;
+pub use identity::Identity;

--- a/subtle-encoding/src/macros.rs
+++ b/subtle-encoding/src/macros.rs
@@ -1,0 +1,49 @@
+//! Macros which provide abort-on-overflow/underflow semantics.
+// TODO: replace this with an `AbortOnOverflow<T>` type?
+
+#![allow(unused_macros)]
+
+/// Message to abort with on overflow
+pub(crate) const OVERFLOW_MSG: &str = "overflow";
+
+/// Checked addition
+macro_rules! add {
+    ($a:expr, $b:expr) => {
+        $a.checked_add($b).expect($crate::macros::OVERFLOW_MSG)
+    };
+}
+
+/// Checked subtraction
+macro_rules! sub {
+    ($a:expr, $b:expr) => {
+        $a.checked_sub($b).expect($crate::macros::OVERFLOW_MSG)
+    };
+}
+
+/// Checked multiplication
+macro_rules! mul {
+    ($a:expr, $b:expr) => {
+        $a.checked_mul($b).expect($crate::macros::OVERFLOW_MSG)
+    };
+}
+
+/// Checked division
+macro_rules! div {
+    ($a:expr, $b:expr) => {
+        $a.checked_div($b).expect($crate::macros::OVERFLOW_MSG)
+    };
+}
+
+/// Checked right shift
+macro_rules! shr {
+    ($a:expr, $b:expr) => {
+        $a.checked_shr($b).expect($crate::macros::OVERFLOW_MSG)
+    };
+}
+
+/// Checked left shift
+macro_rules! shl {
+    ($a:expr, $b:expr) => {
+        $a.checked_shl($b).expect($crate::macros::OVERFLOW_MSG)
+    };
+}

--- a/subtle-encoding/src/prelude.rs
+++ b/subtle-encoding/src/prelude.rs
@@ -1,0 +1,7 @@
+//! Use `std` or `alloc` prelude depending on selected cargo features
+
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+pub use alloc::prelude::*;
+
+#[cfg(feature = "std")]
+pub use std::prelude::v1::*;


### PR DESCRIPTION
Encoders and decoders for common data encodings (WIP) which avoid branching or performing table lookups based on their inputs (a.k.a. constant time-ish).

Useful for encoding/decoding secret values such as cryptographic keys.