### PR TITLE
zeroize_derive: Custom derive support for Zeroize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,6 +401,18 @@ dependencies = [
 [[package]]
 name = "zeroize"
 version = "0.5.2"
+dependencies = [
+ "zeroize_derive 0.0.0",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "0.0.0"
+dependencies = [
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.21 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [metadata]
 "checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,8 @@ members = [
     "gaunt",
     "subtle-encoding",
     "tai64",
-    "zeroize"
+    "zeroize",
+    "zeroize_derive"
 ]
 
 # Enable integer overflow checks in release builds

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This repository contains the following crates:
 
 ## License
 
-Copyright © 2018 iqlusion
+Copyright © 2018-2019 iqlusion
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -4,11 +4,8 @@ description = """
               Securely clear secrets from memory with a simple trait built on
               stable Rust primitives which guarantee memory is zeroed using an
               operation will not be 'optimized away' by the compiler.
-              Uses a portable implementation that leverages LLVM's volatile
-              write semantics and memory fences. No weird tricks, no FFI/ASM,
-              no insecure fallbacks, no dependencies, no std, just a trait
-              implemented for all of Rust's core scalar types and
-              slices/iterators thereof for securely zeroing memory.
+              Uses a portable pure Rust implementation that works everywhere,
+              even WASM!
               """
 version     = "0.5.2" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
@@ -23,8 +20,11 @@ keywords    = ["memory", "memset", "secure", "volatile", "zero"]
 [badges]
 travis-ci = { repository = "iqlusioninc/crates" }
 
+[dependencies]
+zeroize_derive = { version = "0", path = "../zeroize_derive", optional = true }
+
 [features]
-default = ["std"]
+default = ["std", "zeroize_derive"]
 alloc = []
 nightly = []
 std = ["alloc"]

--- a/zeroize_derive/Cargo.toml
+++ b/zeroize_derive/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name        = "zeroize_derive"
+description = "Custom derive support for zeroize"
+version     = "0.0.0" # Also update html_root_url in lib.rs when bumping this
+authors     = ["Tony Arcieri <tony@iqlusion.io>"]
+license     = "Apache-2.0 OR MIT"
+edition     = "2018"
+homepage    = "https://github.com/iqlusioninc/crates/"
+repository  = "https://github.com/iqlusioninc/crates/tree/master/zeroize_derive"
+readme      = "README.md"
+categories  = ["cryptography", "memory-management", "no-std", "os"]
+keywords    = ["memory", "memset", "secure", "volatile", "zero"]
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "0.4"
+quote = "0.6"
+syn = "0.15"
+
+[badges]
+travis-ci = { repository = "iqlusioninc/crates" }

--- a/zeroize_derive/LICENSE-MIT
+++ b/zeroize_derive/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 iqlusion
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/zeroize_derive/README.md
+++ b/zeroize_derive/README.md
@@ -1,0 +1,38 @@
+# [zeroize_derive] 🄌 <a href="https://www.iqlusion.io"><img src="https://storage.googleapis.com/iqlusion-prod-web-assets/img/logo/iqlusion-rings-sm.png" alt="iqlusion" width="24" height="24"></a>
+
+[![Crate][crate-image]][crate-link]
+[![Docs][docs-image]][docs-link]
+![MIT/Apache 2.0 Licensed][license-image]
+[![Build Status][build-image]][build-link]
+
+Custom derive support for [zeroize]: a crate for securely zeroing memory
+while avoiding compiler optimizations.
+
+## Requirements
+
+- Rust 1.31+
+
+## License
+
+**zeroize_derive** is distributed under the terms of either the MIT license
+or the Apache License (Version 2.0), at your option.
+
+See [LICENSE] (Apache License, Version 2.0) file in the `iqlusioninc/crates`
+toplevel directory of this repository or [LICENSE-MIT] for details.
+
+## Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally
+submitted for inclusion in the work by you shall be dual licensed as above,
+without any additional terms or conditions.
+
+[crate-image]: https://img.shields.io/crates/v/zeroize_derive.svg
+[crate-link]: https://crates.io/crates/zeroize_derive
+[docs-image]: https://docs.rs/zeroize_derive/badge.svg
+[docs-link]: https://docs.rs/zeroize_derive/
+[license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
+[build-image]: https://circleci.com/gh/iqlusioninc/crates.svg?style=shield
+[build-link]: https://circleci.com/gh/iqlusioninc/crates
+[zeroize]: https://github.com/iqlusioninc/crates/tree/master/zeroize
+[LICENSE]: https://github.com/iqlusioninc/crates/blob/master/LICENSE
+[LICENSE-MIT]: https://github.com/iqlusioninc/crates/blob/master/zeroize/LICENSE-MIT

--- a/zeroize_derive/src/lib.rs
+++ b/zeroize_derive/src/lib.rs
@@ -1,0 +1,85 @@
+//! Custom derive support for `zeroize`
+
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+#[macro_use]
+extern crate quote;
+#[macro_use]
+extern crate syn;
+
+use proc_macro::TokenStream;
+
+macro_rules! q {
+    ($($t:tt)*) => (quote_spanned!(proc_macro2::Span::call_site() => $($t)*))
+}
+
+#[proc_macro_derive(Zeroize)]
+pub fn derive(input: TokenStream) -> TokenStream {
+    let ast: syn::DeriveInput = syn::parse(input).unwrap();
+
+    let zeroizers = match ast.data {
+        syn::Data::Struct(ref s) => derive_struct_zeroizers(&s.fields),
+        syn::Data::Enum(_) => panic!("support for deriving Zeroize on enums not yet unimplemented"),
+        syn::Data::Union(_) => panic!("can't derive Zeroize on union types"),
+    };
+
+    let name = &ast.ident;
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+
+    let zeroize_impl = q! {
+        impl #impl_generics Zeroize for #name #ty_generics #where_clause {
+            fn zeroize(&mut self) {
+                #zeroizers
+            }
+        }
+    };
+
+    zeroize_impl.into()
+}
+
+fn derive_struct_zeroizers(fields: &syn::Fields) -> proc_macro2::TokenStream {
+    let self_ident = syn::Ident::new("self", proc_macro2::Span::call_site());
+
+    match *fields {
+        syn::Fields::Named(ref fields) => {
+            derive_field_zeroizers(&self_ident, Some(&fields.named), true)
+        }
+        syn::Fields::Unnamed(ref fields) => {
+            derive_field_zeroizers(&self_ident, Some(&fields.unnamed), false)
+        }
+        syn::Fields::Unit => panic!("can't derive Zeroize on unit structs"),
+    }
+}
+
+fn derive_field_zeroizers(
+    target: &syn::Ident,
+    fields: Option<&syn::punctuated::Punctuated<syn::Field, Token![,]>>,
+    named: bool,
+) -> proc_macro2::TokenStream {
+    let empty = Default::default();
+    let zeroizers = fields.unwrap_or(&empty).iter().enumerate().map(|(i, f)| {
+        let is_phantom_data = match f.ty {
+            syn::Type::Path(syn::TypePath {
+                qself: None,
+                ref path,
+            }) => path
+                .segments
+                .last()
+                .map(|x| x.value().ident == "PhantomData")
+                .unwrap_or(false),
+            _ => false,
+        };
+
+        if is_phantom_data {
+            q!()
+        } else if named {
+            let ident = f.ident.clone().unwrap();
+            q!(#target.#ident.zeroize())
+        } else {
+            q!(#target.#i.zeroize())
+        }
+    });
+
+    q!(#(#zeroizers);*)
+}


### PR DESCRIPTION
Adds a `zeroize_derive` crate, re-exported through `zeroize` (and gated on an optional but on-by-default cargo feature).

Presently limited to structs.