### PR TITLE
zeroize: Disable `zeroize_derive` feature by default

### DIFF
--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -24,5 +24,8 @@ travis-ci = { repository = "iqlusioninc/crates", branch = "develop" }
 zeroize_derive = { version = "0.9", path = "../zeroize_derive", optional = true }
 
 [features]
-default = ["alloc", "zeroize_derive"]
+default = ["alloc"]
 alloc = []
+
+[package.metadata.docs.rs]
+all-features = true

--- a/zeroize/README.md
+++ b/zeroize/README.md
@@ -28,11 +28,12 @@ and [core::sync::atomic] memory fences to provide easy-to-use, portable
 zeroing behavior which works on all of Rust's core number types and slices
 thereof, implemented in pure Rust with no usage of FFI or assembly.
 
-- **No insecure fallbacks!**
-- **No dependencies!**
-- **No FFI or inline assembly!**
-- `#![no_std]` **i.e. embedded-friendly**!
-- **No functionality besides securely zeroing memory!**
+- No insecure fallbacks!
+- No dependencies!
+- No FFI or inline assembly! **WASM friendly** (and tested)!
+- `#![no_std]` i.e. **embedded-friendly**!
+- No functionality besides securely zeroing memory!
+- (Optional) Custom derive support for zeroing complex structures
 
 ## Requirements
 

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -18,6 +18,7 @@
 //! - No FFI or inline assembly! **WASM friendly** (and tested)!
 //! - `#![no_std]` i.e. **embedded-friendly**!
 //! - No functionality besides securely zeroing memory!
+//! - (Optional) Custom derive support for zeroing complex structures
 //!
 //! ## Usage
 //!
@@ -52,8 +53,10 @@
 //!
 //! ## Custom Derive Support
 //!
-//! This crate has custom derive support for the `Zeroize` trait, which
-//! automatically calls `zeroize()` on all members of a struct or tuple struct.
+//! This crate has custom derive support for the `Zeroize` trait,
+//! gated under the `zeroize` crate's `zeroize_derive` Cargo feature,
+//! which automatically calls `zeroize()` on all members of a struct
+//! or tuple struct.
 //!
 //! Additionally it supports the following attribute:
 //!


### PR DESCRIPTION
Proc macros are a somewhat onerous dependency due to the amount of time it takes to compile crates like `syn`, and many will prefer explicit implementations to ones derived via proc macros.

This commit removes `zeroize_derive` from the default feature list.