### PR TITLE
tai64 v2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,7 +358,7 @@ dependencies = [
 
 [[package]]
 name = "tai64"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/tai64/CHANGES.md
+++ b/tai64/CHANGES.md
@@ -1,3 +1,13 @@
+## [2.0.0] (2019-05-20)
+
+- `no_std` support ([#196])
+- Cleanups and modernization ([#195])
+  - `to_external` and `from_external` replaced with `From`/`TryFrom`
+  - `byteorder` crate replaced with `from_be_bytes` / `to_be_bytes`
+  - `Error` type
+  - Update `quickcheck` to `0.8`
+- Update to Rust 2018 edition ([#138])
+
 ## 1.0.0 (2018-10-03)
 
 - Initial 1.0 release.
@@ -22,6 +32,9 @@
 
 - Initial release
 
+[2.0.0]: https://github.com/iqlusioninc/crates/pull/197
+[#196]: https://github.com/iqlusioninc/crates/pull/196
+[#195]: https://github.com/iqlusioninc/crates/pull/195
 [#138]: https://github.com/iqlusioninc/crates/pull/138
 [#7]: https://github.com/iqlusioninc/crates/pull/7
 [#2]: https://github.com/iqlusioninc/crates/pull/2

--- a/tai64/Cargo.toml
+++ b/tai64/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "tai64"
 description = "TAI64 and TAI64N (i.e. Temps Atomique International) timestamp support for Rust"
-version     = "1.0.0" # Also update html_root_url in lib.rs when bumping this
+version     = "2.0.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>", "sopium <sopium@mysterious.site>"]
 license     = "Apache-2.0"
 edition     = "2018"

--- a/tai64/src/lib.rs
+++ b/tai64/src/lib.rs
@@ -8,7 +8,7 @@
     unused_import_braces,
     unused_qualifications
 )]
-#![doc(html_root_url = "https://docs.rs/tai64/1.0.0")]
+#![doc(html_root_url = "https://docs.rs/tai64/2.0.0")]
 
 #[cfg(feature = "chrono")]
 use chrono::{DateTime, NaiveDateTime, Utc};


### PR DESCRIPTION
- `no_std` support (#196)
- Cleanups and modernization (#195)
  - `to_external` and `from_external` replaced with `From`/`TryFrom`
  - `byteorder` crate replaced with `from_be_bytes` / `to_be_bytes`
  - `Error` type
  - Update `quickcheck` to `0.8`
- Update to Rust 2018 edition (#138)