### PR TITLE
gaunt v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "gaunt"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/gaunt/CHANGES.md
+++ b/gaunt/CHANGES.md
@@ -1,3 +1,9 @@
+## 0.1.0 (2018-11-19)
+
+- Refactor in prep for switching to `httparse` (#124)
+- Initial `no_std` profile support (#121)
+- Use `slog` for logging (#119)
+
 ## 0.0.1 (2018-10-21)
 
 - Initial release

--- a/gaunt/Cargo.toml
+++ b/gaunt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "gaunt"
 description = "Minimalist Rust HTTP toolkit (client-only)."
-version     = "0.0.1"
+version     = "0.1.0"
 license     = "Apache-2.0"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/iqlusioninc/crates/"

--- a/gaunt/src/lib.rs
+++ b/gaunt/src/lib.rs
@@ -14,7 +14,10 @@
     feature(alloc)
 )]
 #![forbid(unsafe_code)]
-#![doc(html_root_url = "https://docs.rs/gaunt/0.0.1")]
+#![doc(
+    html_logo_url = "https://storage.googleapis.com/iqlusion-production-web/github/gaunt/gaunt-logo.svg",
+    html_root_url = "https://docs.rs/gaunt/0.1.0"
+)]
 
 #[cfg(any(feature = "std", test))]
 #[macro_use]


### PR DESCRIPTION
- Refactor in prep for switching to `httparse` (#124)
- Initial `no_std` profile support (#121)
- Use `slog` for logging (#119)