### PR TITLE
secrecy: Add CloneableSecret marker trait

### DIFF
--- a/secrecy/src/lib.rs
+++ b/secrecy/src/lib.rs
@@ -54,6 +54,17 @@ where
     }
 }
 
+impl<S> Clone for Secret<S>
+where
+    S: CloneableSecret,
+{
+    fn clone(&self) -> Self {
+        Secret {
+            inner_secret: self.inner_secret.clone(),
+        }
+    }
+}
+
 impl<S> Debug for Secret<S>
 where
     S: Zeroize + DebugSecret,
@@ -85,6 +96,9 @@ where
         self.inner_secret.zeroize();
     }
 }
+
+/// Marker trait for secrets which are allowed to be cloned
+pub trait CloneableSecret: Clone + Zeroize {}
 
 /// Expose a reference to an inner secret
 pub trait ExposeSecret<S> {


### PR DESCRIPTION
Adds a marker trait for secrets which are allowed to be cloned.

Ideally secrets aren't cloned all over the place, so in lieu of a blanket impl, this marker trait allows certain secrets to be cloned.