### PR TITLE
zeroize_derive: Use synstructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,6 +424,7 @@ dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -568,47 +568,4 @@ mod tests {
         boxed_arr.zeroize();
         assert_eq!(boxed_arr.as_ref(), &[0u8; 3]);
     }
-
-    #[cfg(feature = "zeroize_derive")]
-    mod derive {
-        use super::*;
-
-        #[derive(Zeroize)]
-        struct ZeroizableTupleStruct([u8; 3]);
-
-        #[test]
-        fn derive_tuple_struct_test() {
-            let mut value = ZeroizableTupleStruct([1, 2, 3]);
-            value.zeroize();
-            assert_eq!(&value.0, &[0, 0, 0])
-        }
-
-        #[derive(Zeroize)]
-        struct ZeroizableStruct {
-            string: String,
-            vec: Vec<u8>,
-            bytearray: [u8; 3],
-            number: usize,
-            boolean: bool,
-        }
-
-        #[test]
-        fn derive_struct_test() {
-            let mut value = ZeroizableStruct {
-                string: String::from("Hello, world!"),
-                vec: vec![1, 2, 3],
-                bytearray: [4, 5, 6],
-                number: 42,
-                boolean: true,
-            };
-
-            value.zeroize();
-
-            assert!(value.string.is_empty());
-            assert!(value.vec.is_empty());
-            assert_eq!(&value.bytearray, &[0, 0, 0]);
-            assert_eq!(value.number, 0);
-            assert!(!value.boolean);
-        }
-    }
 }

--- a/zeroize/tests/zeroize_derive.rs
+++ b/zeroize/tests/zeroize_derive.rs
@@ -1,0 +1,41 @@
+//! Integration tests for `zeroize_derive` proc macros
+
+use zeroize::Zeroize;
+
+#[derive(Zeroize)]
+struct ZeroizableTupleStruct([u8; 3]);
+
+#[test]
+fn derive_tuple_struct_test() {
+    let mut value = ZeroizableTupleStruct([1, 2, 3]);
+    value.zeroize();
+    assert_eq!(&value.0, &[0, 0, 0])
+}
+
+#[derive(Zeroize)]
+struct ZeroizableStruct {
+    string: String,
+    vec: Vec<u8>,
+    bytearray: [u8; 3],
+    number: usize,
+    boolean: bool,
+}
+
+#[test]
+fn derive_struct_test() {
+    let mut value = ZeroizableStruct {
+        string: String::from("Hello, world!"),
+        vec: vec![1, 2, 3],
+        bytearray: [4, 5, 6],
+        number: 42,
+        boolean: true,
+    };
+
+    value.zeroize();
+
+    assert!(value.string.is_empty());
+    assert!(value.vec.is_empty());
+    assert_eq!(&value.bytearray, &[0, 0, 0]);
+    assert_eq!(value.number, 0);
+    assert!(!value.boolean);
+}

--- a/zeroize_derive/Cargo.toml
+++ b/zeroize_derive/Cargo.toml
@@ -18,6 +18,10 @@ proc-macro = true
 proc-macro2 = "0.4"
 quote = "0.6"
 syn = "0.15"
+synstructure = "0.10"
 
 [badges]
 travis-ci = { repository = "iqlusioninc/crates", branch = "develop" }
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--document-private-items"]


### PR DESCRIPTION
Replaces the previous handrolled proc macros with ones generated by synstructure.

This not only makes them more declarative and maintainable, but also allows testing that the output of the proc macro generates the desired code.