### PR TITLE
canonical-path v2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "canonical-path"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/canonical-path/CHANGES.md
+++ b/canonical-path/CHANGES.md
@@ -1,3 +1,8 @@
+## [2.0.0] (2018-05-20)
+
+- Clean up and modernize ([#193])
+- Update to 2018 edition ([#138])
+
 ## 1.0.0 (2018-10-03)
 
 - Initial 1.0 release
@@ -9,3 +14,7 @@
 ## 0.1.0 (2018-04-09)
 
 - Initial release
+
+[2.0.0]: https://github.com/iqlusioninc/crates/pull/194
+[#193]: https://github.com/iqlusioninc/crates/pull/193
+[#138]: https://github.com/iqlusioninc/crates/pull/138

--- a/canonical-path/Cargo.toml
+++ b/canonical-path/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "canonical-path"
 description = "Path and PathBuf-like types for representing canonical filesystem paths"
-version     = "1.0.0" # Also update html_root_url in lib.rs when bumping this
+version     = "2.0.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0"
 edition     = "2018"

--- a/canonical-path/src/lib.rs
+++ b/canonical-path/src/lib.rs
@@ -11,7 +11,7 @@
     unused_import_braces,
     unused_qualifications
 )]
-#![doc(html_root_url = "https://docs.rs/canonical-path/1.0.0")]
+#![doc(html_root_url = "https://docs.rs/canonical-path/2.0.0")]
 
 use std::{
     borrow::Borrow,


### PR DESCRIPTION
- Clean up and modernize (#193)
- Update to 2018 edition (#138)