### PR TITLE
zeroize: Documentation improvements and small code cleanups

### DIFF
--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -3,9 +3,10 @@ name        = "zeroize"
 description = """
               Securely zero memory with using a simple trait built on stable
               Rust primitives which guarantee they will not be 'optimized away'
-              by leveraging LLVM's volatile write semantics. No weird tricks,
-              no insecure fallbacks, no dependencies, no std, just a single
-              trait with a single method for securely zeroing memory.
+              by leveraging LLVM's volatile write semantics and memory fences.
+              No weird tricks, no insecure fallbacks, no dependencies, no std,
+              just a trait implemented for all of Rust's core scalar types
+              and slices/iterators thereof for securely zeroing memory.
               """
 version     = "0.4.2" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
@@ -18,7 +19,7 @@ categories  = ["cryptography", "memory-management", "no-std", "os"]
 keywords    = ["memory", "memset", "secure", "volatile", "zero"]
 
 [badges]
-circle-ci = { repository = "iqlusioninc/crates" }
+travis-ci = { repository = "iqlusioninc/crates" }
 
 [features]
 default = ["std"]

--- a/zeroize/README.md
+++ b/zeroize/README.md
@@ -30,15 +30,20 @@ in doing so they love to "optimize away" unnecessary zeroing calls. There are
 many documented "tricks" to attempt to avoid these optimizations and ensure
 that a zeroing routine is performed reliably.
 
-This crate isn't about tricks: it builds on the [std::ptr::write_volatile()]
-function available in `stable` Rust (since 1.0.9) to provide easy-to-use,
-portable zeroing behavior which works on all of Rust's core number types and
-slices thereof.
+This crate isn't about tricks: it uses [core::ptr::write_volatile]
+and [core::sync::atomic] memory fences to provide easy-to-use, portable
+zeroing behavior which works on all of Rust's core number types and slices
+thereof, implemented in pure Rust with no usage of FFI or assembly.
 
 - **No insecure fallbacks!**
 - **No dependencies!**
+- **No FFI or inline assembly!**
 - `#![no_std]` **i.e. embedded-friendly**!
 - **No functionality besides securely zeroing memory!**
+
+## Requirements
+
+- Rust 1.31+
 
 ## License
 
@@ -58,7 +63,8 @@ without any additional terms or conditions.
 [`Zeroize` trait]: https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html
 [Documentation]: https://docs.rs/zeroize/
 [Zeroing memory securely is hard]: http://www.daemonology.net/blog/2014-09-04-how-to-zero-a-buffer.html
-[std::ptr::write_volatile()]: https://doc.rust-lang.org/std/ptr/fn.write_volatile.html
+[core::ptr::write_volatile]: https://doc.rust-lang.org/core/ptr/fn.write_volatile.html
+[core::sync::atomic]: https://doc.rust-lang.org/stable/core/sync/atomic/index.html
 [pin]: https://github.com/rust-lang/rfcs/blob/master/text/2349-pin.md
 [good cryptographic hygiene]: https://cryptocoding.net/index.php/Coding_rules#Clean_memory_of_secret_data
 [LICENSE]: https://github.com/iqlusioninc/crates/blob/master/LICENSE


### PR DESCRIPTION
Avoids repeatedly calling the `Z::default()` function.