### PR TITLE
Return errors for undersize decode buffers and trailing whitespace

### DIFF
--- a/subtle-encoding/src/bech32/base32.rs
+++ b/subtle-encoding/src/bech32/base32.rs
@@ -1,6 +1,7 @@
-use crate::prelude::*;
-
-use super::Error;
+use crate::{
+    error::Error::{self, *},
+    prelude::*,
+};
 
 /// Encode binary data as base32
 pub fn encode(data: &[u8]) -> Vec<u8> {
@@ -20,10 +21,7 @@ fn convert(data: &[u8], src_base: u32, dst_base: u32) -> Result<Vec<u8>, Error> 
 
     for value in data {
         let v = u32::from(*value);
-
-        if (v >> src_base) != 0 {
-            return Err(Error::EncodingInvalid);
-        }
+        ensure!(v >> src_base == 0, EncodingInvalid);
 
         acc = (acc << src_base) | v;
         bits += src_base;
@@ -39,7 +37,7 @@ fn convert(data: &[u8], src_base: u32, dst_base: u32) -> Result<Vec<u8>, Error> 
             result.push(((acc << (dst_base - bits)) & max) as u8);
         }
     } else if bits >= src_base || ((acc << (dst_base - bits)) & max) != 0 {
-        return Err(Error::PaddingInvalid);
+        return Err(PaddingInvalid);
     }
 
     Ok(result)

--- a/subtle-encoding/src/error.rs
+++ b/subtle-encoding/src/error.rs
@@ -24,6 +24,11 @@ pub enum Error {
     /// Padding missing/invalid
     #[fail(display = "padding invalid")]
     PaddingInvalid,
+
+    /// Trailing whitespace detected
+    // TODO: handle trailing whitespace?
+    #[fail(display = "trailing whitespace")]
+    TrailingWhitespace,
 }
 
 /// Assert that the provided condition is true, or else return the given error


### PR DESCRIPTION
The length calculations we presently perform are dependent on whitespace-free inputs.

This adds an (unfortunately non-constant time) check that the *last* character is *NOT* whitespace. Ideally this would be replaced with a constant time "trim" function that can slice away leading/trailing
whitespace, but for now this gives a meaningful error.

It also adds checks that buffers are correctly sized to receive the resulting output, where otherwise it would've panicked for an undersize buffer. This is a potential DoS vector if subtle-encoding was used on untrusted inputs.