### PR TITLE
gaunt: Initial support for a no_std profile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ script:
 - cargo test --all
 
 # crates with non-default features
-- (cd gaunt && cargo test --features=slog)
+- (cd gaunt && cargo test --features=logger)
 - (cd subtle-encoding && cargo test --features=bech32-preview)
 - (cd tai64 && cargo test --features=chrono)
 

--- a/gaunt/Cargo.toml
+++ b/gaunt/Cargo.toml
@@ -1,19 +1,25 @@
 [package]
 name        = "gaunt"
-description = "High-level, self-contained, minimalist HTTP toolkit"
+description = "Minimalist Rust HTTP toolkit (client-only)."
 version     = "0.0.1"
 license     = "Apache-2.0"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/iqlusioninc/crates/"
 repository  = "https://github.com/iqlusioninc/crates/tree/master/gaunt"
 readme      = "README.md"
-categories  = ["network-programming"]
-keywords    = ["api", "client", "http", "rest", "server"]
+categories  = ["network-programming", "no-std", "web-programming::http-client"]
+keywords    = ["api", "client", "http", "rest", "web"]
 
 [badges]
 circle-ci = { repository = "iqlusioninc/crates" }
 
 [dependencies]
-failure = "0.1"
+failure = { version = "0.1", default-features = false }
 failure_derive = "0.1"
 slog = { version = "2", optional = true }
+
+[features]
+alloc = []
+default = ["std"]
+logger = ["slog", "std"]
+std = ["alloc", "failure/std"]

--- a/gaunt/README.md
+++ b/gaunt/README.md
@@ -14,11 +14,27 @@
 [build-image]: https://circleci.com/gh/iqlusioninc/crates.svg?style=shield
 [build-link]: https://circleci.com/gh/iqlusioninc/crates
 
-High-level, self-contained, minimalist HTTP toolkit built on top
-of the `http` crate and `std`. Suitable for use in constrainted
-environments where `mio` and `futures` are not (yet) available.
+High-level, (mostly) self-contained, minimalist HTTP toolkit (client-only).
+Suitable for use in constrainted environments where `mio` and `tokio`
+are not (yet) available.
 
