### PR TITLE
subtle-encoding: Use new inclusive range syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,9 @@ branches:
 
 rust:
   - 1.36.0 # Minimum supported
-  # - stable # Stable should always be supported (but hasn't been bumped to 1.36)
+  - stable # Stable should always work too
 
-os:
-  - linux
-  - osx
-  - windows
+os: linux
 
 matrix:
   fast_finish: true
@@ -22,6 +19,13 @@ matrix:
     # improvements to Travis Windows support
     - os: windows
   include:
+    # Travis hasn't bumped `stable` on macOS to 1.36 yet =(
+    - name: "Rust: 1.36"
+      os: osx
+      rust: 1.36.0
+    - name: "Rust: 1.36"
+      os: windows
+      rust: 1.36.0
     - name: "Rust: stable (wasm32)"
       rust: stable
       script:

--- a/subtle-encoding/src/bech32/mod.rs
+++ b/subtle-encoding/src/bech32/mod.rs
@@ -109,7 +109,7 @@ impl Bech32 {
         // Check separator validity
         match separator {
             '1' | 'B' | 'I' | 'O' | 'b' | 'i' | 'o' => (),
-            '0'...'9' | 'A'...'Z' | 'a'...'z' => panic!("invalid separator: {:?}", separator),
+            '0'..='9' | 'A'..='Z' | 'a'..='z' => panic!("invalid separator: {:?}", separator),
             _ => (),
         }
 
@@ -200,7 +200,7 @@ impl Bech32 {
         // Ensure all characters in the human readable part are in a valid range
         for c in hrp.chars() {
             match c {
-                '!'...'@' | 'A'...'Z' | '['...'`' | 'a'...'z' | '{'...'~' => (),
+                '!'..='@' | 'A'..='Z' | '['..='`' | 'a'..='z' | '{'..='~' => (),
                 _ => return Err(EncodingInvalid),
             }
         }


### PR DESCRIPTION
The old syntax is causing build failures on 1.37:

https://ci.appveyor.com/project/tony-iqlusion/crates/builds/26780395/job/9jgvr9rye0q6mlok