### PR TITLE
Add rustc badges to all crates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # iqlusion crates <a href="https://www.iqlusion.io"><img src="https://storage.googleapis.com/iqlusion-prod-web-assets/img/logo/iqlusion-rings-sm.png" alt="iqlusion" width="24" height="24"></a> <a href="https://crates.io">📦</a>
 
 [![Apache 2.0 Licensed][license-image]][license-link]
+![Rust 1.34+][rustc-image]
 [![Build Status][build-image]][build-link]
 [![Appveyor Status][appveyor-image]][appveyor-link]
 
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/crates/blob/develop/LICENSE
+[rustc-image]: https://img.shields.io/badge/rustc-1.34+-blue.svg
 [build-image]: https://travis-ci.org/iqlusioninc/crates.svg?branch=develop
 [build-link]: https://travis-ci.org/iqlusioninc/crates/
 [appveyor-image]: https://ci.appveyor.com/api/projects/status/qslcjs7e1rn4a2w9?svg=true
@@ -30,6 +32,12 @@ All crates require Rust 2018 edition and are tested on the following channels:
 
 Crates may work on slightly earlier 2018 edition-supporting versions of Rust
 (i.e. 1.31.0+) but are not tested on these releases or guaranteed to work.
+
+All crates in CI with the above channels on the following operating systems:
+
+- Linux
+- macOS
+- Windows
 
 ## Crate Descriptions
 

--- a/canonical-path/README.md
+++ b/canonical-path/README.md
@@ -2,17 +2,19 @@
 
 [![Crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
-[![Build Status][build-image]][build-link]
 [![Apache 2.0 Licensed][license-image]][license-link]
+![Rust 1.31+][rustc-image]
+[![Build Status][build-image]][build-link]
 
 [crate-image]: https://img.shields.io/crates/v/canonical-path.svg
 [crate-link]: https://crates.io/crates/canonical-path
 [docs-image]: https://docs.rs/canonical-path/badge.svg
 [docs-link]: https://docs.rs/canonical-path/
-[build-image]: https://circleci.com/gh/iqlusioninc/crates.svg?style=shield
-[build-link]: https://circleci.com/gh/iqlusioninc/crates
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/crates/blob/develop/LICENSE
+[rustc-image]: https://img.shields.io/badge/rustc-1.31+-blue.svg
+[build-image]: https://circleci.com/gh/iqlusioninc/crates.svg?style=shield
+[build-link]: https://circleci.com/gh/iqlusioninc/crates
 
 `std::fs::Path` and `PathBuf`-like types for representing canonical
 filesystem paths.

--- a/gaunt/README.md
+++ b/gaunt/README.md
@@ -3,6 +3,7 @@
 [![Crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
 [![Apache 2.0 Licensed][license-image]][license-link]
+![Rust 1.31+][rustc-image]
 [![Build Status][build-image]][build-link]
 
 [crate-image]: https://img.shields.io/crates/v/gaunt.svg
@@ -11,6 +12,7 @@
 [docs-link]: https://docs.rs/gaunt/
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/crates/blob/develop/LICENSE
+[rustc-image]: https://img.shields.io/badge/rustc-1.31+-blue.svg
 [build-image]: https://circleci.com/gh/iqlusioninc/crates.svg?style=shield
 [build-link]: https://circleci.com/gh/iqlusioninc/crates
 

--- a/subtle-encoding/README.md
+++ b/subtle-encoding/README.md
@@ -3,14 +3,15 @@
 [![Crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
 ![Apache 2.0/MIT Licensed][license-image]
+![Rust 1.31+][rustc-image]
 [![Build Status][build-image]][build-link]
-<img src="https://rustsec.org/assets/img/badges/unsafe/forbidden.svg" height="20" alt="unsafe: forbidden">
 
 [crate-image]: https://img.shields.io/crates/v/subtle-encoding.svg
 [crate-link]: https://crates.io/crates/subtle-encoding
 [docs-image]: https://docs.rs/subtle-encoding/badge.svg
 [docs-link]: https://docs.rs/subtle-encoding/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.31+-blue.svg
 [build-image]: https://circleci.com/gh/iqlusioninc/crates.svg?style=shield
 [build-link]: https://circleci.com/gh/iqlusioninc/crates
 

--- a/tai64/README.md
+++ b/tai64/README.md
@@ -2,17 +2,19 @@
 
 [![Crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
-[![Build Status][build-image]][build-link]
 [![Apache 2.0 Licensed][license-image]][license-link]
+![Rust 1.31+][rustc-image]
+[![Build Status][build-image]][build-link]
 
 [crate-image]: https://img.shields.io/crates/v/tai64.svg
 [crate-link]: https://crates.io/crates/tai64
 [docs-image]: https://docs.rs/tai64/badge.svg
 [docs-link]: https://docs.rs/tai64/
-[build-image]: https://circleci.com/gh/iqlusioninc/crates.svg?style=shield
-[build-link]: https://circleci.com/gh/iqlusioninc/crates
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/crates/blob/develop/LICENSE
+[rustc-image]: https://img.shields.io/badge/rustc-1.31+-blue.svg
+[build-image]: https://circleci.com/gh/iqlusioninc/crates.svg?style=shield
+[build-link]: https://circleci.com/gh/iqlusioninc/crates
 
 An implementation of the [TAI64(N)] (*Temps Atomique International*) timestamp
 format in Rust.


### PR DESCRIPTION
Shows minimum supported version.

Some are labeled as 1.31 and others 1.34. The plan is to do another release of "passively-maintained" crates, and then bump all of them to 1.34 (as that's the minimum we presently test on).