### PR TITLE
tendermint-rpc: Basic JSONRPC/HTTP support + integration test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,6 +184,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "gaunt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,6 +554,7 @@ name = "tendermint-rpc"
 version = "0.0.0"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gaunt 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -697,6 +707,7 @@ dependencies = [
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+"checksum gaunt 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0348d3b5fbd30311ea16ce573f137c689e5a3fb2d7b037eefe0a6384143298b6"
 "checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"

--- a/tendermint-rpc/Cargo.toml
+++ b/tendermint-rpc/Cargo.toml
@@ -19,8 +19,12 @@ travis-ci = { repository = "iqlusioninc/crates" }
 
 [dependencies]
 failure = "0.1"
+gaunt = "0.1"
 semver = { version = "0.9", features = ["serde"] }
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
 tendermint = "0.6"
+
+[features]
+integration = []

--- a/tendermint-rpc/src/endpoints.rs
+++ b/tendermint-rpc/src/endpoints.rs
@@ -2,4 +2,4 @@
 
 mod status;
 
-pub use self::status::StatusResponse;
+pub use self::status::{Status, StatusResponse};

--- a/tendermint-rpc/src/endpoints/status.rs
+++ b/tendermint-rpc/src/endpoints/status.rs
@@ -1,7 +1,20 @@
 //! RPC wrapper for `/status` endpoint
 
+use crate::jsonrpc;
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt::{self, Display};
+
+/// Request the status of the node
+#[derive(Default)]
+pub struct Status;
+
+impl jsonrpc::Request for Status {
+    type Response = StatusResponse;
+
+    fn path(&self) -> gaunt::Path {
+        "/status".into()
+    }
+}
 
 /// Status responses
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -15,6 +28,8 @@ pub struct StatusResponse {
     /// Validator information
     pub validator_info: ValidatorInfo,
 }
+
+impl jsonrpc::Response for StatusResponse {}
 
 /// Node information
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/tendermint-rpc/src/lib.rs
+++ b/tendermint-rpc/src/lib.rs
@@ -10,3 +10,5 @@ extern crate serde_derive;
 
 pub mod endpoints;
 pub mod jsonrpc;
+
+pub use tendermint::Address;

--- a/tendermint-rpc/tests/endpoints.rs
+++ b/tendermint-rpc/tests/endpoints.rs
@@ -1,7 +1,7 @@
 //! Tests for consuming endpoint JSON from fixtures
 
 use std::{fs, path::PathBuf};
-use tendermint_rpc::{endpoints::StatusResponse, jsonrpc};
+use tendermint_rpc::{endpoints::StatusResponse, jsonrpc::Response};
 
 fn read_fixture(name: &str) -> String {
     fs::read_to_string(PathBuf::from("./tests/fixtures/").join(name.to_owned() + ".json")).unwrap()
@@ -10,16 +10,12 @@ fn read_fixture(name: &str) -> String {
 #[test]
 fn status_endpoint() {
     let status_json = read_fixture("status");
-    let status_response: jsonrpc::ResponseWrapper<StatusResponse> =
-        tendermint_rpc::jsonrpc::parse_response(&status_json).unwrap();
+    let status_response = StatusResponse::from_json(&status_json).unwrap();
 
-    let StatusResponse {
-        node_info,
-        sync_info,
-        validator_info,
-    } = status_response.result;
-
-    assert_eq!(node_info.network.as_str(), "cosmoshub-1");
-    assert_eq!(sync_info.latest_block_height.value(), 410744);
-    assert_eq!(validator_info.voting_power.value(), 0);
+    assert_eq!(status_response.node_info.network.as_str(), "cosmoshub-1");
+    assert_eq!(
+        status_response.sync_info.latest_block_height.value(),
+        410744
+    );
+    assert_eq!(status_response.validator_info.voting_power.value(), 0);
 }

--- a/tendermint-rpc/tests/integration.rs
+++ b/tendermint-rpc/tests/integration.rs
@@ -1,0 +1,17 @@
+#[cfg(feature = "integration")]
+use tendermint_rpc::{endpoints::Status, jsonrpc::Request, Address};
+
+/// Hit a locally running gaiad full node
+#[cfg(feature = "integration")]
+#[test]
+fn integration_test() {
+    let node_addr = "tcp://127.0.0.1:26657".parse::<Address>().unwrap();
+    let status = Status.perform(&node_addr).unwrap();
+
+    // For lack of better things to test
+    assert_eq!(
+        status.validator_info.voting_power.value(),
+        0,
+        "don't integration test against a validator"
+    );
+}


### PR DESCRIPTION
Uses `gaunt` for now for simplicity.

Should probably switch over to `hyper` (or a `gaunt`-wrapped `hyper`) in the future for better performance.