### PR TITLE
zeroize_derive: Impl Drop by default when deriving Zeroize

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ script:
   - cargo build --all --no-default-features
 
   # test
-  - cargo test --all --release
+  - cargo test --all --all-features --release
 
   # crates with non-default features
   - (cd gaunt && cargo test --release --features=logger)

--- a/zeroize/README.md
+++ b/zeroize/README.md
@@ -2,7 +2,8 @@
 
 [![Crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
-![MIT/Apache 2.0 Licensed][license-image]
+![Apache 2.0/MIT Licensed][license-image]
+![Rust 1.31+][rustc-image]
 [![Build Status][build-image]][build-link]
 
 [crate-image]: https://img.shields.io/crates/v/zeroize.svg
@@ -10,6 +11,7 @@
 [docs-image]: https://docs.rs/zeroize/badge.svg
 [docs-link]: https://docs.rs/zeroize/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.31+-blue.svg
 [build-image]: https://circleci.com/gh/iqlusioninc/crates.svg?style=shield
 [build-link]: https://circleci.com/gh/iqlusioninc/crates
 

--- a/zeroize/tests/zeroize_derive.rs
+++ b/zeroize/tests/zeroize_derive.rs
@@ -1,8 +1,8 @@
 //! Integration tests for `zeroize_derive` proc macros
 
-use zeroize::{Zeroize, ZeroizeOnDrop};
+use zeroize::Zeroize;
 
-#[derive(Zeroize, ZeroizeOnDrop)]
+#[derive(Zeroize)]
 struct ZeroizableTupleStruct([u8; 3]);
 
 #[test]
@@ -12,7 +12,7 @@ fn derive_tuple_struct_test() {
     assert_eq!(&value.0, &[0, 0, 0])
 }
 
-#[derive(Zeroize, ZeroizeOnDrop)]
+#[derive(Zeroize)]
 struct ZeroizableStruct {
     string: String,
     vec: Vec<u8>,
@@ -38,4 +38,19 @@ fn derive_struct_test() {
     assert_eq!(&value.bytearray, &[0, 0, 0]);
     assert_eq!(value.number, 0);
     assert!(!value.boolean);
+}
+
+/// Test that the custom macro actually derived `Drop` for `ZeroizableStruct`
+trait Droppable: Drop {}
+impl Droppable for ZeroizableStruct {}
+
+/// Test that this successfully disables deriving a drop handler by defining
+/// a custom one which should conflict if the custom derive did too
+#[allow(dead_code)]
+#[derive(Zeroize)]
+#[zeroize(no_drop)]
+struct ZeroizeNoDropStruct([u8; 3]);
+
+impl Drop for ZeroizeNoDropStruct {
+    fn drop(&mut self) {}
 }


### PR DESCRIPTION
This change replaces the `ZeroizeOnDrop` trait by having the custom derive for `Zeroize` automatically impl `Drop` and call `zeroize()`.

Opt-out of the default `Drop` handler is provided in the form of a custom attribute: `#[zeroize(no_drop)]`.

This should make zeroizing-on-drop the "happy path" for this crate.