### PR TITLE
[zeroize] Support musl-libc

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -9,6 +9,7 @@ contributions under the terms of the [Apache License, Version 2.0]
 [LICENSE]: https://github.com/iqlusioninc/crates/blob/master/LICENSE
 
 * Anthony Arcieri ([@tarcieri](https://github.com/tarcieri))
+* Amr Ali ([@amrali](https://github.com/amrali))
 * Armin Ronacher ([@mitsuhiko](https://github.com/mitsuhiko))
 * Boats ([@withoutboats](https://github.com/withoutboats))
 * David Tolnay ([@dtolnay](https://github.com/dtolnay))

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -23,8 +23,8 @@ keywords    = ["memory", "memset", "secure", "volatile", "zero"]
 default = ["linux-backport", "std", "windows"]
 std = []
 
-# backport of 'explicit_bzero' (C code) for glibc <2.25
-linux-backport = ["cc"]
+# backport of 'explicit_bzero' (C code) for glibc <2.25 or musl <1.1.20
+linux-backport = ["cc", "semver"]
 
 # `volatile_set_memory` support on nightly Rust
 nightly = []
@@ -34,6 +34,7 @@ windows = ["cc"]
 
 [build-dependencies]
 cc = { version = "1", optional = true }
+semver = { version = "0.9", optional = true }
 
 [badges]
 circle-ci = { repository = "iqlusioninc/crates" }

--- a/zeroize/build.rs
+++ b/zeroize/build.rs
@@ -43,7 +43,17 @@ mod linux {
             .unwrap();
 
         if !output.status.success() {
-            panic!("/usr/bin/ldd --version exited with error: {:?}", output);
+            let stderr = String::from_utf8(output.stderr).unwrap();
+            let libc_info = stderr.split('\n').collect::<Vec<&str>>()[0];
+            let libc_name = libc_info.split(' ').collect::<Vec<&str>>()[0];
+
+            if libc_name != "musl" {
+                panic!("/usr/bin/ldd --version exited with error: {:?}", output);
+            }
+
+            // Return a version less than the least glibc version to support explicit_bzero
+            // to force compilation of our backport.
+            return "2.24".to_owned();
         }
 
         let stdout = String::from_utf8(output.stdout).unwrap();

--- a/zeroize/build.rs
+++ b/zeroize/build.rs
@@ -41,7 +41,7 @@ mod linux {
 
     impl StdLibrary {
         /// Build backports if necessary
-        fn should_build(&self) -> Option<bool> {
+        fn should_build_explicit_bzero(&self) -> Option<bool> {
             match self {
                 StdLibrary::GNU(ver) => Some(ver < &Version::parse(GLIBC_WITH_EXPLICIT_BZERO).unwrap()),
                 StdLibrary::Musl(ver) => Some(ver < &Version::parse(MUSL_WITH_EXPLICIT_BZERO).unwrap()),
@@ -114,7 +114,7 @@ mod linux {
     pub fn build_explicit_bzero_backport() {
         let stdlib = StdLibrary::resolve();
 
-        match stdlib.should_build() {
+        match stdlib.should_build_explicit_bzero() {
             Some(should_build) => if should_build {
                 cc::Build::new()
                     .file("src/os/linux/explicit_bzero_backport.c")

--- a/zeroize/build.rs
+++ b/zeroize/build.rs
@@ -2,6 +2,8 @@
 
 #[cfg(any(feature = "linux-backport", feature = "windows"))]
 extern crate cc;
+#[cfg(any(feature = "linux-backport", feature = "windows"))]
+extern crate semver;
 
 fn main() {
     #[cfg(all(feature = "linux-backport", target_os = "linux"))]
@@ -13,53 +15,115 @@ fn main() {
 
 /// Support for building the `explicit_bzero.c` backport.
 /// Only used when the `linux-backport` cargo feature is enabled and the
-/// installed glibc version is < 2.25.
+/// installed glibc version is < 2.25 or musl-libc version is < 1.1.20.
 #[cfg(all(feature = "linux-backport", target_os = "linux"))]
 mod linux {
     use super::cc;
+    use super::semver::Version;
     use std::process::Command;
 
     /// First version of glibc to support `explicit_bzero()`
-    const GLIBC_WITH_EXPLICIT_BZERO: &str = "2.25";
+    const GLIBC_WITH_EXPLICIT_BZERO: &str = "2.25.0";
 
-    /// Build `src/os/linux/explicit_bzero_backport.c` using the `cc` crate
-    pub fn build_explicit_bzero_backport() {
-        let glibc_version = get_glibc_version();
+    /// First version of musl-libc to support `explicit_bzero()`
+    const MUSL_WITH_EXPLICIT_BZERO: &str = "1.1.20";
 
-        // Hax: this probably isn't the best use of floats
-        if glibc_version.is_none()
-            || glibc_version.unwrap().parse::<f32>().unwrap()
-                < GLIBC_WITH_EXPLICIT_BZERO.parse::<f32>().unwrap()
-        {
-            cc::Build::new()
-                .file("src/os/linux/explicit_bzero_backport.c")
-                .compile("explicit_bzero");
-        }
+    enum StdLibrary {
+        /// GNU C standard library
+        GNU(Version),
+
+        /// Musl C standard library
+        Musl(Version),
+
+        /// Unsupported standard library
+        Unsupported,
     }
 
-    /// Get the current glibc version (vicariously by querying `/usr/bin/ldd`)
-    fn get_glibc_version() -> Option<String> {
-        let output = Command::new("/usr/bin/ldd")
-            .arg("--version")
-            .output()
-            .unwrap();
+    impl StdLibrary {
+        /// Resolve the version of the installed C standard library
+        fn resolve() -> Self {
+            let output = Command::new("/usr/bin/ldd")
+                .arg("--version")
+                .output()
+                .unwrap();
 
-        if !output.status.success() {
-            let stderr = String::from_utf8(output.stderr).unwrap();
-            let libc_info = stderr.split('\n').collect::<Vec<&str>>()[0];
-            let libc_name = libc_info.split(' ').collect::<Vec<&str>>()[0];
+            let stdout = String::from_utf8(output.stdout)
+                .unwrap()
+                .to_ascii_lowercase();
+            let stderr = String::from_utf8(output.stderr)
+                .unwrap()
+                .to_ascii_lowercase();
 
-            if libc_name != "musl" {
+            // Check if this is GNU C standard library
+            if stdout.find("glibc").is_some() || stderr.find("glibc").is_some() {
+                return Self::get_glibc_version();
+            }
+
+            // Check if this is musl-libc
+            if stdout.find("musl").is_some() || stderr.find("musl").is_some() {
+                return Self::get_musl_version();
+            }
+
+            StdLibrary::Unsupported
+        }
+
+        /// Get the version of the GNU C standard library
+        fn get_glibc_version() -> Self {
+            let output = Command::new("/usr/bin/ldd")
+                .arg("--version")
+                .output()
+                .unwrap();
+
+            if !output.status.success() {
                 panic!("/usr/bin/ldd --version exited with error: {:?}", output);
             }
 
-            return None;
+            let stdout = String::from_utf8(output.stdout).unwrap();
+            let info = stdout.split('\n').next().unwrap();
+            let version =
+                Version::parse(&(info.split(' ').last().unwrap().to_owned() + ".0")).unwrap();
+
+            StdLibrary::GNU(version)
         }
 
-        let stdout = String::from_utf8(output.stdout).unwrap();
-        let info = stdout.split('\n').next().unwrap();
+        /// Get the version of the Musl C standard library
+        fn get_musl_version() -> Self {
+            let output = Command::new("/usr/bin/ldd")
+                .arg("--version")
+                .output()
+                .unwrap();
 
-        Some(info.split(' ').last().unwrap().to_owned())
+            let stderr = String::from_utf8(output.stderr).unwrap();
+            let info = stderr.split('\n').collect::<Vec<&str>>()[1];
+            let version = Version::parse(info.split(' ').collect::<Vec<&str>>()[1]).unwrap();
+
+            StdLibrary::Musl(version)
+        }
+    }
+
+    /// Build `src/os/linux/explicit_bzero_backport.c` using the `cc` crate
+    pub fn build_explicit_bzero_backport() {
+        match StdLibrary::resolve() {
+            StdLibrary::GNU(ver) => {
+                if ver < Version::parse(GLIBC_WITH_EXPLICIT_BZERO).unwrap() {
+                    cc::Build::new()
+                        .file("src/os/linux/explicit_bzero_backport.c")
+                        .compile("explicit_bzero");
+                }
+            }
+
+            StdLibrary::Musl(ver) => {
+                if ver < Version::parse(MUSL_WITH_EXPLICIT_BZERO).unwrap() {
+                    cc::Build::new()
+                        .file("src/os/linux/explicit_bzero_backport.c")
+                        .compile("explicit_bzero");
+                }
+            }
+
+            StdLibrary::Unsupported => {
+                panic!("unsupported standard library");
+            }
+        }
     }
 }
 

--- a/zeroize/build.rs
+++ b/zeroize/build.rs
@@ -54,8 +54,12 @@ mod linux {
         /// Build backports if necessary
         fn should_build_explicit_bzero(&self) -> Option<bool> {
             match self {
-                StdLibrary::GNU(ver) => Some(ver < &Version::parse(GLIBC_WITH_EXPLICIT_BZERO).unwrap()),
-                StdLibrary::Musl(ver) => Some(ver < &Version::parse(MUSL_WITH_EXPLICIT_BZERO).unwrap()),
+                StdLibrary::GNU(ver) => {
+                    Some(ver < &Version::parse(GLIBC_WITH_EXPLICIT_BZERO).unwrap())
+                }
+                StdLibrary::Musl(ver) => {
+                    Some(ver < &Version::parse(MUSL_WITH_EXPLICIT_BZERO).unwrap())
+                }
                 StdLibrary::Unsupported => None,
             }
         }
@@ -97,7 +101,10 @@ mod linux {
         /// Get the version of the GNU C standard library
         fn get_glibc_version(&self) -> StdLibrary {
             if !self.success {
-                panic!("/usr/bin/ldd --version exited with error: {:?}", self.stderr);
+                panic!(
+                    "/usr/bin/ldd --version exited with error: {:?}",
+                    self.stderr
+                );
             }
 
             let info = self.stdout.split('\n').next().unwrap();


### PR DESCRIPTION
I changed `get_glibc_version` so that when the return code is not 0 it will check if it is a musl dynamic loader first before it panics, if that's the case it returns a version less than the least known glibc version that supported `explicit_bzero` to force compilation of the backport.