### PR TITLE
zeroize: Initial crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@ name = "aho-corasick"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -13,7 +13,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -25,7 +25,7 @@ dependencies = [
  "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -33,7 +33,7 @@ name = "backtrace-sys"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.23"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -70,7 +70,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -78,7 +78,7 @@ name = "clear_on_drop"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -88,9 +88,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "termcolor 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -107,7 +107,7 @@ name = "failure_derive"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -148,7 +148,7 @@ name = "lazy_static"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "version_check 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -158,7 +158,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "log"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -166,10 +166,12 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -177,17 +179,17 @@ name = "num-integer"
 version = "0.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.15"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -204,7 +206,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -213,7 +215,7 @@ name = "quote"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -223,7 +225,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -241,11 +243,11 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -264,7 +266,7 @@ name = "remove_dir_all"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -277,7 +279,7 @@ name = "syn"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -287,7 +289,7 @@ name = "synstructure"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -313,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -354,12 +356,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "version_check"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -376,7 +378,7 @@ name = "winapi-util"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -389,8 +391,15 @@ name = "wincolor"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zeroize"
+version = "0.0.0"
+dependencies = [
+ "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
@@ -400,7 +409,7 @@ dependencies = [
 "checksum backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "c66d56ac8dabd07f6aacdaf633f4b8262f5b3601a810a0dcddffd5c22c69daa0"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "90492c5858dd7d2e78691cfb89f90d273a2800fc11d98f60786e5d87e2f83781"
-"checksum cc 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)" = "c37f0efaa4b9b001fa6f02d4b644dee4af97d3414df07c51e3e4f015f3a3e131"
+"checksum cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "f159dfd43363c4d08055a07703eb7a3406b0dac4d0584d96965a3262db3c9d16"
 "checksum cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4e7bb64a8ebb0d856483e1e682ea3422f883c5f5615a90d51a2c82fe87fdd3"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "97276801e127ffb46b66ce23f35cc96bd454fa311294bced4bbace7baa8b1d17"
@@ -412,32 +421,32 @@ dependencies = [
 "checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
 "checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
-"checksum log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cba860f648db8e6f269df990180c2217f333472b4a6e901e97446858487971e2"
-"checksum memchr 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a3b4142ab8738a78c51896f704f83c11df047ff1bda9a92a661aa6361552d93d"
+"checksum log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fcce5fa49cc693c312001daf1d13411c4a5283796bac1084299ea3e567113f"
+"checksum memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4b3629fe9fdbff6daa6c33b90f7c08355c1aca05a3d01fa8063b822fcf185f3b"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
-"checksum num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "630de1ef5cc79d0cdd78b7e33b81f083cbfe90de0f4b2b2f07f905867c70e9fe"
-"checksum proc-macro2 0.4.15 (registry+https://github.com/rust-lang/crates.io-index)" = "295af93acfb1d5be29c16ca5b3f82d863836efd9cb0c14fd83811eb9a110e452"
+"checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
+"checksum proc-macro2 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)" = "ffe022fb8c8bd254524b0b3305906c1921fa37a84a644e29079a9e62200c3901"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quickcheck 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c01babc5ffd48a2a83744b3024814bb46dfd4f2a4705ccb44b1b60e644fdcab7"
 "checksum quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5"
 "checksum rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd"
 "checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
-"checksum regex 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "67d0301b0c6804eca7e3c275119d0b01ff3b7ab9258a65709e608a66312a1025"
+"checksum regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2069749032ea3ec200ca51e4a31df41759190a88edca0d2d86ee8bedf7073341"
 "checksum regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "747ba3b235651f6e2f67dfa8bcdcd073ddb7c243cb21c442fc12395dfcac212d"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
 "checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
 "checksum synstructure 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "85bb9b7550d063ea184027c9b8c20ac167cd36d3e06b3a40bceb9d746dc1a7b7"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-"checksum termcolor 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3390f44f1f706d8870297b6a2c4f92d9ab65a37c265fbbc6ac4ee72bcc2f3698"
+"checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum utf8-ranges 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd70f467df6810094968e2fce0ee1bd0e87157aceb026a8c083bcf5e25b9efe4"
-"checksum version_check 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7716c242968ee87e5542f8021178248f267f295a5c4803beae8b8b7fd9bc6051"
-"checksum winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "773ef9dcc5f24b7d850d0ff101e542ff24c3b090a9768e03ff889fdef41f00fd"
+"checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+"checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "afc5508759c5bf4285e61feb862b6083c8480aec864fa17a81fdec6f69b461ab"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,5 +2,6 @@
 members = [
     "canonical-path",
     "iq-bech32",
-    "tai64"
+    "tai64",
+    "zeroize"
 ]

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name        = "zeroize"
+description = """
+              (Alpha quality preview) Securely zero out memory while avoiding
+              compiler optimizations: unified 'secure_zero_memory()' wrapper for
+              secure intrinsic functions for zeroing memory, using FFI to
+              invoke OS intrinsics on stable (with support for Linux, Windows,
+              OS X/iOS, FreeBSD, OpenBSD, NetBSD, DragonflyBSD), or the
+              unstable 'volatile_set_memory()` intrinsic on nightly.
+              No insecure fallbacks, no dependencies, no std, no functionality
+              besides securely zeroing memory.
+              """
+version     = "0.0.0" # Also update html_root_url in lib.rs when bumping this
+authors     = ["Tony Arcieri <tony@iqlusion.io>"]
+license     = "Apache-2.0 OR MIT"
+homepage    = "https://github.com/iqlusioninc/crates/"
+repository  = "https://github.com/iqlusioninc/crates/tree/master/zeroize"
+readme      = "README.md"
+categories  = ["cryptography", "no-std"]
+keywords    = ["memory", "memset", "secure", "volatile", "zero"]
+
+[features]
+default = ["linux-backport", "windows"]
+linux-backport = ["cc"] # backport of 'explicit_bzero' (C code) for glibc <2.25
+nightly = []
+windows = ["cc"]
+
+[build-dependencies]
+cc = { version = "1", optional = true }
+
+[badges]
+circle-ci = { repository = "iqlusioninc/crates" }

--- a/zeroize/LICENSE-MIT
+++ b/zeroize/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 iqlusion
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/zeroize/README.md
+++ b/zeroize/README.md
@@ -1,0 +1,150 @@
+# [zeroize].rs <a href="https://www.iqlusion.io"><img src="https://storage.googleapis.com/iqlusion-prod-web-assets/img/logo/iqlusion-rings-sm.png" alt="iqlusion" width="24" height="24"></a>🄌
+
+[![Crate][crate-image]][crate-link]
+[![Docs][docs-image]][docs-link]
+![MIT/Apache 2.0 Licensed][license-image]
+[![Build Status][build-image]][build-link]
+
+[crate-image]: https://img.shields.io/crates/v/zeroize.svg
+[crate-link]: https://crates.io/crates/zeroize
+[docs-image]: https://docs.rs/zeroize/badge.svg
+[docs-link]: https://docs.rs/zeroize/
+[license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
+[build-image]: https://circleci.com/gh/iqlusioninc/crates.svg?style=shield
+[build-link]: https://circleci.com/gh/iqlusioninc/crates
+
+*Alpha-quality preview*: Rust crate for securely zeroing memory while
+avoiding compiler optimizations.
+
+This crate provides a safe<sup>†</sup>, portable `secure_zero_memory()`
+wrapper function for secure memory zeroing intrinsics which are
+specifically documented as guaranteeing they won't be "optimized away".
+
+[Documentation]
+
+## About
+
+[Zeroing memory securely is hard] - compilers optimize for performance, and
+in doing so they love to "optimize away" unnecessary zeroing calls. There are
+many documented "tricks" to attempt to avoid these optimizations and ensure
+that a zeroing routine is performed reliably.
+
+This crate isn't about tricks: instead it *only* invokes intrinsics (either
+rustc/LLVM or OS) with a documented contract assuring the caller that after
+the intrinsic is invoked, memory will be zeroed 100% of the time.
+
+**No insecure fallbacks. No dependencies<sup>‡</sup>. `#![no_std]`. No
+functionality besides securely zeroing memory.**
+
+This crate has one job and one function: `secure_zero_memory()`, and it
+provides the thinnest portable wrapper for secure zeroing intrinsics.
+
+If it can't find a way to securely zero memory, **it will refuse to compile**.
+Don't worry about that though: it supports almost every tier 1 and 2 Rust
+platform (and even most of tier 3!). See below for compatiblity.
+
+## Platform Support / Intrinsics
+
+This crate provides wrappers for the following intrinsics:
+
+- `stable` rust: OS intrinsics
+  - [explicit_bzero()]: Linux<sup>‡</sup>, FreeBSD, OpenBSD, DragonflyBSD
+  - [explicit_memset()]: NetBSD
+  - [memset_s()]: Mac OS X/iOS, Solaris
+  - [RtlSecureZeroMemory()]: Windows
+- `nightly` rust: [volatile_set_memory()] (all platforms)
+
+Notable unsupported platforms at present: Fuchsia, Redox. PRs accepted!
+
+Enable the `nightly` cargo feature to take advantage of the Rust intrinsic
+rather than using FFI to invoke OS intrinsics (requires a nightly rustc):
+
+`Cargo.toml` example:
+
+```toml
+[dependencies.zeroize]
+version = "0"
+features = ["nightly"]
+```
+
+‡ NOTE: Linux w\ glibc versions earlier than 2.2.5 (i.e. when the
+  `linux-backport` cargo feature is enabled) uses `cc` as a build
+  dependency to link `explicit_bzero.c`, a backport of the method
+  glibc uses to implement `explicit_bzero()`.
+
+## Stack/Heap Zeroing Notes
+
+This crate can be used to zero values from either the stack or the heap.
+
+However, be aware that Rust's current memory semantics (e.g. move)
+can leave copies of data in memory, and there isn't presently a good solution
+for ensuring all copies of data on the stack are properly cleared.
+
+The [`Pin` RFC][pin] proposes a method for avoiding this. See also:
+<https://github.com/rust-lang/rust/issues/17046>.
+
+## What about: clearing registers, mlock, mprotect, etc?
+
+This crate is laser focused on being a simple, unobtrusive crate for zeroing
+memory reliably.
+
+Clearing registers is a difficult problem that can't easily be solved by
+something like a crate, and requires either inline ASM or rustc support.
+
+Other memory protection mechanisms are interesting and useful, but often
+overkill (e.g. defending against RAM scraping or attackers with swap access).
+There are already many other crates that already implement more sophisticated
+memory protections.
+
+Zeroing memory is [good cryptographic hygiene] and this crate seeks to promote
+it in the most unobtrusive manner possible. This includes omitting complex
+`unsafe` memory protection systems and just trying to make the best memory
+zeroing crate available.
+
+## Security Warning
+
+† NOTE: When we say "safe", we mean the caller doesn't need to use the
+  `unsafe` keyword. 
+
+This crate is presently **alpha quality**.
+
+This crate makes use of `unsafe`, and furthermore, contains FFI bindings for
+operating systems it hasn't been directly tested against. These usages have
+not been expertly audited to ensure they are memory safe.
+
+There is presently no automated testing in CI (e.g. ASAN) to ensure memory
+safe operation.
+
+Though the intrinsic wrappers in this crate are trivial, their current form
+involves a certain degree of guesswork and their compatibility has not been
+rigorously tested for memory safety on the platforms this crate claims to
+support.
+
+**USE AT YOUR OWN RISK!**
+
+## License
+
+**zeroize** is distributed under the terms of either the MIT license
+or the Apache License (Version 2.0), at your option.
+
+See [LICENSE] (Apache License, Version 2.0) file in the `iqlusioninc/crates`
+toplevel directory of this repository or [LICENSE-MIT] for details.
+
+## Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally
+submitted for inclusion in the work by you shall be dual licensed as above,
+without any additional terms or conditions.
+
+[zeroize]: https://en.wikipedia.org/wiki/Zeroisation
+[Documentation]: https://docs.rs/zeroize/
+[Zeroing memory is hard]: http://www.daemonology.net/blog/2014-09-04-how-to-zero-a-buffer.html
+[explicit_bzero()]: http://man7.org/linux/man-pages/man3/bzero.3.html
+[explicit_memset()]: http://netbsd.gw.com/cgi-bin/man-cgi?explicit_memset+3.i386+NetBSD-8.0
+[memset_s()]: https://www.unix.com/man-page/osx/3/memset_s/
+[RtlSecureZeroMemory()]: https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/content/wdm/nf-wdm-rtlsecurezeromemory
+[volatile_set_memory()]: https://doc.rust-lang.org/std/intrinsics/fn.volatile_set_memory.html
+[pin]: https://github.com/rust-lang/rfcs/blob/master/text/2349-pin.md
+[good cryptographic hygiene]: https://cryptocoding.net/index.php/Coding_rules#Clean_memory_of_secret_data
+[LICENSE]: https://github.com/iqlusioninc/crates/blob/master/LICENSE
+[LICENSE-MIT]: https://github.com/iqlusioninc/crates/blob/master/zeroize/LICENSE-MIT

--- a/zeroize/build.rs
+++ b/zeroize/build.rs
@@ -1,0 +1,67 @@
+//! Support for building `explicit_bzero.c` backport for Linux w\ glibc < 2.25.
+
+#[cfg(any(feature = "linux-backport", feature = "windows"))]
+extern crate cc;
+
+fn main() {
+    #[cfg(all(feature = "linux-backport", target_os = "linux"))]
+    linux::build_explicit_bzero_backport();
+
+    #[cfg(all(feature = "windows", target_os = "windows"))]
+    windows::build_explicit_bzero_shim();
+}
+
+/// Support for building the `explicit_bzero.c` backport.
+/// Only used when the `linux-backport` cargo feature is enabled and the
+/// installed glibc version is < 2.25.
+#[cfg(all(feature = "linux-backport", target_os = "linux"))]
+mod linux {
+    use super::cc;
+    use std::process::Command;
+
+    /// First version of glibc to support `explicit_bzero()`
+    const GLIBC_WITH_EXPLICIT_BZERO: &str = "2.25";
+
+    /// Build `src/os/linux/explicit_bzero_backport.c` using the `cc` crate
+    pub fn build_explicit_bzero_backport() {
+        let glibc_version = get_glibc_version();
+
+        // Hax: this probably isn't the best use of floats
+        if glibc_version.parse::<f32>().unwrap() < GLIBC_WITH_EXPLICIT_BZERO.parse::<f32>().unwrap()
+        {
+            cc::Build::new()
+                .file("src/os/linux/explicit_bzero_backport.c")
+                .compile("explicit_bzero");
+        }
+    }
+
+    /// Get the current glibc version (vicariously by querying `/usr/bin/ldd`)
+    fn get_glibc_version() -> String {
+        let output = Command::new("/usr/bin/ldd")
+            .arg("--version")
+            .output()
+            .unwrap();
+
+        if !output.status.success() {
+            panic!("/usr/bin/ldd --version exited with error: {:?}", output);
+        }
+
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        let info = stdout.split('\n').next().unwrap();
+        info.split(' ').last().unwrap().to_owned()
+    }
+}
+
+/// Support for `SecureZeroMemory` (a macro found in `winnt.h`) is implemented
+/// as a shim for the `explicit_bzero()` API.
+#[cfg(all(feature = "windows", target_os = "windows"))]
+mod windows {
+    use super::cc;
+
+    /// Build `src/os/windows/explicit_bzero_shim.c` using the `cc` crate
+    pub fn build_explicit_bzero_shim() {
+        cc::Build::new()
+            .file("src/os/windows/explicit_bzero_shim.c")
+            .compile("explicit_bzero");
+    }
+}

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -1,0 +1,49 @@
+//! Securely zero memory using core or OS intrinsics. This crate wraps
+//! facilities specifically designed to securely zero memory in a common,
+//! safe API.
+//!
+//! This crate deliberately avoids use of `cc`, C shims, and other "tricks"
+//! to "securely" zero memory, preferring to use the appropriate intrinsic
+//! on nightly, or on stable using FFI bindings to specifically designed
+//! OS APIs for securely zeroing memory.
+
+#![crate_name = "zeroize"]
+#![crate_type = "rlib"]
+#![no_std]
+#![deny(
+    warnings,
+    missing_docs,
+    unused_import_braces,
+    unused_qualifications,
+)]
+#![doc(html_root_url = "https://docs.rs/zeroize/0.0.0")]
+
+#[cfg(any(feature = "std", test))]
+#[macro_use]
+extern crate std;
+
+// nightly: use `volatile_set_memory`
+#[cfg(feature = "nightly")]
+mod nightly;
+#[cfg(feature = "nightly")]
+pub use nightly::secure_zero_memory;
+
+// stable: use OS-specific APIs
+#[cfg(not(feature = "nightly"))]
+mod stable;
+#[cfg(not(feature = "nightly"))]
+pub use stable::secure_zero_memory;
+
+#[cfg(test)]
+mod tests {
+    use super::secure_zero_memory;
+    use std::prelude::v1::*;
+
+    /// Ensure the selected implementation actually zeroes memory
+    #[test]
+    fn test_secure_zero_memory() {
+        let mut buffer = Vec::from("DEADBEEFCAFE");
+        secure_zero_memory(&mut buffer);
+        assert_eq!(buffer, [0u8; 12]);
+    }
+}

--- a/zeroize/src/nightly.rs
+++ b/zeroize/src/nightly.rs
@@ -1,0 +1,11 @@
+//! nightly: use the `volatile_set_memory` intrinsic
+
+use core::intrinsics::volatile_set_memory;
+
+/// Zero out memory using `core::intrinsics::volatile_set_memory`
+///
+/// The volatile parameter is set to true, so it will not be optimized out
+/// unless size is equal to zero.
+pub fn secure_zero_memory(bytes: &mut [u8]) {
+    unsafe { volatile_set_memory(bytes.as_mut_ptr(), 0, bytes.len()) }
+}

--- a/zeroize/src/os/linux/explicit_bzero_backport.c
+++ b/zeroize/src/os/linux/explicit_bzero_backport.c
@@ -1,0 +1,13 @@
+/**
+ * Backport of `explicit_bzero()` for Linux when using glibc versions earlier
+ * than 2.2.5.
+ */
+
+#include <string.h>
+
+#undef explicit_bzero
+
+void explicit_bzero(void *dest, size_t n) {
+    memset(dest, '\0', n);
+    asm volatile ("" ::: "memory");
+}

--- a/zeroize/src/os/windows/explicit_bzero_shim.c
+++ b/zeroize/src/os/windows/explicit_bzero_shim.c
@@ -1,0 +1,11 @@
+/**
+ * `explicit_bzero()` shim for invoking `SecureZeroMemory` on Windows, which
+ * is provided as a macro.
+ */
+
+#include <windows.h>
+#include <wincrypt.h>
+
+void explicit_bzero(void *dest, size_t n) {
+    SecureZeroMemory(dest, n);
+}

--- a/zeroize/src/stable/explicit_bzero.rs
+++ b/zeroize/src/stable/explicit_bzero.rs
@@ -1,0 +1,16 @@
+/// Zero out memory using `explicit_bzero()`.
+///
+/// The `explicit_bzero()` is a non-standard function which performs the
+/// same task as `bzero()`, but differs in that it guarantees that compiler
+/// optimizations will not remove the erase operation if the compiler
+/// deduces that the operation is "unnecessary".
+pub fn secure_zero_memory(bytes: &mut [u8]) {
+    #[cfg_attr(not(target_os = "windows"), link(name = "c"))]
+    extern "C" {
+        fn explicit_bzero(dest: *mut u8, n: usize);
+    }
+
+    unsafe {
+        explicit_bzero(bytes.as_mut_ptr(), bytes.len());
+    }
+}

--- a/zeroize/src/stable/explicit_memset.rs
+++ b/zeroize/src/stable/explicit_memset.rs
@@ -1,0 +1,16 @@
+/// Zero out memory using `explicit_memset()`.
+///
+/// The `explicit_memset()` is a non-standard function which performs the
+/// same task as `memset()`, but differs in that it guarantees that compiler
+/// optimizations will not remove the operation if the compiler deduces that
+/// it is "unnecessary".
+pub fn secure_zero_memory(bytes: &mut [u8]) {
+    #[link(name = "c")]
+    extern "C" {
+        fn explicit_memset(dest: *mut u8, byte: isize, n: usize);
+    }
+
+    unsafe {
+        explicit_memset(bytes.as_mut_ptr(), 0, bytes.len());
+    }
+}

--- a/zeroize/src/stable/memset_s.rs
+++ b/zeroize/src/stable/memset_s.rs
@@ -1,0 +1,15 @@
+/// Zero out memory using `memset_s()`.
+///
+/// Unlike `memset()`, any call to the `memset_s()` function shall be
+/// evaluated strictly, i.e. callers of `memset_s()` can safely assume that
+/// it has been executed and not "optimized away" by the compiler.
+pub fn secure_zero_memory(bytes: &mut [u8]) {
+    #[link(name = "c")]
+    extern "C" {
+        fn memset_s(dest: *mut u8, dest_len: usize, byte: isize, n: usize) -> isize;
+    }
+
+    unsafe {
+        assert_eq!(memset_s(bytes.as_mut_ptr(), bytes.len(), 0, bytes.len()), 0);
+    }
+}

--- a/zeroize/src/stable/mod.rs
+++ b/zeroize/src/stable/mod.rs
@@ -1,0 +1,64 @@
+//! stable: invoke OS-specific secure memory zeroing intrinsics
+
+// Linux, FreeBSD, OpenBSD, DragonflyBSD: use `explicit_bzero()`
+#[cfg(
+    any(
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "linux",
+        target_os = "openbsd",
+        target_os = "windows", // via `explicit_bzero_shim.c`
+    )
+)]
+mod explicit_bzero;
+#[cfg(
+    any(
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "linux",
+        target_os = "openbsd",
+        target_os = "windows"
+    )
+)]
+pub use self::explicit_bzero::secure_zero_memory;
+
+// iOS, Mac OS X, Solaris: use `memset_s()`
+#[cfg(
+    any(
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "solaris"
+    )
+)]
+mod memset_s;
+#[cfg(
+    any(
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "solaris"
+    )
+)]
+pub use self::memset_s::secure_zero_memory;
+
+// NetBSD: use `explicit_memset()`
+#[cfg(target_os = "netbsd")]
+mod explicit_memset;
+#[cfg(target_os = "netbsd")]
+pub use self::explicit_memset::secure_zero_memory;
+
+#[cfg(
+    not(
+        any(
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "ios",
+            target_os = "linux",
+            target_os = "macos",
+            target_os = "netbsd",
+            target_os = "openbsd",
+            target_os = "solaris",
+            target_os = "windows"
+        )
+    )
+)]
+compile_error!("no secure_zero_memory() implementation available for this platform");


### PR DESCRIPTION
Rust crate for securely zeroing memory while avoiding compiler optimizations.

Yes, there are already a dozen crates for doing this, however they are all (according to my accounting) "best effort" and fall back to using tricks to attempt to outsmart the compiler.

This crate exclusively wraps secure intrinsics and does not provide any sort of insecure fallback. If a suitable OS or Rust intrinsic is not available, it will fail to compile.