### PR TITLE
hkd32: Add (optional) Bech32 encoding support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,6 +209,7 @@ dependencies = [
  "getrandom 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle-encoding 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-bip39 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 0.9.2",
 ]
@@ -608,6 +609,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle-encoding"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "syn"
 version = "0.15.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -719,6 +730,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "zeroize_derive"
 version = "0.9.0"
 dependencies = [
@@ -800,6 +816,7 @@ dependencies = [
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
+"checksum subtle-encoding 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "661a0cd6c74eca6fab1a5b452d9f2201fbac9004e958bd70d5b4f288b1aed479"
 "checksum syn 0.15.39 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d960b829a55e56db167e861ddb43602c003c7be0bee1d345021703fac2fb7c"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
@@ -812,3 +829,4 @@ dependencies = [
 "checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+"checksum zeroize 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4177936c03b5a349c1b8e4509c46add268e66bc66fe92663729fa0570fe4f213"

--- a/hkd32/Cargo.toml
+++ b/hkd32/Cargo.toml
@@ -23,6 +23,7 @@ travis-ci = { repository = "iqlusioninc/crates", branch = "develop" }
 getrandom = { version = "0.1", optional = true }
 hmac = { version = "0.7", default-features = false }
 sha2 = { version = "0.8", default-features = false }
+subtle-encoding = { version = "0.3", optional = true }
 tiny-bip39 = { version = "0.6", default-features = false, optional = true }
 
 [dependencies.zeroize]
@@ -32,8 +33,9 @@ default-features = false
 features = ["zeroize_derive"]
 
 [features]
-default = ["alloc", "getrandom"]
+default = ["alloc", "bech32", "getrandom"]
 alloc = ["zeroize/alloc"]
+bech32 = ["alloc", "subtle-encoding/bech32-preview"]
 mnemonic = ["alloc", "tiny-bip39"]
 
 [package.metadata.docs.rs]

--- a/hkd32/src/lib.rs
+++ b/hkd32/src/lib.rs
@@ -6,6 +6,29 @@
 //! This library implements a fully symmetric construction inspired by
 //! [BIP-0032: Hierarchical Deterministic Wallets][bip32].
 //!
+//! # Usage
+//!
+//! To derive a key using HKD32, you'll need the following:
+//!
+//! - `hkd32::KeyMaterial`: a 32-byte (256-bit) uniformly random value
+//! - `hkd32::Path` or `hkd32::PathBuf`: path to the child key
+//!
+//! Derivation paths can be raw bytestrings but also support
+//!
+//! # Example
+//!
+//! ```rust
+//! // Parent key
+//! let input_key_material = hkd32::KeyMaterial::random();
+//!
+//! // Path to the child key
+//! let derivation_path = "/foo/bar/baz".parse::<hkd32::PathBuf>().unwrap();
+//!
+//! // Derive subkey from the parent key. Call `as_bytes()` on this to obtain
+//! // a byte slice containing the derived key.
+//! let output_key_material = input_key_material.derive_subkey(derivation_path);
+//! ```
+//!
 //! [bip32]: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
 
 #![no_std]

--- a/hkd32/src/path.rs
+++ b/hkd32/src/path.rs
@@ -192,9 +192,15 @@ impl<'a> Component<'a> {
     /// Requires the `alloc` feature is enabled.
     #[cfg(feature = "alloc")]
     pub fn stringify(&self) -> Result<String, Error> {
-        str::from_utf8(self.as_bytes())
+        let s = str::from_utf8(self.as_bytes())
             .map(String::from)
-            .map_err(|_| Error)
+            .map_err(|_| Error)?;
+
+        if s.is_ascii() {
+            Ok(s)
+        } else {
+            Err(Error)
+        }
     }
 
     /// Serialize this component as a length-prefixed bytestring.

--- a/hkd32/src/pathbuf.rs
+++ b/hkd32/src/pathbuf.rs
@@ -117,6 +117,10 @@ impl FromStr for PathBuf {
         }
 
         for component in components {
+            if !component.is_ascii() {
+                return Err(Error);
+            }
+
             result.push(Component::new(component.as_bytes())?);
         }
 


### PR DESCRIPTION
Support for encoding/decoding `KeyMaterial` to/from Bech32 with arbitrary human readable parts.