### PR TITLE
subtle-encoding: Fix no_std support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,6 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/subtle-encoding/Cargo.toml
+++ b/subtle-encoding/Cargo.toml
@@ -17,17 +17,17 @@ categories  = ["cryptography", "encoding", "no-std"]
 keywords    = ["base64", "bech32", "constant-time", "hex", "security"]
 
 [dependencies]
-failure = "0.1"
+failure = { version = "0.1", default-features = false }
 failure_derive = "0.1"
-zeroize = { version = "0.5", optional = true, path = "../zeroize" }
+zeroize = { version = "0.5", default-features = false, optional = true, path = "../zeroize" }
 
 [features]
 default = ["base64", "hex", "std"]
 alloc = []
 base64 = ["zeroize"]
-bech32-preview = ["alloc"]
+bech32-preview = ["alloc", "zeroize"]
 hex = []
-nightly = []
+nightly = ["zeroize/nightly"]
 std = ["alloc", "zeroize"]
 
 [badges]


### PR DESCRIPTION
Dependencies were not being imported with `default-features = false`, pulling in `std` accidentally (e.g. in `zeroize`).