### PR TITLE
zeroize: Impls for Vec and String

### DIFF
--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -19,3 +19,9 @@ keywords    = ["memory", "memset", "secure", "volatile", "zero"]
 
 [badges]
 circle-ci = { repository = "iqlusioninc/crates" }
+
+[features]
+default = ["std"]
+alloc = []
+nightly = []
+std = ["alloc"]


### PR DESCRIPTION
Adds `Zeroize` impls for `Vec` and `String` gated on an `alloc` feature (available automatically on `nightly`, but requiring `std` on stable).

For both of these types, the `clear()` method is called to make them zero-length.