### PR TITLE
zeroize v0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,6 +265,19 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "slog"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,7 +288,7 @@ version = "0.3.0"
 dependencies = [
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 0.4.0",
+ "zeroize 0.4.1",
 ]
 
 [[package]]
@@ -401,9 +414,10 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
@@ -439,6 +453,8 @@ dependencies = [
 "checksum regex-syntax 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fbc557aac2b708fe84121caf261346cc2eed71978024337e42eb46b8a252ac6e"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
+"checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+"checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1e1a2eec401952cd7b12a84ea120e2d57281329940c3f93c2bf04f462539508e"
 "checksum syn 0.15.21 (registry+https://github.com/rust-lang/crates.io-index)" = "816b7af21405b011a23554ea2dc3f6576dc86ca557047c34098c1d741f10f823"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"

--- a/zeroize/CHANGES.md
+++ b/zeroize/CHANGES.md
@@ -1,3 +1,8 @@
+## 0.4.1 (2018-10-12)
+
+- [#131](https://github.com/iqlusioninc/crates/pull/131)
+  Support musl-libc.
+  
 ## 0.4.0 (2018-10-12)
 
 - [#108](https://github.com/iqlusioninc/crates/pull/108)

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -9,7 +9,7 @@ description = """
               No insecure fallbacks, no dependencies, no std, no functionality
               besides securely zeroing memory.
               """
-version     = "0.4.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.4.1" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://github.com/iqlusioninc/crates/"

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -116,7 +116,7 @@
     unused_import_braces,
     unused_qualifications,
 )]
-#![doc(html_root_url = "https://docs.rs/zeroize/0.3.0")]
+#![doc(html_root_url = "https://docs.rs/zeroize/0.4.1")]
 
 #[cfg(any(feature = "std", test))]
 #[allow(unused_imports)]


### PR DESCRIPTION
- Support musl-libc (#131)