### PR TITLE
zeroize v0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,7 +288,7 @@ version = "0.3.0"
 dependencies = [
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 0.4.1",
+ "zeroize 0.4.2",
 ]
 
 [[package]]
@@ -414,7 +414,7 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/zeroize/CHANGES.md
+++ b/zeroize/CHANGES.md
@@ -1,3 +1,7 @@
+## [0.4.2] (2018-10-12)
+
+- Fix ldd scraper for older glibc versions ([#134])
+
 ## 0.4.1 (2018-10-12)
 
 - Support musl-libc ([#131])
@@ -26,6 +30,8 @@
 
 - Initial release
 
+[0.4.2]: https://github.com/iqlusioninc/crates/pull/136
+[#134]: https://github.com/iqlusioninc/crates/pull/134
 [#131]: https://github.com/iqlusioninc/crates/pull/131
 [#108]: https://github.com/iqlusioninc/crates/pull/108
 [#104]: https://github.com/iqlusioninc/crates/pull/104

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -9,7 +9,7 @@ description = """
               No insecure fallbacks, no dependencies, no std, no functionality
               besides securely zeroing memory.
               """
-version     = "0.4.1" # Also update html_root_url in lib.rs when bumping this
+version     = "0.4.2" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://github.com/iqlusioninc/crates/"

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -116,7 +116,7 @@
     unused_import_braces,
     unused_qualifications,
 )]
-#![doc(html_root_url = "https://docs.rs/zeroize/0.4.1")]
+#![doc(html_root_url = "https://docs.rs/zeroize/0.4.2")]
 
 #[cfg(any(feature = "std", test))]
 #[allow(unused_imports)]


### PR DESCRIPTION
- Fix ldd scraper for older glibc versions (#134)