### PR TITLE
Remove *-preview from rustup components

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ matrix:
   - os: windows
 
 install:
-- rustup component add rustfmt-preview
-- rustup component add clippy-preview
+- rustup component add rustfmt
+- rustup component add clippy
 - command -v cargo-audit >/dev/null 2>&1 || cargo install cargo-audit
 
 script:


### PR DESCRIPTION
They are now stable as of Rust 1.31