### PR TITLE
zeroize v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,7 +326,7 @@ name = "secrecy"
 version = "0.2.0"
 dependencies = [
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 0.8.0",
+ "zeroize 0.9.0",
 ]
 
 [[package]]
@@ -345,7 +345,7 @@ version = "0.3.6"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 0.8.0",
+ "zeroize 0.9.0",
 ]
 
 [[package]]
@@ -435,14 +435,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "zeroize"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
- "zeroize_derive 0.8.0",
+ "zeroize_derive 0.9.0",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/secrecy/Cargo.toml
+++ b/secrecy/Cargo.toml
@@ -21,4 +21,4 @@ travis-ci = { repository = "iqlusioninc/crates", branch = "develop" }
 
 [dependencies]
 serde = { version = "1", optional = true }
-zeroize = { version = "0.8", path = "../zeroize", default-features = false }
+zeroize = { version = "0.9", path = "../zeroize", default-features = false }

--- a/subtle-encoding/Cargo.toml
+++ b/subtle-encoding/Cargo.toml
@@ -19,7 +19,7 @@ keywords    = ["base64", "bech32", "constant-time", "hex", "security"]
 [dependencies]
 failure = { version = "0.1", default-features = false }
 failure_derive = "0.1"
-zeroize = { version = "0.8", default-features = false, optional = true, path = "../zeroize" }
+zeroize = { version = "0.9", default-features = false, optional = true, path = "../zeroize" }
 
 [features]
 default = ["base64", "hex", "std"]

--- a/zeroize/CHANGES.md
+++ b/zeroize/CHANGES.md
@@ -1,3 +1,17 @@
+## [0.9.0] (2019-06-04)
+
+**NOTICE**: This release changes the default behavior of `derive(Zeroize)`
+to no longer derive a `Drop` impl. If you wish to derive `Drop`, you must
+now explicitly add a `#[zeroize(drop)]` attribute on the type for which you
+are deriving `Zeroize`.
+
+- Remove CPU fences ([#216])
+- Remove scary language about undefined behavior ([#214])
+- Bound blanket array impls on `Zeroize` instead of `DefaultIsZeroes` ([#213])
+- Require `zeroize(drop)` or `zeroize(no_drop)` attributes when deriving
+  `Zeroize` ([#212]).
+- Support stablized 'alloc' crate ([#192])
+
 ## [0.8.0] (2019-05-20)
 
 - Impl `Drop` by default when deriving `Zeroize` ([#188])
@@ -64,6 +78,12 @@ a pure Rust solution.
 
 - Initial release
 
+[0.9.0]: https://github.com/iqlusioninc/crates/pull/215
+[#216]: https://github.com/iqlusioninc/crates/pull/216
+[#214]: https://github.com/iqlusioninc/crates/pull/214
+[#213]: https://github.com/iqlusioninc/crates/pull/213
+[#212]: https://github.com/iqlusioninc/crates/pull/212
+[#192]: https://github.com/iqlusioninc/crates/pull/192
 [0.8.0]: https://github.com/iqlusioninc/crates/pull/189
 [#188]: https://github.com/iqlusioninc/crates/pull/188
 [0.7.0]: https://github.com/iqlusioninc/crates/pull/186

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -7,7 +7,7 @@ description = """
               Uses a portable pure Rust implementation that works everywhere,
               even WASM!
               """
-version     = "0.8.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.9.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0 OR MIT"
 edition     = "2018"
@@ -21,7 +21,7 @@ keywords    = ["memory", "memset", "secure", "volatile", "zero"]
 travis-ci = { repository = "iqlusioninc/crates", branch = "develop" }
 
 [dependencies]
-zeroize_derive = { version = "0.8", path = "../zeroize_derive", optional = true }
+zeroize_derive = { version = "0.9", path = "../zeroize_derive", optional = true }
 
 [features]
 default = ["std", "zeroize_derive"]

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -192,9 +192,6 @@
 //! [core::sync::atomic]: https://doc.rust-lang.org/stable/core/sync/atomic/index.html
 //! [Ordering::SeqCst]: https://doc.rust-lang.org/std/sync/atomic/enum.Ordering.html#variant.SeqCst
 //! [compiler_fence]: https://doc.rust-lang.org/stable/core/sync/atomic/fn.compiler_fence.html
-//! [memory-model]: https://github.com/nikomatsakis/rust-memory-model
-//! [unordered]: https://llvm.org/docs/Atomics.html#unordered
-//! [llvm-atomic]: https://github.com/rust-lang/rust/issues/58599
 //! [pin]: https://doc.rust-lang.org/std/pin/struct.Pin.html
 //! [good cryptographic hygiene]: https://cryptocoding.net/index.php/Coding_rules#Clean_memory_of_secret_data
 
@@ -207,7 +204,7 @@
     unused_import_braces,
     unused_qualifications
 )]
-#![doc(html_root_url = "https://docs.rs/zeroize/0.7.0")]
+#![doc(html_root_url = "https://docs.rs/zeroize/0.9.0")]
 
 #[cfg(all(feature = "alloc", not(feature = "std")))]
 #[allow(unused_imports)] // rustc bug?

--- a/zeroize_derive/Cargo.toml
+++ b/zeroize_derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "zeroize_derive"
 description = "Custom derive support for zeroize"
-version     = "0.8.0"
+version     = "0.9.0"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0 OR MIT"
 edition     = "2018"


### PR DESCRIPTION
**NOTICE**: This release changes the default behavior of `derive(Zeroize)` to no longer derive a `Drop` impl. If you wish to derive `Drop`, you must now explicitly add a `#[zeroize(drop)]` attribute on the type for which you are deriving `Zeroize`.

- Remove CPU fences (#216)
- Remove scary language about undefined behavior (#214)
- Bound blanket array impls on `Zeroize` instead of `DefaultIsZeroes` (#213)
- Require `zeroize(drop)` or `zeroize(no_drop)` attributes when deriving `Zeroize` (#212).
- Support stablized 'alloc' crate (#192)