### PR TITLE
zeroize: Improved attribute parser (fixes #237)

### DIFF
--- a/zeroize/README.md
+++ b/zeroize/README.md
@@ -13,7 +13,7 @@ This crate provides a safe<sup>†</sup>, portable access to cross-platform
 intrinsics for securely zeroing memory which are specifically documented as
 guaranteeing they won't be "optimized away".
 
-The [`Zeroize` trait] is the crate's primary (and only) API.
+The [`Zeroize` trait] is the crate's primary API.
 
 [Documentation]
 

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -52,17 +52,13 @@
 //!
 //! ## Custom Derive Support
 //!
-//! **NOTICE**: Previous versions of `zeroize` automatically derived
-//! `Drop`. This has been *REMOVED* and you now *MUST* explicitly specify
-//! either `zeroize(drop)` or `zeroize(no_drop)` (see below).
-//!
 //! This crate has custom derive support for the `Zeroize` trait, which
 //! automatically calls `zeroize()` on all members of a struct or tuple struct.
 //!
-//! Additionally it supports the following attributes (you *MUST* pick one):
+//! Additionally it supports the following attributes:
 //!
-//! - `#[zeroize(no_drop)]`: derive only `Zeroize` without adding a `Drop` impl
 //! - `#[zeroize(drop)]`: call `zeroize()` when this item is dropped
+//! - `#[zeroize(no_drop)]`: legacy attribute which will be removed in `zeroize` 1.0
 //!
 //! Example which derives `Drop`:
 //!
@@ -82,7 +78,6 @@
 //!
 //! // This struct will *NOT* be zeroized on drop
 //! #[derive(Copy, Clone, Zeroize)]
-//! #[zeroize(no_drop)]
 //! struct MyStruct([u8; 32]);
 //! ```
 //!


### PR DESCRIPTION
The previous attribute parser used a hack where it would compare to the s-exp representation of zeroize attributes to determine of they are `drop` or `no_drop`. This was a bit of a hack that broke with a recent nightly, which removed the spaces surrounding the ident.

This commit rewrites the attribute parser to properly walk the attribute `syn::Meta` nodes in the AST until it arrives at a `syn::Ident` containing either `drop` or `no_drop`. All other AST nodes will result in a panic.

This relaxes the previous restriction that any `#[derive(Zeroize)]` MUST be annotated with either `drop` or `no_drop`. This was put in place because `zeroize` v0.9 switched from default drop to requiring an explicit attribute. However v0.8 was the only version with implict drop, and has been yanked for several weeks. The change is fully backwards compatible and should have no effect on any existing v0.9 users.