### PR TITLE
Test all crates on Rust 1.35.0 (and bump min version)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ branches:
     - develop
 
 rust:
-  - stable
+  - 1.35.0 # Minimum supported
+  - stable # Stable should always be supported
 
 os:
   - linux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,9 +2,12 @@ os: Visual Studio 2017
 
 environment:
   matrix:
-    - channel: stable
+    # Minimum supported rustc
+    - channel: 1.35.0
       target: x86_64-pc-windows-msvc
-    - channel: 1.34.0
+
+    # Stable channel should always be supported too
+    - channel: stable
       target: x86_64-pc-windows-msvc
 
 branches:
@@ -21,4 +24,5 @@ install:
 build: false
 
 test_script:
-  - cargo test --all
+  - cargo test --all --release
+  - cargo test --all --all-features --release

--- a/canonical-path/README.md
+++ b/canonical-path/README.md
@@ -3,7 +3,7 @@
 [![Crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
 [![Apache 2.0 Licensed][license-image]][license-link]
-![Rust 1.31+][rustc-image]
+![Rust 1.35+][rustc-image]
 [![Build Status][build-image]][build-link]
 
 `std::fs::Path` and `PathBuf`-like types for representing canonical
@@ -14,6 +14,10 @@ In the same way a `str` "guarantees" a `&[u8]` contains only valid UTF-8 data,
 are canonical, or at least, were canonical at the time they were created.
 
 [Documentation][docs-link]
+
+## Requirements
+
+- Rust 1.35+
 
 ## License
 
@@ -45,6 +49,6 @@ without any additional terms or conditions.
 [docs-link]: https://docs.rs/canonical-path/
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/crates/blob/develop/LICENSE
-[rustc-image]: https://img.shields.io/badge/rustc-1.31+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.35+-blue.svg
 [build-image]: https://travis-ci.com/iqlusioninc/crates.svg?branch=develop
 [build-link]: https://travis-ci.com/iqlusioninc/crates/

--- a/gaunt/README.md
+++ b/gaunt/README.md
@@ -3,7 +3,7 @@
 [![Crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
 [![Apache 2.0 Licensed][license-image]][license-link]
-![Rust 1.31+][rustc-image]
+![Rust 1.35+][rustc-image]
 [![forbid(unsafe_code)][unsafe-image]][unsafe-link]
 [![Build Status][build-image]][build-link]
 
@@ -28,6 +28,10 @@ use, but has the following roadmap:
 - Leverage `http` and `httparse` crates (`hyper` dependencies)
   as they are mature and well-tested.
 - Add server support in addition to client support.
+
+## Requirements
+
+- Rust 1.35+
 
 ## License
 
@@ -59,7 +63,7 @@ without any additional terms or conditions.
 [docs-link]: https://docs.rs/gaunt/
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/crates/blob/develop/LICENSE
-[rustc-image]: https://img.shields.io/badge/rustc-1.31+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.35+-blue.svg
 [unsafe-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [unsafe-link]: https://internals.rust-lang.org/t/disabling-unsafe-by-default/7988
 [build-image]: https://travis-ci.com/iqlusioninc/crates.svg?branch=develop

--- a/secrecy/README.md
+++ b/secrecy/README.md
@@ -22,6 +22,10 @@ This helps to ensure secrets aren't accidentally copied, logged, or otherwise
 exposed (as much as possible), and also ensures secrets are securely wiped
 from memory when dropped.
 
+## Requirements
+
+- Rust 1.35+
+
 ### serde support
 
 Optional `serde` support for parsing owned secret values is available, gated

--- a/subtle-encoding/README.md
+++ b/subtle-encoding/README.md
@@ -3,7 +3,7 @@
 [![Crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
 ![Apache 2.0/MIT Licensed][license-image]
-![Rust 1.31+][rustc-image]
+![Rust 1.35+][rustc-image]
 [![forbid(unsafe_code)][unsafe-image]][unsafe-link]
 [![Build Status][build-image]][build-link]
 
@@ -14,6 +14,10 @@ providing "best effort" constant-time operation.
 Useful for encoding/decoding secret values such as cryptographic keys.
 
 [Documentation]
+
+## Requirements
+
+- Rust 1.35+
 
 ## Security Notice
 
@@ -43,7 +47,7 @@ toplevel directory of this repository or [LICENSE-MIT] for details.
 [docs-image]: https://docs.rs/subtle-encoding/badge.svg
 [docs-link]: https://docs.rs/subtle-encoding/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.31+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.35+-blue.svg
 [unsafe-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [unsafe-link]: https://internals.rust-lang.org/t/disabling-unsafe-by-default/7988
 [build-image]: https://travis-ci.com/iqlusioninc/crates.svg?branch=develop

--- a/tai64/README.md
+++ b/tai64/README.md
@@ -3,7 +3,7 @@
 [![Crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
 [![Apache 2.0 Licensed][license-image]][license-link]
-![Rust 1.34+][rustc-image]
+![Rust 1.35+][rustc-image]
 [![forbid(unsafe_code)][unsafe-image]][unsafe-link]
 [![Build Status][build-image]][build-link]
 
@@ -17,7 +17,7 @@ Supports converting to/from Rust's built-in [SystemTime] type and optionally to
 
 ## Requirements
 
-- Rust 1.34+
+- Rust 1.35+
 
 ## License
 
@@ -47,7 +47,7 @@ without any additional terms or conditions.
 [docs-link]: https://docs.rs/tai64/
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/crates/blob/develop/LICENSE
-[rustc-image]: https://img.shields.io/badge/rustc-1.34+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.35+-blue.svg
 [unsafe-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [unsafe-link]: https://internals.rust-lang.org/t/disabling-unsafe-by-default/7988
 [build-image]: https://travis-ci.com/iqlusioninc/crates.svg?branch=develop

--- a/zeroize/README.md
+++ b/zeroize/README.md
@@ -3,7 +3,7 @@
 [![Crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
 ![Apache 2.0/MIT Licensed][license-image]
-![Rust 1.31+][rustc-image]
+![Rust 1.35+][rustc-image]
 [![Build Status][build-image]][build-link]
 
 Securely zero memory while avoiding compiler optimizations.
@@ -36,7 +36,7 @@ thereof, implemented in pure Rust with no usage of FFI or assembly.
 
 ## Requirements
 
-- Rust 1.31+
+- Rust 1.35+
 
 ## License
 
@@ -59,7 +59,7 @@ without any additional terms or conditions.
 [docs-image]: https://docs.rs/zeroize/badge.svg
 [docs-link]: https://docs.rs/zeroize/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.31+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.35+-blue.svg
 [build-image]: https://travis-ci.com/iqlusioninc/crates.svg?branch=develop
 [build-link]: https://travis-ci.com/iqlusioninc/crates/
 

--- a/zeroize_derive/README.md
+++ b/zeroize_derive/README.md
@@ -1,7 +1,8 @@
 # zeroize_derive 🄌 <a href="https://www.iqlusion.io"><img src="https://storage.googleapis.com/iqlusion-prod-web-assets/img/logo/iqlusion-rings-sm.png" alt="iqlusion" width="24" height="24"></a>
 
 [![Crate][crate-image]][crate-link]
-![MIT/Apache 2.0 Licensed][license-image]
+![Apache 2.0 Licensed/MIT][license-image]
+![Rust 1.35+][rustc-image]
 [![Build Status][build-image]][build-link]
 
 Custom derive support for [zeroize]: a crate for securely zeroing memory
@@ -12,7 +13,7 @@ See [zeroize] crate for documentation.
 
 ## Requirements
 
-- Rust 1.31+
+- Rust 1.35+
 
 ## License
 
@@ -28,11 +29,17 @@ Unless you explicitly state otherwise, any contribution intentionally
 submitted for inclusion in the work by you shall be dual licensed as above,
 without any additional terms or conditions.
 
+[//]: # (badges)
+
 [crate-image]: https://img.shields.io/crates/v/zeroize_derive.svg
 [crate-link]: https://crates.io/crates/zeroize_derive
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.35+-blue.svg
 [build-image]: https://travis-ci.com/iqlusioninc/crates.svg?branch=develop
 [build-link]: https://travis-ci.com/iqlusioninc/crates/
+
+[//]: # (general links)
+
 [zeroize]: https://github.com/iqlusioninc/crates/tree/develop/zeroize
 [LICENSE]: https://github.com/iqlusioninc/crates/blob/develop/LICENSE
 [LICENSE-MIT]: https://github.com/iqlusioninc/crates/blob/develop/zeroize/LICENSE-MIT


### PR DESCRIPTION
Notably `Box<Fn*>` was stabilized and is quite useful.

This consistently advertises the supported `rustc` version across all crates is 1.35.

This should, hopefully, represent a minimum version we'll be able to stick with for awhile.