### PR TITLE
gaunt/subtle-encoding/tai64: Remove `failure`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,12 +10,12 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "backtrace"
-version = "0.3.34"
+version = "0.3.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -142,7 +142,7 @@ name = "failure"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -171,8 +171,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "gaunt"
 version = "0.1.0"
 dependencies = [
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -260,7 +258,7 @@ name = "num-integer"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -269,7 +267,7 @@ name = "num-traits"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -368,7 +366,7 @@ name = "rand"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -398,7 +396,7 @@ name = "rand_chacha"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -484,7 +482,7 @@ name = "rand_pcg"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -607,8 +605,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "subtle-encoding"
 version = "0.3.7"
 dependencies = [
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 0.9.3",
 ]
 
@@ -669,7 +665,6 @@ name = "tai64"
 version = "2.0.1"
 dependencies = [
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -771,8 +766,8 @@ dependencies = [
 
 [metadata]
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
-"checksum autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "22130e92352b948e7e82a49cdb0aa94f2211761117f29e052dd397c1ac33542b"
-"checksum backtrace 0.3.34 (registry+https://github.com/rust-lang/crates.io-index)" = "b5164d292487f037ece34ec0de2fcede2faa162f085dd96d2385ab81b12765ba"
+"checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
+"checksum backtrace 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)" = "1371048253fa3bac6704bfd6bbfc922ee9bdcee8881330d40f308b81cc5adc55"
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"

--- a/gaunt/Cargo.toml
+++ b/gaunt/Cargo.toml
@@ -15,12 +15,10 @@ keywords    = ["api", "client", "http", "rest", "web"]
 travis-ci = { repository = "iqlusioninc/crates", branch = "develop" }
 
 [dependencies]
-failure = { version = "0.1", default-features = false }
-failure_derive = "0.1"
 slog = { version = "2", optional = true }
 
 [features]
 alloc = []
 default = ["std"]
 logger = ["slog", "std"]
-std = ["alloc", "failure/std"]
+std = ["alloc"]

--- a/gaunt/src/connection.rs
+++ b/gaunt/src/connection.rs
@@ -1,7 +1,5 @@
 //! Connections to HTTP servers
 
-use crate::prelude::*;
-
 #[cfg(feature = "logger")]
 use slog::Logger;
 use std::{
@@ -9,8 +7,10 @@ use std::{
     io::Write,
     net::{TcpStream, ToSocketAddrs},
     ops::DerefMut,
+    string::String,
     sync::Mutex,
     time::{Duration, Instant},
+    vec::Vec,
 };
 
 use super::{HTTP_VERSION, USER_AGENT};

--- a/gaunt/src/lib.rs
+++ b/gaunt/src/lib.rs
@@ -1,23 +1,20 @@
 //! **gaunt.rs**: high-level, self-contained, minimalist HTTP toolkit.
 
-#![crate_name = "gaunt"]
-#![crate_type = "rlib"]
-#![deny(warnings, missing_docs, unused_import_braces, unused_qualifications)]
 #![no_std]
-#![cfg_attr(all(feature = "nightly", not(feature = "std")), feature(alloc))]
+#![deny(warnings, missing_docs, unused_import_braces, unused_qualifications)]
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://storage.googleapis.com/iqlusion-production-web/github/gaunt/gaunt-logo.svg",
     html_root_url = "https://docs.rs/gaunt/0.1.0"
 )]
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
 #[cfg(any(feature = "std", test))]
 #[macro_use]
 extern crate std;
 
-extern crate failure;
-#[macro_use]
-extern crate failure_derive;
 #[cfg(feature = "logger")]
 #[macro_use]
 extern crate slog;
@@ -28,7 +25,6 @@ pub mod error;
 #[cfg(feature = "std")]
 pub mod connection;
 pub mod path;
-pub mod prelude;
 #[cfg(feature = "alloc")]
 pub mod request;
 #[cfg(feature = "alloc")]

--- a/gaunt/src/path.rs
+++ b/gaunt/src/path.rs
@@ -2,7 +2,8 @@
 
 #[cfg(feature = "alloc")]
 use {
-    crate::{error::Error, prelude::*},
+    crate::error::Error,
+    alloc::{borrow::ToOwned, string::String},
     core::{
         fmt::{self, Display},
         str::FromStr,

--- a/gaunt/src/prelude.rs
+++ b/gaunt/src/prelude.rs
@@ -1,7 +1,0 @@
-//! Use `std` or `alloc` prelude depending on selected cargo features
-
-#[cfg(all(feature = "alloc", not(feature = "std")))]
-pub use alloc::prelude::*;
-
-#[cfg(feature = "std")]
-pub use std::prelude::v1::*;

--- a/gaunt/src/request.rs
+++ b/gaunt/src/request.rs
@@ -1,6 +1,6 @@
 //! HTTP request types
 
-use crate::prelude::*;
+use alloc::vec::Vec;
 
 /// Request bodies
 #[derive(Debug, Default)]

--- a/gaunt/src/response/body.rs
+++ b/gaunt/src/response/body.rs
@@ -1,7 +1,7 @@
 //! Response body types.
 // TODO: support for streaming response bodies
 
-use crate::prelude::*;
+use alloc::vec::Vec;
 
 /// Response body
 #[derive(Debug)]

--- a/gaunt/src/response/reader.rs
+++ b/gaunt/src/response/reader.rs
@@ -1,8 +1,6 @@
 //! Read HTTP responses from an `io::Read`
 
-use crate::prelude::*;
-
-use std::{io::Read, str};
+use std::{io::Read, str, vec::Vec};
 
 use super::Body;
 use crate::error::Error;

--- a/subtle-encoding/Cargo.toml
+++ b/subtle-encoding/Cargo.toml
@@ -17,8 +17,6 @@ categories  = ["cryptography", "encoding", "no-std"]
 keywords    = ["base64", "bech32", "constant-time", "hex", "security"]
 
 [dependencies]
-failure = { version = "0.1", default-features = false }
-failure_derive = "0.1"
 zeroize = { version = "0.9", default-features = false, optional = true, path = "../zeroize" }
 
 [features]

--- a/subtle-encoding/README.md
+++ b/subtle-encoding/README.md
@@ -3,7 +3,7 @@
 [![Crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
 ![Apache 2.0/MIT Licensed][license-image]
-![Rust 1.35+][rustc-image]
+![MSRV][rustc-image]
 [![Safety Dance][safety-image]][safety-link]
 [![Build Status][build-image]][build-link]
 [![Gitter Chat][gitter-image]][gitter-link]
@@ -18,7 +18,7 @@ Useful for encoding/decoding secret values such as cryptographic keys.
 
 ## Requirements
 
-- Rust 1.35+
+- Rust **1.36+**
 
 ## Security Notice
 
@@ -48,7 +48,7 @@ toplevel directory of this repository or [LICENSE-MIT] for details.
 [docs-image]: https://docs.rs/subtle-encoding/badge.svg
 [docs-link]: https://docs.rs/subtle-encoding/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.35+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.36+-blue.svg
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
 [build-image]: https://travis-ci.com/iqlusioninc/crates.svg?branch=develop

--- a/subtle-encoding/src/base64.rs
+++ b/subtle-encoding/src/base64.rs
@@ -12,7 +12,7 @@ use super::{
     Error::{self, *},
 };
 #[cfg(feature = "alloc")]
-use crate::prelude::*;
+use alloc::vec::Vec;
 use zeroize::Zeroize;
 
 /// Base64 `Encoding` (traditional non-URL-safe RFC 4648 version)

--- a/subtle-encoding/src/bech32/base32.rs
+++ b/subtle-encoding/src/bech32/base32.rs
@@ -1,7 +1,7 @@
-use crate::{
-    error::Error::{self, *},
-    prelude::*,
-};
+//! Base32 encoding support
+
+use crate::error::Error;
+use alloc::vec::Vec;
 
 /// Encode binary data as base32
 pub fn encode(data: &[u8]) -> Vec<u8> {
@@ -21,7 +21,7 @@ fn convert(data: &[u8], src_base: u32, dst_base: u32) -> Result<Vec<u8>, Error> 
 
     for value in data {
         let v = u32::from(*value);
-        ensure!(v >> src_base == 0, EncodingInvalid);
+        ensure!(v >> src_base == 0, Error::EncodingInvalid);
 
         acc = (acc << src_base) | v;
         bits += src_base;
@@ -37,7 +37,7 @@ fn convert(data: &[u8], src_base: u32, dst_base: u32) -> Result<Vec<u8>, Error> 
             result.push(((acc << (dst_base - bits)) & max) as u8);
         }
     } else if bits >= src_base || ((acc << (dst_base - bits)) & max) != 0 {
-        return Err(PaddingInvalid);
+        return Err(Error::PaddingInvalid);
     }
 
     Ok(result)

--- a/subtle-encoding/src/encoding.rs
+++ b/subtle-encoding/src/encoding.rs
@@ -1,5 +1,7 @@
 //! The `Encoding` trait: common operations across all encoders
 
+#[cfg(feature = "alloc")]
+use alloc::{string::String, vec::Vec};
 #[cfg(feature = "std")]
 use std::{
     fs::File,
@@ -12,8 +14,6 @@ use std::{fs::OpenOptions, os::unix::fs::OpenOptionsExt};
 use zeroize::Zeroize;
 
 use super::Error;
-#[allow(unused_imports)]
-use crate::prelude::*;
 
 /// Mode to use for newly created files
 // TODO: make this configurable?
@@ -148,6 +148,8 @@ pub trait Encoding: Send + Sync {
     }
 }
 
+// TODO(tarcieri): `no_std` tests
+#[cfg(feature = "alloc")]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/subtle-encoding/src/error.rs
+++ b/subtle-encoding/src/error.rs
@@ -2,42 +2,54 @@
 
 #[cfg(all(feature = "alloc", not(feature = "std")))]
 use alloc::string::FromUtf8Error;
+use core::fmt;
 #[cfg(feature = "std")]
 use std::{io, string::FromUtf8Error};
 
 /// Error type
-#[derive(Clone, Eq, PartialEq, Debug, Fail)]
+#[derive(Clone, Eq, PartialEq, Debug)]
 pub enum Error {
     /// Checksum fdoes not match expected value
-    #[fail(display = "checksum mismatch")]
     ChecksumInvalid,
 
     /// Data is not encoded correctly
-    #[fail(display = "bad encoding")]
     EncodingInvalid,
 
     /// Error performing I/O operation
-    #[cfg(feature = "std")]
-    #[fail(display = "I/O error")]
     IoError,
 
     /// Input or output buffer is an incorrect length
-    #[fail(display = "invalid length")]
     LengthInvalid,
 
     /// Padding missing/invalid
-    #[fail(display = "padding invalid")]
     PaddingInvalid,
 
     /// Trailing whitespace detected
     // TODO: handle trailing whitespace?
-    #[fail(display = "trailing whitespace")]
     TrailingWhitespace,
 }
 
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let description = match self {
+            Error::ChecksumInvalid => "checksum mismatch",
+            Error::EncodingInvalid => "bad encoding",
+            Error::IoError => "I/O error",
+            Error::LengthInvalid => "invalid length",
+            Error::PaddingInvalid => "padding invalid",
+            Error::TrailingWhitespace => "trailing whitespace",
+        };
+
+        write!(f, "{}", description)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
+
 /// Assert that the provided condition is true, or else return the given error
 macro_rules! ensure {
-    ($condition:expr, $err:ident) => {
+    ($condition:expr, $err:path) => {
         if !($condition) {
             Err($err)?;
         }

--- a/subtle-encoding/src/hex.rs
+++ b/subtle-encoding/src/hex.rs
@@ -44,7 +44,7 @@ use super::{
     Error::{self, *},
 };
 #[cfg(feature = "alloc")]
-use crate::prelude::*;
+use alloc::vec::Vec;
 
 /// Encode the given data as lower-case hexadecimal, returning a `Vec<u8>`
 #[cfg(feature = "alloc")]

--- a/subtle-encoding/src/identity.rs
+++ b/subtle-encoding/src/identity.rs
@@ -34,6 +34,8 @@ impl Encoding for Identity {
     }
 }
 
+// TODO(tarcieri): `no_std` tests
+#[cfg(feature = "alloc")]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/subtle-encoding/src/lib.rs
+++ b/subtle-encoding/src/lib.rs
@@ -17,18 +17,13 @@
 #![forbid(unsafe_code)]
 #![doc(html_root_url = "https://docs.rs/subtle-encoding/0.3.7")]
 
-#[cfg(all(feature = "alloc", not(feature = "std")))]
-#[allow(unused_imports)] // rustc bug?
+#[cfg(feature = "alloc")]
 #[macro_use]
 extern crate alloc;
 
 #[cfg(any(feature = "std", test))]
-#[macro_use]
 extern crate std;
 
-extern crate failure;
-#[macro_use]
-extern crate failure_derive;
 #[cfg(feature = "zeroize")]
 extern crate zeroize;
 
@@ -43,7 +38,6 @@ pub mod encoding;
 #[cfg(feature = "hex")]
 pub mod hex;
 pub mod identity;
-mod prelude;
 
 #[cfg(feature = "base64")]
 pub use crate::base64::Base64;

--- a/subtle-encoding/src/prelude.rs
+++ b/subtle-encoding/src/prelude.rs
@@ -1,7 +1,0 @@
-//! Use `std` or `alloc` prelude depending on selected cargo features
-
-#[cfg(all(feature = "alloc", not(feature = "std")))]
-pub use alloc::{string::String, vec::Vec};
-
-#[cfg(feature = "std")]
-pub use std::prelude::v1::*;

--- a/tai64/Cargo.toml
+++ b/tai64/Cargo.toml
@@ -17,7 +17,6 @@ travis-ci = { repository = "iqlusioninc/crates", branch = "develop" }
 
 [dependencies]
 chrono = { version = "0.4", optional = true, default-features = false }
-failure = { version = "0.1", default-features = false, features = ["failure_derive"] }
 
 [features]
 default = ["std"]

--- a/tai64/src/lib.rs
+++ b/tai64/src/lib.rs
@@ -7,8 +7,7 @@
 
 #[cfg(feature = "chrono")]
 use chrono::{DateTime, NaiveDateTime, Utc};
-use core::{convert::TryFrom, ops, time::Duration};
-use failure::Fail;
+use core::{convert::TryFrom, fmt, ops, time::Duration};
 
 #[cfg(feature = "std")]
 extern crate std;
@@ -284,16 +283,28 @@ impl ops::Sub<Duration> for TAI64N {
 }
 
 /// TAI64 errors
-#[derive(Copy, Clone, Debug, Eq, Fail, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Error {
     /// Invalid length
-    #[fail(display = "length invalid")]
     LengthInvalid,
 
     /// Nanosecond part must be <= 999999999.
-    #[fail(display = "invalid number of nanoseconds")]
     NanosInvalid,
 }
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let description = match self {
+            Error::LengthInvalid => "length invalid",
+            Error::NanosInvalid => "invalid number of nanoseconds",
+        };
+
+        write!(f, "{}", description)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
 
 #[cfg(all(test, feature = "std"))]
 mod tests {


### PR DESCRIPTION
These crates weren't getting much value out of `failure`, and the use of proc macros to generate what is effectively a match statement on enum variants which returns a string literal adds a lot to compile times.

Furthermore, `failure` is still using the non-1.0 proc macro crates. It seems there's upstream work to get this fixed[1], but since we're not really getting value out of the proc macros as-is, there's not much reason to bother.

[1]: https://github.com/rust-lang-nursery/failure/pull/319