### PR TITLE
Remove `std` feature in favor of `alloc`; MSRV 1.36+

### DIFF
--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -24,6 +24,5 @@ travis-ci = { repository = "iqlusioninc/crates", branch = "develop" }
 zeroize_derive = { version = "0.9", path = "../zeroize_derive", optional = true }
 
 [features]
-default = ["std", "zeroize_derive"]
+default = ["alloc", "zeroize_derive"]
 alloc = []
-std = ["alloc"]

--- a/zeroize/README.md
+++ b/zeroize/README.md
@@ -3,15 +3,14 @@
 [![Crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
 ![Apache 2.0/MIT Licensed][license-image]
-![Rust 1.35+][rustc-image]
+![MSRV][rustc-image]
 [![Build Status][build-image]][build-link]
 [![Gitter Chat][gitter-image]][gitter-link]
 
 Securely zero memory while avoiding compiler optimizations.
 
-This crate provides a safe<sup>†</sup>, portable access to cross-platform
-intrinsics for securely zeroing memory which are specifically documented as
-guaranteeing they won't be "optimized away".
+This crate implements a portable approach to securely zeroing memory using
+techniques which guarantee they won't be "optimized away" by the compiler.
 
 The [`Zeroize` trait] is the crate's primary API.
 
@@ -37,7 +36,7 @@ thereof, implemented in pure Rust with no usage of FFI or assembly.
 
 ## Requirements
 
-- Rust 1.35+
+- Rust **1.36+**
 
 ## License
 
@@ -60,7 +59,7 @@ without any additional terms or conditions.
 [docs-image]: https://docs.rs/zeroize/badge.svg
 [docs-link]: https://docs.rs/zeroize/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.35+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.36+-blue.svg
 [build-image]: https://travis-ci.com/iqlusioninc/crates.svg?branch=develop
 [build-link]: https://travis-ci.com/iqlusioninc/crates/
 [gitter-image]: https://badges.gitter.im/iqlusioninc/community.svg

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -193,14 +193,9 @@
 #![deny(warnings, missing_docs, trivial_casts, unused_qualifications)]
 #![doc(html_root_url = "https://docs.rs/zeroize/0.9.3")]
 
-#[cfg(all(feature = "alloc", not(feature = "std")))]
-#[allow(unused_imports)] // rustc bug?
-#[macro_use]
-extern crate alloc;
-
-#[cfg(any(feature = "std", test))]
+#[cfg(feature = "alloc")]
 #[cfg_attr(test, macro_use)]
-extern crate std;
+extern crate alloc;
 
 #[cfg(feature = "zeroize_derive")]
 #[allow(unused_imports)]
@@ -213,10 +208,8 @@ pub use zeroize_derive::*;
 
 use core::{ops, ptr, slice::IterMut, sync::atomic};
 
-#[cfg(all(feature = "alloc", not(feature = "std")))]
+#[cfg(feature = "alloc")]
 use alloc::{string::String, vec::Vec};
-#[cfg(feature = "std")]
-use std::{string::String, vec::Vec};
 
 /// Trait for securely erasing types from memory
 pub trait Zeroize {
@@ -414,10 +407,8 @@ fn volatile_set<T: Copy + Sized>(dst: &mut [T], src: T) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(all(feature = "alloc", not(feature = "std")))]
+    #[cfg(feature = "alloc")]
     use alloc::boxed::Box;
-    #[cfg(feature = "std")]
-    use std::boxed::Box;
 
     #[test]
     fn zeroize_byte_arrays() {

--- a/zeroize_derive/README.md
+++ b/zeroize_derive/README.md
@@ -2,7 +2,7 @@
 
 [![Crate][crate-image]][crate-link]
 ![Apache 2.0 Licensed/MIT][license-image]
-![Rust 1.35+][rustc-image]
+![MSRV][rustc-image]
 [![Build Status][build-image]][build-link]
 
 Custom derive support for [zeroize]: a crate for securely zeroing memory
@@ -13,7 +13,7 @@ See [zeroize] crate for documentation.
 
 ## Requirements
 
-- Rust 1.35+
+- Rust **1.36+**
 
 ## License
 
@@ -34,7 +34,7 @@ without any additional terms or conditions.
 [crate-image]: https://img.shields.io/crates/v/zeroize_derive.svg
 [crate-link]: https://crates.io/crates/zeroize_derive
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.35+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.36+-blue.svg
 [build-image]: https://travis-ci.com/iqlusioninc/crates.svg?branch=develop
 [build-link]: https://travis-ci.com/iqlusioninc/crates/
 


### PR DESCRIPTION
Previously the `std` feature gated `Zeroize` impls on `Box`, `String`, and `Vec`.

Now that the `alloc` crate is stable, if we go MSRV 1.36+, we can always source these types from there, and thereby eliminate the `std` feature.