### PR TITLE
Update macOS name in README

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -14,3 +14,4 @@ contributions under the terms of the [Apache License, Version 2.0]
 * David Tolnay ([@dtolnay](https://github.com/dtolnay))
 * Murarth ([@murarth](https://github.com/murarth))
 * Yin Guanhao ([@sopium](https://github.com/sopium))
+* Will Speak ([@iwillspeak](https://github.com/iwillspeak))

--- a/zeroize/README.md
+++ b/zeroize/README.md
@@ -53,7 +53,7 @@ This crate provides wrappers for the following intrinsics:
   - [explicit_memset():](http://netbsd.gw.com/cgi-bin/man-cgi?explicit_memset+3.i386+NetBSD-8.0)
     NetBSD
   - [memset_s():](https://www.unix.com/man-page/osx/3/memset_s/)
-    Mac OS X/iOS, Solaris
+    macOS/iOS, Solaris
   - [SecureZeroMemory():](https://msdn.microsoft.com/en-us/library/windows/desktop/aa366877(v=vs.85).aspx)
     Windows
 - `nightly` rust: [volatile_set_memory()] (all platforms)


### PR DESCRIPTION
The proper name for the operating system is now macOS rather
than Mac OS X. I guess it is for parity with iOS, watchOS and tvOS.