### PR TITLE
zeroize: Replace 'secure_zero_memory' with 'Zeroize'

### DIFF
--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -2,11 +2,10 @@
 name        = "zeroize"
 description = """
               Securely zero memory while avoiding compiler optimizations:
-              unified 'secure_zero_memory()' wrapper for secure intrinsic
-              functions for zeroing memory, using FFI to invoke OS intrinsics
-              on stable (with support for Linux, Windows, OS X/iOS, FreeBSD,
-              OpenBSD, NetBSD, DragonflyBSD), or the unstable
-              'volatile_set_memory()` intrinsic on nightly.
+              cross-platform secure intrinsics for zeroing memory, using FFI
+              to invoke OS intrinsics on stable Rust (with support for Linux,
+              Windows, macOS/iOS, FreeBSD, OpenBSD, NetBSD, DragonflyBSD),
+              or the unstable 'volatile_set_memory()` intrinsic on nightly.
               No insecure fallbacks, no dependencies, no std, no functionality
               besides securely zeroing memory.
               """

--- a/zeroize/README.md
+++ b/zeroize/README.md
@@ -13,12 +13,13 @@
 [build-image]: https://circleci.com/gh/iqlusioninc/crates.svg?style=shield
 [build-link]: https://circleci.com/gh/iqlusioninc/crates
 
-Rust crate for securely zeroing memory while avoiding compiler optimizations.
+Securely zero memory while avoiding compiler optimizations.
 
-This crate provides a safe<sup>†</sup>, portable [secure_zero_memory()]
-wrapper function for secure memory zeroing intrinsics which are
-specifically documented as guaranteeing they won't be "optimized away",
-as well as a [`Zeroize` trait] for types which are erased using this function.
+This crate provides a safe<sup>†</sup>, portable access to cross-platform
+intrinsics for securely zeroing memory which are specifically documented as
+guaranteeing they won't be "optimized away".
+
+The [`Zeroize` trait] is the crate's primary (and only) API.
 
 [Documentation]
 
@@ -141,7 +142,6 @@ submitted for inclusion in the work by you shall be dual licensed as above,
 without any additional terms or conditions.
 
 [zeroize]: https://en.wikipedia.org/wiki/Zeroisation
-[secure_zero_memory()]: https://docs.rs/zeroize/latest/zeroize/fn.secure_zero_memory.html
 [`Zeroize` trait]: https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html
 [Documentation]: https://docs.rs/zeroize/
 [Zeroing memory securely is hard]: http://www.daemonology.net/blog/2014-09-04-how-to-zero-a-buffer.html

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -1,6 +1,22 @@
 //! Securely zero memory using core or OS intrinsics. This crate wraps
 //! facilities specifically designed to securely zero memory in a common,
-//! safe API: `secure_zero_memory()`.
+//! safe API: [Zeroize].
+//!
+//! ## Usage
+//!
+//! ```
+//! extern crate zeroize;
+//! use zeroize::Zeroize;
+//!
+//! fn main() {
+//!     let mut secret = Vec::from("The password to the air shield is 1,2,3,4,5...");
+//!     // [ ... ] open the air shield here
+//!
+//!     // Actual call to zeroize here:
+//!     // `Zeroize` is impl'd for any type which impls `AsMut<[u8]>`
+//!     secret.zeroize();
+//! }
+//! ```
 //!
 //! ## About
 //!
@@ -16,10 +32,10 @@
 //! **No insecure fallbacks. No dependencies. `#![no_std]`. No functionality
 //! besides securely zeroing memory.**
 //!
-//! This crate has one job and one function: `secure_zero_memory()`, and it
-//! provides the thinnest portable wrapper for secure zeroing intrinsics.
+//! This crate provides the thinnest portable wrapper for secure zeroing
+//! intrinsics. If it can't find a way to securely zero memory,
+//! **it will refuse to compile**.
 //!
-//! If it can't find a way to securely zero memory, **it will refuse to compile**.
 //! Don't worry about that though: it supports almost every tier 1 and 2 Rust
 //! platform (and even most of tier 3!). See below for compatiblity.
 //!
@@ -85,6 +101,7 @@
 //! `unsafe` memory protection systems and just trying to make the best memory
 //! zeroing crate available.
 //!
+//! [Zeroize]: https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html
 //! [Zeroing memory securely is hard]: http://www.daemonology.net/blog/2014-09-04-how-to-zero-a-buffer.html
 //! [volatile_set_memory()]: https://doc.rust-lang.org/std/intrinsics/fn.volatile_set_memory.html
 //! [pin]: https://github.com/rust-lang/rfcs/blob/master/text/2349-pin.md
@@ -113,13 +130,13 @@ pub use zeroize::*;
 #[cfg(feature = "nightly")]
 mod nightly;
 #[cfg(feature = "nightly")]
-pub use nightly::secure_zero_memory;
+pub(crate) use nightly::secure_zero_memory;
 
 // stable: use OS-specific APIs
 #[cfg(not(feature = "nightly"))]
 mod stable;
 #[cfg(not(feature = "nightly"))]
