### PR TITLE
zeroize: Add 'Zeroize' trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "subtle-encoding"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name        = "zeroize"
 description = """
-              (Alpha quality preview) Securely zero memory while avoiding
-              compiler optimizations: unified 'secure_zero_memory()' wrapper for
-              secure intrinsic functions for zeroing memory, using FFI to
-              invoke OS intrinsics on stable (with support for Linux, Windows,
-              OS X/iOS, FreeBSD, OpenBSD, NetBSD, DragonflyBSD), or the
-              unstable 'volatile_set_memory()` intrinsic on nightly.
+              Securely zero memory while avoiding compiler optimizations:
+              unified 'secure_zero_memory()' wrapper for secure intrinsic
+              functions for zeroing memory, using FFI to invoke OS intrinsics
+              on stable (with support for Linux, Windows, OS X/iOS, FreeBSD,
+              OpenBSD, NetBSD, DragonflyBSD), or the unstable
+              'volatile_set_memory()` intrinsic on nightly.
               No insecure fallbacks, no dependencies, no std, no functionality
               besides securely zeroing memory.
               """
@@ -20,9 +20,16 @@ categories  = ["cryptography", "memory-management", "no-std", "os"]
 keywords    = ["memory", "memset", "secure", "volatile", "zero"]
 
 [features]
+# enable feature detection for all platforms by default
 default = ["linux-backport", "windows"]
-linux-backport = ["cc"] # backport of 'explicit_bzero' (C code) for glibc <2.25
+
+# backport of 'explicit_bzero' (C code) for glibc <2.25
+linux-backport = ["cc"]
+
+# `volatile_set_memory` support on nightly Rust
 nightly = []
+
+# `SecureZeroMemory` shim on Windows
 windows = ["cc"]
 
 [build-dependencies]

--- a/zeroize/README.md
+++ b/zeroize/README.md
@@ -13,12 +13,12 @@
 [build-image]: https://circleci.com/gh/iqlusioninc/crates.svg?style=shield
 [build-link]: https://circleci.com/gh/iqlusioninc/crates
 
-*Alpha-quality preview*: Rust crate for securely zeroing memory while
-avoiding compiler optimizations.
+Rust crate for securely zeroing memory while avoiding compiler optimizations.
 
-This crate provides a safe<sup>†</sup>, portable `secure_zero_memory()`
+This crate provides a safe<sup>†</sup>, portable [secure_zero_memory()]
 wrapper function for secure memory zeroing intrinsics which are
-specifically documented as guaranteeing they won't be "optimized away".
+specifically documented as guaranteeing they won't be "optimized away",
+as well as a [`Zeroize` trait] for types which are erased using this function.
 
 [Documentation]
 
@@ -36,12 +36,12 @@ the intrinsic is invoked, memory will be zeroed 100% of the time.
 **No insecure fallbacks. No dependencies<sup>‡</sup>. `#![no_std]`. No
 functionality besides securely zeroing memory.**
 
-This crate has one job and one function: `secure_zero_memory()`, and it
-provides the thinnest portable wrapper for secure zeroing intrinsics.
+This crate provides the thinnest portable wrapper for secure zeroing
+intrinsics available. If it can't find a way to securely zero memory, **it
+will refuse to compile**.
 
-If it can't find a way to securely zero memory, **it will refuse to compile**.
 Don't worry about that though: it supports almost every tier 1 and 2 Rust
-platform (and even most of tier 3!). See below for compatiblity.
+platform (and even most of tier 3!). See below for compatibility.
 
 ## Platform Support / Intrinsics
 
@@ -110,7 +110,7 @@ zeroing crate available.
 † NOTE: When we say "safe", we mean the caller doesn't need to use the
   `unsafe` keyword. 
 
-This crate is presently **alpha quality**.
+This crate is presently **beta quality**.
 
 This crate makes use of `unsafe`, and furthermore, contains FFI bindings for
 operating systems it hasn't been directly tested against. These usages have
@@ -141,6 +141,8 @@ submitted for inclusion in the work by you shall be dual licensed as above,
 without any additional terms or conditions.
 
 [zeroize]: https://en.wikipedia.org/wiki/Zeroisation
+[secure_zero_memory()]: https://docs.rs/zeroize/latest/zeroize/fn.secure_zero_memory.html
+[`Zeroize` trait]: https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html
 [Documentation]: https://docs.rs/zeroize/
 [Zeroing memory securely is hard]: http://www.daemonology.net/blog/2014-09-04-how-to-zero-a-buffer.html
 [SecureZeroMemory()]: https://msdn.microsoft.com/en-us/library/windows/desktop/aa366877(v=vs.85).aspx

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -105,6 +105,10 @@
 #[macro_use]
 extern crate std;
 
+/// Zeroization traits
+mod zeroize;
+pub use zeroize::*;
+
 // nightly: use `volatile_set_memory`
 #[cfg(feature = "nightly")]
 mod nightly;

--- a/zeroize/src/zeroize.rs
+++ b/zeroize/src/zeroize.rs
@@ -1,0 +1,38 @@
+use super::secure_zero_memory;
+
+/// Trait for securely erasing types from memory
+pub trait Zeroize {
+    /// Zero out this object from memory (using Rust or OS intrinsics which
+    /// ensure the zeroization operation is not "optimized away")
+    fn zeroize(&mut self);
+}
+
+// Zeroize implementations for the most common types we might want it for
+
+impl<T> Zeroize for T
+where
+    T: AsMut<[u8]>,
+{
+    fn zeroize(&mut self) {
+        secure_zero_memory(self.as_mut());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Zeroize;
+
+    #[test]
+    fn zeroize_slice() {
+        let mut arr = [42; 3];
+        arr.zeroize();
+        assert_eq!(arr, [0, 0, 0]);
+    }
+
+    #[test]
+    fn zeroize_vec() {
+        let mut arr = vec![42; 3];
+        arr.zeroize();
+        assert_eq!(arr.as_slice(), [0, 0, 0]);
+    }
+}


### PR DESCRIPTION
Adds a trait for clearing types in a secure fashion, and impls it for `T: AsMut<[u8]>`, with the idea that it can be implemented for custom types (and potentially other types by default).