### PR TITLE
zeroize_derive: Deprecate `#[zeroize(no_drop)]` attribute

### DIFF
--- a/zeroize_derive/src/lib.rs
+++ b/zeroize_derive/src/lib.rs
@@ -77,7 +77,10 @@ impl DeriveAttrs {
         if ident == "drop" {
             self.set_drop_flag(true);
         } else if ident == "no_drop" {
-            self.set_drop_flag(false);
+            eprintln!(
+                "warning: use of deprecated attribute #[zeroize(no_drop)]: \
+                 has no effect and will be removed in zeroize 1.0"
+            );
         } else {
             panic!("unknown #[zeroize] attribute type: {}", ident);
         }


### PR DESCRIPTION
The `no_drop` attribute existed because the initial proc macro implicitly added a `Drop` impl unless instructed otherwise.

It turns out there are several legitimate reasons not to derive `Drop`, so this was reversed in v0.9, with `drop` or `no_drop` attributes mandatory to ensure everyone migrated and was not expecting an implicit `Drop` handler to be derived (this was further enforced by yanking v0.8
which was the only version with this behavior).

Now that everyone has migrated, `no_drop` no longer serves any purpose, so this deprecates it by printing a warning.