### PR TITLE
zeroize v0.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,7 +275,7 @@ version = "0.3.1"
 dependencies = [
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 0.5.1",
+ "zeroize 0.5.2",
 ]
 
 [[package]]
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "0.5.1"
+version = "0.5.2"
 
 [metadata]
 "checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"

--- a/zeroize/CHANGES.md
+++ b/zeroize/CHANGES.md
@@ -1,6 +1,10 @@
+## [0.5.2] (2018-12-25)
+
+- Add `debug_assert!` to ensure string interiors are zeroized ([#156])
+
 ## [0.5.1] (2018-12-24)
 
-- zeroize: Avoid re-exporting the whole prelude ([#150])
+- Avoid re-exporting the whole prelude ([#150])
 
 ## [0.5.0] (2018-12-24)
 
@@ -43,6 +47,8 @@ a pure Rust solution.
 
 - Initial release
 
+[0.5.2]: https://github.com/iqlusioninc/crates/pull/157
+[#156]: https://github.com/iqlusioninc/crates/pull/157
 [0.5.1]: https://github.com/iqlusioninc/crates/pull/151
 [#150]: https://github.com/iqlusioninc/crates/pull/150
 [0.5.0]: https://github.com/iqlusioninc/crates/pull/149

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -10,7 +10,7 @@ description = """
               implemented for all of Rust's core scalar types and
               slices/iterators thereof for securely zeroing memory.
               """
-version     = "0.5.1" # Also update html_root_url in lib.rs when bumping this
+version     = "0.5.2" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0 OR MIT"
 edition     = "2018"

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -203,7 +203,7 @@
 #![deny(warnings, missing_docs, unused_import_braces, unused_qualifications)]
 #![cfg_attr(all(feature = "nightly", not(feature = "std")), feature(alloc))]
 #![cfg_attr(feature = "nightly", feature(core_intrinsics))]
-#![doc(html_root_url = "https://docs.rs/zeroize/0.5.1")]
+#![doc(html_root_url = "https://docs.rs/zeroize/0.5.2")]
 
 #[cfg(any(feature = "std", test))]
 #[cfg_attr(test, macro_use)]


### PR DESCRIPTION
- Add `debug_assert!` to ensure string interiors are zeroized (#156)