### PR TITLE
zeroize v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ version = "0.3.3"
 dependencies = [
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 0.5.2",
+ "zeroize 0.6.0",
 ]
 
 [[package]]
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "zeroize_derive 0.1.0",
 ]

--- a/subtle-encoding/Cargo.toml
+++ b/subtle-encoding/Cargo.toml
@@ -19,7 +19,7 @@ keywords    = ["base64", "bech32", "constant-time", "hex", "security"]
 [dependencies]
 failure = { version = "0.1", default-features = false }
 failure_derive = "0.1"
-zeroize = { version = "0.5", default-features = false, optional = true, path = "../zeroize" }
+zeroize = { version = "0.6", default-features = false, optional = true, path = "../zeroize" }
 
 [features]
 default = ["base64", "hex", "std"]

--- a/zeroize/CHANGES.md
+++ b/zeroize/CHANGES.md
@@ -1,3 +1,9 @@
+## [0.6.0] (2018-03-23)
+
+- Add ZeroizeOnDrop marker trait + custom derive ([#168])
+- Custom derive support for `Zeroize` ([#167])
+- Rename `ZeroizeWithDefault` to `DefaultIsZeroes` ([#166])
+
 ## [0.5.2] (2018-12-25)
 
 - Add `debug_assert!` to ensure string interiors are zeroized ([#156])
@@ -47,8 +53,12 @@ a pure Rust solution.
 
 - Initial release
 
+[0.6.0]: https://github.com/iqlusioninc/crates/pull/170
+[#168]: https://github.com/iqlusioninc/crates/pull/168
+[#167]: https://github.com/iqlusioninc/crates/pull/167
+[#166]: https://github.com/iqlusioninc/crates/pull/166
 [0.5.2]: https://github.com/iqlusioninc/crates/pull/157
-[#156]: https://github.com/iqlusioninc/crates/pull/157
+[#156]: https://github.com/iqlusioninc/crates/pull/156
 [0.5.1]: https://github.com/iqlusioninc/crates/pull/151
 [#150]: https://github.com/iqlusioninc/crates/pull/150
 [0.5.0]: https://github.com/iqlusioninc/crates/pull/149

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -7,7 +7,7 @@ description = """
               Uses a portable pure Rust implementation that works everywhere,
               even WASM!
               """
-version     = "0.5.2" # Also update html_root_url in lib.rs when bumping this
+version     = "0.6.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0 OR MIT"
 edition     = "2018"

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -229,7 +229,7 @@
 #![deny(warnings, missing_docs, unused_import_braces, unused_qualifications)]
 #![cfg_attr(all(feature = "nightly", not(feature = "std")), feature(alloc))]
 #![cfg_attr(feature = "nightly", feature(core_intrinsics))]
-#![doc(html_root_url = "https://docs.rs/zeroize/0.5.2")]
+#![doc(html_root_url = "https://docs.rs/zeroize/0.6.0")]
 
 #[cfg(any(feature = "std", test))]
 #[cfg_attr(test, macro_use)]

--- a/zeroize_derive/README.md
+++ b/zeroize_derive/README.md
@@ -1,12 +1,13 @@
 # zeroize_derive 🄌 <a href="https://www.iqlusion.io"><img src="https://storage.googleapis.com/iqlusion-prod-web-assets/img/logo/iqlusion-rings-sm.png" alt="iqlusion" width="24" height="24"></a>
 
 [![Crate][crate-image]][crate-link]
-[![Docs][docs-image]][docs-link]
 ![MIT/Apache 2.0 Licensed][license-image]
 [![Build Status][build-image]][build-link]
 
 Custom derive support for [zeroize]: a crate for securely zeroing memory
 while avoiding compiler optimizations.
+
+See [zeroize] crate for documentation.
 
 ## Requirements
 
@@ -28,8 +29,6 @@ without any additional terms or conditions.
 
 [crate-image]: https://img.shields.io/crates/v/zeroize_derive.svg
 [crate-link]: https://crates.io/crates/zeroize_derive
-[docs-image]: https://docs.rs/zeroize_derive/badge.svg
-[docs-link]: https://docs.rs/zeroize_derive/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [build-image]: https://circleci.com/gh/iqlusioninc/crates.svg?style=shield
 [build-link]: https://circleci.com/gh/iqlusioninc/crates


### PR DESCRIPTION
- Add ZeroizeOnDrop marker trait + custom derive (#168)
- Custom derive support for `Zeroize` (#167)
- Rename `ZeroizeWithDefault` to `DefaultIsZeroes` (#166)