-[Documentation](https://bitly.com/98K8eH)
+[Documentation](https://docs.rs/gaunt/)
+
+## About
+
+**gaunt.rs** is a minimalist alternative to `hyper` suitable for use in
+environments where crates like `mio` and `tokio` aren't (yet) available,
+such as Intel SGX or `#![no_std]` environments.
+
+It's presently in an early stage of development and not ready for general
+use, but has the following roadmap:
+
+- Lightweight, `#![no_std]`-friendly core.
+- `std`-based blocking socket I/O backend.
+- `hyper`-based backend to leverage `mio`/`tokio` when available.
+- Leverage `http` and `httparse` crates (`hyper` dependencies)
+  as they are mature and well-tested.
+- Add server support in addition to client support.
 
 ## License
 

--- a/gaunt/src/connection.rs
+++ b/gaunt/src/connection.rs
@@ -1,6 +1,8 @@
 //! Connections to HTTP servers
 
-#[cfg(feature = "slog")]
+use prelude::*;
+
+#[cfg(feature = "logger")]
 use slog::Logger;
 use std::{
     fmt::Write as FmtWrite,
@@ -22,7 +24,7 @@ const DEFAULT_TIMEOUT_MS: u64 = 5000;
 pub struct ConnectionOptions {
     timeout: Duration,
 
-    #[cfg(feature = "slog")]
+    #[cfg(feature = "logger")]
     logger: Option<Logger>,
 }
 
@@ -38,7 +40,7 @@ impl ConnectionOptions {
     }
 
     /// Set the logger
-    #[cfg(feature = "slog")]
+    #[cfg(feature = "logger")]
     pub fn logger(&mut self, l: Logger) {
         self.logger = Some(l)
     }
@@ -49,7 +51,7 @@ impl Default for ConnectionOptions {
         Self {
             timeout: Duration::from_millis(DEFAULT_TIMEOUT_MS),
 
-            #[cfg(feature = "slog")]
+            #[cfg(feature = "logger")]
             logger: None,
         }
     }
@@ -70,7 +72,7 @@ pub struct Connection {
     request_count: usize,
 
     /// Logger for recording request details
-    #[cfg(feature = "slog")]
+    #[cfg(feature = "logger")]
     logger: Option<Logger>,
 }
 
@@ -99,7 +101,7 @@ impl Connection {
             socket: Mutex::new(socket),
             created_at: Instant::now(),
             request_count: 0,
-            #[cfg(feature = "slog")]
+            #[cfg(feature = "logger")]
             logger: opts.logger.clone(),
         })
     }
@@ -124,7 +126,7 @@ impl Connection {
         write!(request, "User-Agent: {}\r\n", USER_AGENT)?;
         write!(request, "Content-Length: 0\r\n\r\n")?;
 
-        #[cfg(feature = "slog")]
+        #[cfg(feature = "logger")]
         let request_start = Instant::now();
 
         let mut socket = self.socket.lock().unwrap();
@@ -132,7 +134,7 @@ impl Connection {
 
         let response = ResponseReader::new(&mut socket)?.into();
 
-        #[cfg(feature = "slog")]
+        #[cfg(feature = "logger")]
         self.log("GET", &path, request_start);
 
         Ok(response)
@@ -152,7 +154,7 @@ impl Connection {
         let mut request: Vec<u8> = headers.into();
         request.append(&mut body);
 
-        #[cfg(feature = "slog")]
+        #[cfg(feature = "logger")]
         let request_start = Instant::now();
 
         let mut socket = self.socket.lock().unwrap();
@@ -160,14 +162,14 @@ impl Connection {
 
         let response = ResponseReader::new(&mut socket)?.into();
 
-        #[cfg(feature = "slog")]
+        #[cfg(feature = "logger")]
         self.log("POST", &path, request_start);
 
         Ok(response)
     }
 
-    /// Log information about a request (if `slog` feature is enabled)
-    #[cfg(feature = "slog")]
+    /// Log information about a request (if `logger` feature is enabled)
+    #[cfg(feature = "logger")]
     fn log(&self, method: &str, path: &Path, started_at: Instant) {
         let duration = Instant::now().duration_since(started_at);
 

--- a/gaunt/src/lib.rs
+++ b/gaunt/src/lib.rs
@@ -1,4 +1,4 @@
-//! **Gaunt**: high-level, self-contained, minimalist HTTP toolkit.
+//! **gaunt.rs**: high-level, self-contained, minimalist HTTP toolkit.
 
 #![crate_name = "gaunt"]
 #![crate_type = "rlib"]
@@ -8,26 +8,40 @@
     unused_import_braces,
     unused_qualifications,
 )]
+#![no_std]
+#![cfg_attr(
+    all(feature = "nightly", not(feature = "std")),
+    feature(alloc)
+)]
 #![forbid(unsafe_code)]
 #![doc(html_root_url = "https://docs.rs/gaunt/0.0.1")]
+
+#[cfg(any(feature = "std", test))]
+#[macro_use]
+extern crate std;
 
 extern crate failure;
 #[macro_use]
 extern crate failure_derive;
-#[cfg(feature = "slog")]
+#[cfg(feature = "logger")]
 #[macro_use]
 extern crate slog;
 
 #[macro_use]
 pub mod error;
 
+#[cfg(feature = "std")]
 pub mod connection;
 pub mod path;
+pub mod prelude;
+#[cfg(feature = "std")]
 pub mod response;
 
+#[cfg(feature = "std")]
 pub use connection::*;
 pub use error::*;
 pub use path::*;
+#[cfg(feature = "std")]
 pub use response::*;
 
 /// Version of HTTP supported by Gaunt.

--- a/gaunt/src/path.rs
+++ b/gaunt/src/path.rs
@@ -1,12 +1,19 @@
 //! Remote paths on HTTP servers
 
-use std::fmt::{self, Display};
+#[cfg(feature = "alloc")]
+use prelude::*;
 
+#[cfg(feature = "alloc")]
+use core::fmt::{self, Display};
+
+#[cfg(feature = "alloc")]
 use error::Error;
 
 /// Paths requested via HTTP
+#[cfg(feature = "alloc")]
 pub struct Path(String);
 
+#[cfg(feature = "alloc")]
 impl Path {
     /// Create a path from the given string
     pub fn new(path: &str) -> Result<Self, Error> {
@@ -15,18 +22,21 @@ impl Path {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl AsRef<str> for Path {
     fn as_ref(&self) -> &str {
         self.0.as_ref()
     }
 }
 
+#[cfg(feature = "alloc")]
 impl Display for Path {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(f)
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> From<&'a str> for Path {
     fn from(path: &str) -> Self {
         Self::new(path).unwrap()

--- a/gaunt/src/prelude.rs
+++ b/gaunt/src/prelude.rs
@@ -1,0 +1,7 @@
+//! Use `std` or `alloc` prelude depending on selected cargo features
+
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+pub use alloc::prelude::*;
+
+#[cfg(feature = "std")]
+pub use std::prelude::v1::*;

--- a/gaunt/src/response.rs
+++ b/gaunt/src/response.rs
@@ -1,5 +1,7 @@
 //! HTTP responses
 
+use prelude::*;
+
 use std::{io::Read, net::TcpStream, str};
 
 use error::Error;


### PR DESCRIPTION
Gate parts of the crate which can build on `no_std` versus with the `alloc` feature versus which ones have hard dependencies on `std`.

Most things need at least `alloc` to do anything useful, but this should be expandable after switching to the `no_std`-friendly `httparse` crate.