### PR TITLE
subtle-encoding v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,7 +271,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "subtle-encoding"
-version = "0.3.0-alpha1"
+version = "0.3.0"
 dependencies = [
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/subtle-encoding/CHANGES.md
+++ b/subtle-encoding/CHANGES.md
@@ -1,3 +1,8 @@
+## 0.3.0 (2018-11-25)
+
+- Fix critical encode/decode bug in `release` builds (#126)
+- Non-constant-time Bech32 implementation via `bech32-preview` feature (#113)
+
 ## 0.2.3 (2018-10-12)
 
 - Bump zeroize dependency to 0.4

--- a/subtle-encoding/Cargo.toml
+++ b/subtle-encoding/Cargo.toml
@@ -6,7 +6,7 @@ description = """
               provide "best effort" constant time. Useful for encoding/decoding
               secret values such as cryptographic keys.
               """
-version     = "0.3.0-alpha1" # Also update html_root_url in lib.rs when bumping this
+version     = "0.3.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://github.com/iqlusioninc/crates/"

--- a/subtle-encoding/src/lib.rs
+++ b/subtle-encoding/src/lib.rs
@@ -26,7 +26,7 @@
     unused_qualifications,
 )]
 #![forbid(unsafe_code)]
-#![doc(html_root_url = "https://docs.rs/subtle-encoding/0.3.0-alpha1")]
+#![doc(html_root_url = "https://docs.rs/subtle-encoding/0.3.0")]
 
 #[cfg(any(feature = "std", test))]
 #[macro_use]


### PR DESCRIPTION
- Fix critical encode/decode bug in `release` builds (#126)
- Non-constant-time Bech32 implementation via `bech32-preview` feature (#113)