### PR TITLE
Add a default impl for 'DebugSecret' trait

### DIFF
--- a/secrecy/src/lib.rs
+++ b/secrecy/src/lib.rs
@@ -104,5 +104,7 @@ pub trait DebugSecret {
     /// Information about what the secret contains.
     ///
     /// Static so as to discourage unintentional secret exposure.
-    fn debug_secret() -> &'static str;
+    fn debug_secret() -> &'static str {
+        "[SECRET]"
+    }
 }


### PR DESCRIPTION
By using a default implementation of the trait's function
'debug_secret()', downstream users don't have to define
the function themselves. They can simply:
```rust
    impl DebugSecret for MyType {}
```
and the static string returned will be the default one.

Downstream users can still add a full 'debug_secret()'
definition to the trait impl to change the string used.