### PR TITLE
subtle-encoding v0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,7 +270,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "subtle-encoding"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/subtle-encoding/CHANGES.md
+++ b/subtle-encoding/CHANGES.md
@@ -1,3 +1,7 @@
+## [0.3.2] (2018-12-25)
+
+- Fix `#![no_std]` support ([#158])
+
 ## [0.3.1] (2018-12-25)
 
 - Update to zeroize 0.5 ([#149])
@@ -31,6 +35,8 @@
 
 - Initial release
 
+[0.3.2]: https://github.com/iqlusioninc/crates/pull/160
+[#158]: https://github.com/iqlusioninc/crates/pull/158
 [0.3.1]: https://github.com/iqlusioninc/crates/pull/155
 [#149]: https://github.com/iqlusioninc/crates/pull/149
 [0.3.0]: https://github.com/iqlusioninc/crates/pull/129

--- a/subtle-encoding/Cargo.toml
+++ b/subtle-encoding/Cargo.toml
@@ -6,7 +6,7 @@ description = """
               provide "best effort" constant time. Useful for encoding/decoding
               secret values such as cryptographic keys.
               """
-version     = "0.3.1" # Also update html_root_url in lib.rs when bumping this
+version     = "0.3.2" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0 OR MIT"
 edition     = "2018"

--- a/subtle-encoding/src/lib.rs
+++ b/subtle-encoding/src/lib.rs
@@ -16,7 +16,7 @@
 #![cfg_attr(all(feature = "nightly", not(feature = "std")), feature(alloc))]
 #![deny(warnings, missing_docs, unused_import_braces, unused_qualifications)]
 #![forbid(unsafe_code)]
-#![doc(html_root_url = "https://docs.rs/subtle-encoding/0.3.1")]
+#![doc(html_root_url = "https://docs.rs/subtle-encoding/0.3.2")]
 
 #[cfg(any(feature = "std", test))]
 #[macro_use]


### PR DESCRIPTION
- Fix `#![no_std]` support (#158)