### PR TITLE
zeroize: Remove 'nightly' feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: cargo
 
 branches:
   only:
-    - master
+    - develop
 
 rust:
   - stable
@@ -54,6 +54,7 @@ script:
   - (cd gaunt && cargo test --release --features=logger)
   - (cd subtle-encoding && cargo test --release --features=bech32-preview)
   - (cd tai64 && cargo test --release --features=chrono)
+  - (cd zeroize && cargo test --no-default-features --lib)
 
   # doc build
   - cargo doc --no-deps

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -6,7 +6,7 @@ contributions under the terms of the [Apache License, Version 2.0]
 (included in this repository in the toplevel [LICENSE] file).
 
 [Apache License, Version 2.0]: https://www.apache.org/licenses/LICENSE-2.0
-[LICENSE]: https://github.com/iqlusioninc/crates/blob/master/LICENSE
+[LICENSE]: https://github.com/iqlusioninc/crates/blob/develop/LICENSE
 
 * Anthony Arcieri ([@tarcieri](https://github.com/tarcieri))
 * Amr Ali ([@amrali](https://github.com/amrali))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,8 @@ To contribute to this repository, here is all you need to do:
 3. Create one or more additional commits including your contributions, then open
    a [pull request] along with the commit adding yourself to [AUTHORS.md].
 
-[CODE_OF_CONDUCT.md]: https://github.com/iqlusioninc/crates/blob/master/CODE_OF_CONDUCT.md
-[AUTHORS.md]: https://github.com/iqlusioninc/crates/blob/master/AUTHORS.md
+[CODE_OF_CONDUCT.md]: https://github.com/iqlusioninc/crates/blob/develop/CODE_OF_CONDUCT.md
+[AUTHORS.md]: https://github.com/iqlusioninc/crates/blob/develop/AUTHORS.md
 [pull request]: https://help.github.com/articles/about-pull-requests/
 
 ## Code of Conduct
@@ -34,7 +34,7 @@ the terms of the [Apache License, Version 2.0] (included in this repository in
 the toplevel [LICENSE] file).
 
 [Apache License, Version 2.0]: https://www.apache.org/licenses/LICENSE-2.0
-[LICENSE]: https://github.com/iqlusioninc/crates/blob/master/LICENSE
+[LICENSE]: https://github.com/iqlusioninc/crates/blob/develop/LICENSE
 
 To do this, edit the [AUTHORS.md] file, inserting your name in the list of
 contributors (in rougly alphabetical order by last name, preferably) along with

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 [![Appveyor Status][appveyor-image]][appveyor-link]
 
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
-[license-link]: https://github.com/iqlusioninc/crates/blob/master/LICENSE
-[build-image]: https://travis-ci.org/iqlusioninc/crates.svg?branch=master
+[license-link]: https://github.com/iqlusioninc/crates/blob/develop/LICENSE
+[build-image]: https://travis-ci.org/iqlusioninc/crates.svg?branch=develop
 [build-link]: https://travis-ci.org/iqlusioninc/crates/
 [appveyor-image]: https://ci.appveyor.com/api/projects/status/qslcjs7e1rn4a2w9?svg=true
 [appveyor-link]: https://ci.appveyor.com/project/tony-iqlusion/crates
@@ -18,22 +18,32 @@ to the community by [iqlusion](https://www.iqlusion.io).
 If you are interested in contributing to this repository, please make sure to
 read the [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md] files first.
 
-[CONTRIBUTING.md]: https://github.com/iqlusioninc/crates/blob/master/CONTRIBUTING.md
-[CODE_OF_CONDUCT.md]: https://github.com/iqlusioninc/crates/blob/master/CODE_OF_CONDUCT.md
+[CONTRIBUTING.md]: https://github.com/iqlusioninc/crates/blob/develop/CONTRIBUTING.md
+[CODE_OF_CONDUCT.md]: https://github.com/iqlusioninc/crates/blob/develop/CODE_OF_CONDUCT.md
+
+## Requirements
+
+All crates require Rust 2018 edition and are tested on the following channels:
+
+- `1.34.0` (minimum supported)
+- `stable`
+
+Crates may work on slightly earlier 2018 edition-supporting versions of Rust
+(i.e. 1.31.0+) but are not tested on these releases or guaranteed to work.
 
 ## Crate Descriptions
 
 This repository contains the following crates:
 
-* [canonical-path:](https://github.com/iqlusioninc/crates/tree/master/canonical-path)
+* [canonical-path:](https://github.com/iqlusioninc/crates/tree/develop/canonical-path)
   `Path` and `PathBuf`-like types for representing canonical filesystem paths.
-* [gaunt:](https://github.com/iqlusioninc/crates/tree/master/gaunt)
+* [gaunt:](https://github.com/iqlusioninc/crates/tree/develop/gaunt)
   Minimalist Rust HTTP library (with optional `hyper` backend coming soon)
-* [subtle-encoding:](https://github.com/iqlusioninc/crates/tree/master/subtle-encoding)
+* [subtle-encoding:](https://github.com/iqlusioninc/crates/tree/develop/subtle-encoding)
   Base64 and hexadecimal encoder/decoder with "constant time-ish" implementation.
-* [tai64:](https://github.com/iqlusioninc/crates/tree/master/tai64)
+* [tai64:](https://github.com/iqlusioninc/crates/tree/develop/tai64)
   TAI64(N) timestamp format (Temps Atomique International).
-* [zeroize:](https://github.com/iqlusioninc/crates/tree/master/zeroize)
+* [zeroize:](https://github.com/iqlusioninc/crates/tree/develop/zeroize)
    Securely zero memory while avoiding compiler optimizations.
 
 ## License

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,15 @@
-branches:
-  only:
-    - master
-
 os: Visual Studio 2017
 
 environment:
   matrix:
     - channel: stable
       target: x86_64-pc-windows-msvc
+    - channel: 1.34.0
+      target: x86_64-pc-windows-msvc
+
+branches:
+  only:
+    - develop
 
 install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe

--- a/canonical-path/Cargo.toml
+++ b/canonical-path/Cargo.toml
@@ -6,13 +6,14 @@ authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0"
 edition     = "2018"
 homepage    = "https://github.com/iqlusioninc/crates/"
-repository  = "https://github.com/iqlusioninc/crates/tree/master/canonical-path"
+repository  = "https://github.com/iqlusioninc/crates/tree/develop/canonical-path"
 readme      = "README.md"
 categories  = ["filesystem"]
 keywords    = ["filesystem", "path", "canonicalization"]
 
 [badges]
-travis-ci = { repository = "iqlusioninc/crates" }
+maintenance = { status = "passively-maintained" }
+travis-ci = { repository = "iqlusioninc/crates", branch = "develop" }
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/canonical-path/README.md
+++ b/canonical-path/README.md
@@ -12,7 +12,7 @@
 [build-image]: https://circleci.com/gh/iqlusioninc/crates.svg?style=shield
 [build-link]: https://circleci.com/gh/iqlusioninc/crates
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
-[license-link]: https://github.com/iqlusioninc/crates/blob/master/LICENSE
+[license-link]: https://github.com/iqlusioninc/crates/blob/develop/LICENSE
 
 `std::fs::Path` and `PathBuf`-like types for representing canonical
 filesystem paths.
@@ -31,4 +31,4 @@ Apache License (Version 2.0).
 See [LICENSE] file in the `iqlusioninc/crates` toplevel directory for more
 information.
 
-[LICENSE]: https://github.com/iqlusioninc/crates/blob/master/LICENSE
+[LICENSE]: https://github.com/iqlusioninc/crates/blob/develop/LICENSE

--- a/gaunt/Cargo.toml
+++ b/gaunt/Cargo.toml
@@ -6,13 +6,13 @@ license     = "Apache-2.0"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 edition     = "2018"
 homepage    = "https://github.com/iqlusioninc/crates/"
-repository  = "https://github.com/iqlusioninc/crates/tree/master/gaunt"
+repository  = "https://github.com/iqlusioninc/crates/tree/develop/gaunt"
 readme      = "README.md"
 categories  = ["network-programming", "no-std", "web-programming::http-client"]
 keywords    = ["api", "client", "http", "rest", "web"]
 
 [badges]
-travis-ci = { repository = "iqlusioninc/crates" }
+travis-ci = { repository = "iqlusioninc/crates", branch = "develop" }
 
 [dependencies]
 failure = { version = "0.1", default-features = false }

--- a/gaunt/README.md
+++ b/gaunt/README.md
@@ -10,7 +10,7 @@
 [docs-image]: https://docs.rs/gaunt/badge.svg
 [docs-link]: https://docs.rs/gaunt/
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
-[license-link]: https://github.com/iqlusioninc/crates/blob/master/LICENSE
+[license-link]: https://github.com/iqlusioninc/crates/blob/develop/LICENSE
 [build-image]: https://circleci.com/gh/iqlusioninc/crates.svg?style=shield
 [build-link]: https://circleci.com/gh/iqlusioninc/crates
 

--- a/subtle-encoding/Cargo.toml
+++ b/subtle-encoding/Cargo.toml
@@ -11,7 +11,7 @@ authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0 OR MIT"
 edition     = "2018"
 homepage    = "https://github.com/iqlusioninc/crates/"
-repository  = "https://github.com/iqlusioninc/crates/tree/master/subtle-encoding"
+repository  = "https://github.com/iqlusioninc/crates/tree/develop/subtle-encoding"
 readme      = "README.md"
 categories  = ["cryptography", "encoding", "no-std"]
 keywords    = ["base64", "bech32", "constant-time", "hex", "security"]
@@ -27,11 +27,11 @@ alloc = []
 base64 = ["zeroize"]
 bech32-preview = ["alloc", "zeroize"]
 hex = []
-nightly = ["zeroize/nightly"]
 std = ["alloc", "zeroize"]
 
 [badges]
-travis-ci = { repository = "iqlusioninc/crates" }
+maintenance = { status = "passively-maintained" }
+travis-ci = { repository = "iqlusioninc/crates", branch = "develop" }
 
 [package.metadata.docs.rs]
 features = ["bech32-preview"]

--- a/subtle-encoding/README.md
+++ b/subtle-encoding/README.md
@@ -42,5 +42,5 @@ See [LICENSE] (Apache License, Version 2.0) file in the `iqlusioninc/crates`
 toplevel directory of this repository or [LICENSE-MIT] for details.
 
 [Documentation]: https://docs.rs/subtle-encoding/
-[LICENSE]: https://github.com/iqlusioninc/crates/blob/master/LICENSE
-[LICENSE-MIT]: https://github.com/iqlusioninc/crates/blob/master/subtle-encoding/LICENSE-MIT
+[LICENSE]: https://github.com/iqlusioninc/crates/blob/develop/LICENSE
+[LICENSE-MIT]: https://github.com/iqlusioninc/crates/blob/develop/subtle-encoding/LICENSE-MIT

--- a/tai64/Cargo.toml
+++ b/tai64/Cargo.toml
@@ -6,13 +6,14 @@ authors     = ["Tony Arcieri <tony@iqlusion.io>", "sopium <sopium@mysterious.sit
 license     = "Apache-2.0"
 edition     = "2018"
 homepage    = "https://github.com/iqlusioninc/crates/"
-repository  = "https://github.com/iqlusioninc/crates/tree/master/tai64"
+repository  = "https://github.com/iqlusioninc/crates/tree/develop/tai64"
 readme      = "README.md"
 categories  = ["date-and-time", "internationalization", "network-programming", "parser-implementations"]
 keywords    = ["tai64", "time", "timestamps", "chrono"]
 
 [badges]
-travis-ci = { repository = "iqlusioninc/crates" }
+maintenance = { status = "passively-maintained" }
+travis-ci = { repository = "iqlusioninc/crates", branch = "develop" }
 
 [dependencies]
 byteorder = "1.0"

--- a/tai64/README.md
+++ b/tai64/README.md
@@ -12,7 +12,7 @@
 [build-image]: https://circleci.com/gh/iqlusioninc/crates.svg?style=shield
 [build-link]: https://circleci.com/gh/iqlusioninc/crates
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
-[license-link]: https://github.com/iqlusioninc/crates/blob/master/LICENSE
+[license-link]: https://github.com/iqlusioninc/crates/blob/develop/LICENSE
 
 An implementation of the [TAI64(N)] (*Temps Atomique International*) timestamp
 format in Rust.
@@ -35,4 +35,4 @@ The **tai64** crate is distributed under the terms of the Apache License
 See [LICENSE] file in the `iqlusioninc/crates` toplevel directory for more
 information.
 
-[LICENSE]: https://github.com/iqlusioninc/crates/blob/master/LICENSE
+[LICENSE]: https://github.com/iqlusioninc/crates/blob/develop/LICENSE

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -12,13 +12,13 @@ authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0 OR MIT"
 edition     = "2018"
 homepage    = "https://github.com/iqlusioninc/crates/"
-repository  = "https://github.com/iqlusioninc/crates/tree/master/zeroize"
+repository  = "https://github.com/iqlusioninc/crates/tree/develop/zeroize"
 readme      = "README.md"
 categories  = ["cryptography", "memory-management", "no-std", "os"]
 keywords    = ["memory", "memset", "secure", "volatile", "zero"]
 
 [badges]
-travis-ci = { repository = "iqlusioninc/crates" }
+travis-ci = { repository = "iqlusioninc/crates", branch = "develop" }
 
 [dependencies]
 zeroize_derive = { version = "0.1", path = "../zeroize_derive", optional = true }
@@ -26,5 +26,4 @@ zeroize_derive = { version = "0.1", path = "../zeroize_derive", optional = true 
 [features]
 default = ["std", "zeroize_derive"]
 alloc = []
-nightly = []
 std = ["alloc"]

--- a/zeroize/README.md
+++ b/zeroize/README.md
@@ -65,7 +65,6 @@ without any additional terms or conditions.
 [Zeroing memory securely is hard]: http://www.daemonology.net/blog/2014-09-04-how-to-zero-a-buffer.html
 [core::ptr::write_volatile]: https://doc.rust-lang.org/core/ptr/fn.write_volatile.html
 [core::sync::atomic]: https://doc.rust-lang.org/stable/core/sync/atomic/index.html
-[pin]: https://github.com/rust-lang/rfcs/blob/master/text/2349-pin.md
 [good cryptographic hygiene]: https://cryptocoding.net/index.php/Coding_rules#Clean_memory_of_secret_data
-[LICENSE]: https://github.com/iqlusioninc/crates/blob/master/LICENSE
-[LICENSE-MIT]: https://github.com/iqlusioninc/crates/blob/master/zeroize/LICENSE-MIT
+[LICENSE]: https://github.com/iqlusioninc/crates/blob/develop/LICENSE
+[LICENSE-MIT]: https://github.com/iqlusioninc/crates/blob/develop/zeroize/LICENSE-MIT

--- a/zeroize_derive/Cargo.toml
+++ b/zeroize_derive/Cargo.toml
@@ -6,7 +6,7 @@ authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0 OR MIT"
 edition     = "2018"
 homepage    = "https://github.com/iqlusioninc/crates/"
-repository  = "https://github.com/iqlusioninc/crates/tree/master/zeroize_derive"
+repository  = "https://github.com/iqlusioninc/crates/tree/develop/zeroize_derive"
 readme      = "README.md"
 categories  = ["cryptography", "memory-management", "no-std", "os"]
 keywords    = ["memory", "memset", "secure", "volatile", "zero"]
@@ -20,4 +20,4 @@ quote = "0.6"
 syn = "0.15"
 
 [badges]
-travis-ci = { repository = "iqlusioninc/crates" }
+travis-ci = { repository = "iqlusioninc/crates", branch = "develop" }

--- a/zeroize_derive/README.md
+++ b/zeroize_derive/README.md
@@ -32,6 +32,6 @@ without any additional terms or conditions.
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [build-image]: https://circleci.com/gh/iqlusioninc/crates.svg?style=shield
 [build-link]: https://circleci.com/gh/iqlusioninc/crates
-[zeroize]: https://github.com/iqlusioninc/crates/tree/master/zeroize
-[LICENSE]: https://github.com/iqlusioninc/crates/blob/master/LICENSE
-[LICENSE-MIT]: https://github.com/iqlusioninc/crates/blob/master/zeroize/LICENSE-MIT
+[zeroize]: https://github.com/iqlusioninc/crates/tree/develop/zeroize
+[LICENSE]: https://github.com/iqlusioninc/crates/blob/develop/LICENSE
+[LICENSE-MIT]: https://github.com/iqlusioninc/crates/blob/develop/zeroize/LICENSE-MIT


### PR DESCRIPTION
Zeroize previously provided a 'nightly' feature which used a slightly more complex implementation in order to facilitate a micro-optimization: namely it used [volatile_set_memory] on `nightly` to efficiently byte slices (which typically thunks to `memset()` followed by a fence instruction).

However, the extra complexity was never justified through benchmarking, nor does it represent the desired path forward on nightly (which would be to use atomic writes instead of volatile writes, when they become available but aren't yet stabilized).

It also seems some `Zeroize` impls are missing, particularly for arrays, in which case the special-case nightly impls become more cumbersome.

This commit rips out the entire nightly feature and ensures the crate behaves the same way everywhere regardless of Rust channel.

[volatile_set_memory]: https://doc.rust-lang.org/std/intrinsics/fn.volatile_set_memory.html