### PR TITLE
Clarify licensing

### DIFF
--- a/canonical-path/README.md
+++ b/canonical-path/README.md
@@ -19,13 +19,23 @@ are canonical, or at least, were canonical at the time they were created.
 
 Copyright © 2018-2019 iqlusion
 
-The **canonical-path** crate is distributed under the terms of the
-Apache License (Version 2.0).
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-See [LICENSE] file in the `iqlusioninc/crates` toplevel directory for more
-information.
+    https://www.apache.org/licenses/LICENSE-2.0
 
-[LICENSE]: https://github.com/iqlusioninc/crates/blob/develop/LICENSE
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally
+submitted for inclusion in the work by you shall be dual licensed as above,
+without any additional terms or conditions.
 
 [//]: # (badges)
 

--- a/gaunt/README.md
+++ b/gaunt/README.md
@@ -31,7 +31,7 @@ use, but has the following roadmap:
 
 ## License
 
-Copyright © 2018 iqlusion
+Copyright © 2019 iqlusion
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -44,6 +44,12 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+## Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally
+submitted for inclusion in the work by you shall be dual licensed as above,
+without any additional terms or conditions.
 
 [//]: # (badges)
 

--- a/secrecy/Cargo.toml
+++ b/secrecy/Cargo.toml
@@ -8,7 +8,7 @@ description = """
               """
 version     = "0.1.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
-license     = "Apache-2.0 OR MIT"
+license     = "Apache-2.0"
 edition     = "2018"
 homepage    = "https://github.com/iqlusioninc/crates/"
 repository  = "https://github.com/iqlusioninc/crates/tree/master/secrecy"

--- a/secrecy/README.md
+++ b/secrecy/README.md
@@ -43,11 +43,17 @@ possible.
 
 Copyright © 2019 iqlusion
 
-**secrecy** is distributed under the terms of either the MIT license
-or the Apache License (Version 2.0), at your option.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-See [LICENSE] (Apache License, Version 2.0) file in the `iqlusioninc/crates`
-toplevel directory of this repository or [LICENSE-MIT] for details.
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 
 ## Contribution
 

--- a/tai64/README.md
+++ b/tai64/README.md
@@ -21,11 +21,23 @@ Supports converting to/from Rust's built-in [SystemTime] type and optionally to
 
 ## License
 
-The **tai64** crate is distributed under the terms of the Apache License
-(Version 2.0).
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-See [LICENSE] file in the `iqlusioninc/crates` toplevel directory for more
-information.
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally
+submitted for inclusion in the work by you shall be dual licensed as above,
+without any additional terms or conditions.
 
 [//]: # (badges)
 


### PR DESCRIPTION
Some crates in this repo are Apache 2.0 ONLY. Others are Apache 2.0+MIT.

Some of the previous boilerplate didn't properly reflect the intended licensing on these crates. This commit updates all licensing boilerplate to properly reflect our intent.

To spell it out explicitly:

## Apache 2.0 ONLY

- `canonical-path`
- `gaunt`
- `secrecy`
- `tai64`

## Apache 2.0 + MIT

- `subtle-encoding`
- `zeroize`
- `zeroize_derive`

Note: The crates that are dual licensed as MIT were either adapted from code that was originally MIT licensed with Apache 2.0 dual licensing added with the original author's permission (`subtle-encoding`), or deliberately dual licensed from the start with the goal of potentially upstreaming the code to Rust projects (`zeroize` / `zeroize_derive`)