### PR TITLE
zeroize v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,7 +275,7 @@ version = "0.3.0"
 dependencies = [
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 0.4.2",
+ "zeroize 0.5.0",
 ]
 
 [[package]]
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "0.4.2"
+version = "0.5.0"
 
 [metadata]
 "checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"

--- a/subtle-encoding/Cargo.toml
+++ b/subtle-encoding/Cargo.toml
@@ -19,7 +19,7 @@ keywords    = ["base64", "bech32", "constant-time", "hex", "security"]
 [dependencies]
 failure = "0.1"
 failure_derive = "0.1"
-zeroize = { version = "0.4", optional = true, path = "../zeroize" }
+zeroize = { version = "0.5", optional = true, path = "../zeroize" }
 
 [features]
 default = ["base64", "hex", "std"]

--- a/zeroize/CHANGES.md
+++ b/zeroize/CHANGES.md
@@ -1,3 +1,12 @@
+## [0.5.0] (2018-12-24)
+
+This release is a rewrite which replaces FFI bindings to OS-specific APIs with
+a pure Rust solution.
+
+- Use `core::sync::atomic` fences ([#146])
+- Test wasm target ([#143])
+- Rewrite using `core::ptr::write_volatile` ([#142])
+
 ## [0.4.2] (2018-10-12)
 
 - Fix ldd scraper for older glibc versions ([#134])
@@ -30,6 +39,10 @@
 
 - Initial release
 
+[0.5.0]: https://github.com/iqlusioninc/crates/pull/149
+[#146]: https://github.com/iqlusioninc/crates/pull/146
+[#143]: https://github.com/iqlusioninc/crates/pull/143
+[#142]: https://github.com/iqlusioninc/crates/pull/142
 [0.4.2]: https://github.com/iqlusioninc/crates/pull/136
 [#134]: https://github.com/iqlusioninc/crates/pull/134
 [#131]: https://github.com/iqlusioninc/crates/pull/131

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -8,7 +8,7 @@ description = """
               just a trait implemented for all of Rust's core scalar types
               and slices/iterators thereof for securely zeroing memory.
               """
-version     = "0.4.2" # Also update html_root_url in lib.rs when bumping this
+version     = "0.5.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0 OR MIT"
 edition     = "2018"

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -205,7 +205,7 @@
 #![deny(warnings, missing_docs, unused_import_braces, unused_qualifications)]
 #![cfg_attr(all(feature = "nightly", not(feature = "std")), feature(alloc))]
 #![cfg_attr(feature = "nightly", feature(core_intrinsics))]
-#![doc(html_root_url = "https://docs.rs/zeroize/0.4.2")]
+#![doc(html_root_url = "https://docs.rs/zeroize/0.5.0")]
 
 #[cfg(any(feature = "std", test))]
 #[cfg_attr(test, macro_use)]


### PR DESCRIPTION
This release is a rewrite which replaces FFI bindings to OS-specific APIs with a pure Rust solution.

- Use `core::sync::atomic` fences (#146)
- Test wasm target (#143)
- Rewrite using `core::ptr::write_volatile` (#142)