### PR TITLE
tai64: Ignore clippy pass-by-ref lint for SystemTime on Windows

### DIFF
--- a/tai64/src/lib.rs
+++ b/tai64/src/lib.rs
@@ -179,6 +179,7 @@ pub const UNIX_EPOCH_TAI64N: TAI64N = TAI64N(TAI64(10 + (1 << 62)), 0);
 
 impl TAI64N {
     /// Convert `SystemTime` to `TAI64N`.
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn from_system_time(t: &SystemTime) -> Self {
         match t.duration_since(UNIX_EPOCH) {
             Ok(d) => UNIX_EPOCH_TAI64N + d,


### PR DESCRIPTION
On Windows, `SystemTime` is a copy type, so passing it by ref fails this clippy lint.

This crate is already 1.0, and this is not true on other platforms, so allow pass-by-ref on the one function where this occurs.

For background, see https://travis-ci.org/iqlusioninc/crates/jobs/471506875#L202