### PR TITLE
Cargo.toml (all crates): circle-ci -> travis-ci

### DIFF
--- a/canonical-path/Cargo.toml
+++ b/canonical-path/Cargo.toml
@@ -12,7 +12,7 @@ categories  = ["filesystem"]
 keywords    = ["filesystem", "path", "canonicalization"]
 
 [badges]
-circle-ci = { repository = "iqlusioninc/crates" }
+travis-ci = { repository = "iqlusioninc/crates" }
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/gaunt/Cargo.toml
+++ b/gaunt/Cargo.toml
@@ -12,7 +12,7 @@ categories  = ["network-programming", "no-std", "web-programming::http-client"]
 keywords    = ["api", "client", "http", "rest", "web"]
 
 [badges]
-circle-ci = { repository = "iqlusioninc/crates" }
+travis-ci = { repository = "iqlusioninc/crates" }
 
 [dependencies]
 failure = { version = "0.1", default-features = false }

--- a/subtle-encoding/Cargo.toml
+++ b/subtle-encoding/Cargo.toml
@@ -31,7 +31,7 @@ nightly = []
 std = ["alloc", "zeroize"]
 
 [badges]
-circle-ci = { repository = "iqlusioninc/crates" }
+travis-ci = { repository = "iqlusioninc/crates" }
 
 [package.metadata.docs.rs]
 features = ["bech32-preview"]

--- a/tai64/Cargo.toml
+++ b/tai64/Cargo.toml
@@ -12,7 +12,7 @@ categories  = ["date-and-time", "internationalization", "network-programming", "
 keywords    = ["tai64", "time", "timestamps", "chrono"]
 
 [badges]
-circle-ci = { repository = "iqlusioninc/crates" }
+travis-ci = { repository = "iqlusioninc/crates" }
 
 [dependencies]
 byteorder = "1.0"


### PR DESCRIPTION
or: there and back again.

We've migrated back to Travis CI as it allows for testing of Linux, Mac, and Windows on a single CI environment and without the need to manage a Docker image.