### PR TITLE
Cargo.toml: Fix comment (s/abort/panic/)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 # Enable integer overflow checks in release builds
-# WARNING: DO NOT REMOVE THIS! We rely on this for abort-on-overflow semantics
+# WARNING: DO NOT REMOVE THIS! We rely on this for panic-on-overflow semantics
 # in the event of integer arithmetic bugs.
 [profile.release]
 overflow-checks = true


### PR DESCRIPTION
The `overflow-checks = true` option enables panic-on-overflow semantics, and we're not using `panic = abort`, so this comment should say "panic".