-pub use stable::secure_zero_memory;
+pub(crate) use stable::secure_zero_memory;
 
 #[cfg(test)]
 mod tests {

--- a/zeroize/src/nightly.rs
+++ b/zeroize/src/nightly.rs
@@ -6,6 +6,6 @@ use core::intrinsics::volatile_set_memory;
 ///
 /// The volatile parameter is set to true, so it will not be optimized out
 /// unless size is equal to zero.
-pub fn secure_zero_memory(bytes: &mut [u8]) {
+pub(crate) fn secure_zero_memory(bytes: &mut [u8]) {
     unsafe { volatile_set_memory(bytes.as_mut_ptr(), 0, bytes.len()) }
 }

--- a/zeroize/src/stable/explicit_bzero.rs
+++ b/zeroize/src/stable/explicit_bzero.rs
@@ -4,7 +4,7 @@
 /// same task as `bzero()`, but differs in that it guarantees that compiler
 /// optimizations will not remove the erase operation if the compiler
 /// deduces that the operation is "unnecessary".
-pub fn secure_zero_memory(bytes: &mut [u8]) {
+pub(crate) fn secure_zero_memory(bytes: &mut [u8]) {
     #[cfg_attr(not(target_os = "windows"), link(name = "c"))]
     extern "C" {
         fn explicit_bzero(dest: *mut u8, n: usize);

--- a/zeroize/src/stable/explicit_memset.rs
+++ b/zeroize/src/stable/explicit_memset.rs
@@ -4,7 +4,7 @@
 /// same task as `memset()`, but differs in that it guarantees that compiler
 /// optimizations will not remove the operation if the compiler deduces that
 /// it is "unnecessary".
-pub fn secure_zero_memory(bytes: &mut [u8]) {
+pub(crate) fn secure_zero_memory(bytes: &mut [u8]) {
     #[link(name = "c")]
     extern "C" {
         fn explicit_memset(dest: *mut u8, byte: isize, n: usize);

--- a/zeroize/src/stable/memset_s.rs
+++ b/zeroize/src/stable/memset_s.rs
@@ -3,7 +3,7 @@
 /// Unlike `memset()`, any call to the `memset_s()` function shall be
 /// evaluated strictly, i.e. callers of `memset_s()` can safely assume that
 /// it has been executed and not "optimized away" by the compiler.
-pub fn secure_zero_memory(bytes: &mut [u8]) {
+pub(crate) fn secure_zero_memory(bytes: &mut [u8]) {
     #[link(name = "c")]
     extern "C" {
         fn memset_s(dest: *mut u8, dest_len: usize, byte: isize, n: usize) -> isize;

--- a/zeroize/src/stable/mod.rs
+++ b/zeroize/src/stable/mod.rs
@@ -20,7 +20,7 @@ mod explicit_bzero;
         target_os = "windows"
     )
 )]
-pub use self::explicit_bzero::secure_zero_memory;
+pub(crate) use self::explicit_bzero::secure_zero_memory;
 
 // iOS, Mac OS X, Solaris: use `memset_s()`
 #[cfg(
@@ -38,13 +38,13 @@ mod memset_s;
         target_os = "solaris"
     )
 )]
-pub use self::memset_s::secure_zero_memory;
+pub(crate) use self::memset_s::secure_zero_memory;
 
 // NetBSD: use `explicit_memset()`
 #[cfg(target_os = "netbsd")]
 mod explicit_memset;
 #[cfg(target_os = "netbsd")]
-pub use self::explicit_memset::secure_zero_memory;
+pub(crate) use self::explicit_memset::secure_zero_memory;
 
 #[cfg(
     not(

--- a/zeroize/src/zeroize.rs
+++ b/zeroize/src/zeroize.rs
@@ -7,8 +7,8 @@ pub trait Zeroize {
     fn zeroize(&mut self);
 }
 
-// Zeroize implementations for the most common types we might want it for
-
+/// `AsMut<[u8]>` should hopefully most types we want to `Zeroize`
+// TODO: `impl Zeroize` for other types (e.g. integers)?
 impl<T> Zeroize for T
 where
     T: AsMut<[u8]>,
@@ -31,8 +31,8 @@ mod tests {
 
     #[test]
     fn zeroize_vec() {
-        let mut arr = vec![42; 3];
-        arr.zeroize();
-        assert_eq!(arr.as_slice(), [0, 0, 0]);
+        let mut vec = vec![42; 3];
+        vec.zeroize();
+        assert_eq!(vec.as_slice(), [0, 0, 0]);
     }
 }


### PR DESCRIPTION
This commit makes the `secure_zero_memory()` function `pub(crate)` and uses it to implement the `Zeroize` trait for `AsMut<[u8]>`, which is now the only API provided by this crate.

It might be worth adding back for certain cases(?), but this crate's original focus was having a very simple API, and with both there's confusion as to which to use.

Removing `secure_zero_memory()` from the public API makes it *very* clear: `Zeroize` is the API to use.