### PR TITLE
zeroize v0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,7 @@ dependencies = [
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle-encoding 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-bip39 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 0.9.3",
+ "zeroize 0.10.0",
 ]
 
 [[package]]
@@ -554,7 +554,7 @@ name = "secrecy"
 version = "0.2.2"
 dependencies = [
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 0.9.3",
+ "zeroize 0.10.0",
 ]
 
 [[package]]
@@ -605,7 +605,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "subtle-encoding"
 version = "0.3.7"
 dependencies = [
- "zeroize 0.9.3",
+ "zeroize 0.10.0",
 ]
 
 [[package]]
@@ -745,18 +745,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "zeroize"
 version = "0.9.3"
-dependencies = [
- "zeroize_derive 0.9.3",
-]
-
-[[package]]
-name = "zeroize"
-version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "zeroize"
+version = "0.10.0"
+dependencies = [
+ "zeroize_derive 0.10.0",
+]
+
+[[package]]
 name = "zeroize_derive"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/hkd32/Cargo.toml
+++ b/hkd32/Cargo.toml
@@ -28,7 +28,7 @@ subtle-encoding = { version = "0.3", optional = true }
 tiny-bip39 = { version = "0.6", default-features = false, optional = true }
 
 [dependencies.zeroize]
-version = "0.9"
+version = "0.10"
 path = "../zeroize"
 default-features = false
 features = ["zeroize_derive"]

--- a/secrecy/Cargo.toml
+++ b/secrecy/Cargo.toml
@@ -21,4 +21,4 @@ travis-ci = { repository = "iqlusioninc/crates", branch = "develop" }
 
 [dependencies]
 serde = { version = "1", optional = true }
-zeroize = { version = "0.9", path = "../zeroize", default-features = false }
+zeroize = { version = "0.10", path = "../zeroize", default-features = false }

--- a/subtle-encoding/Cargo.toml
+++ b/subtle-encoding/Cargo.toml
@@ -16,8 +16,11 @@ readme      = "README.md"
 categories  = ["cryptography", "encoding", "no-std"]
 keywords    = ["base64", "bech32", "constant-time", "hex", "security"]
 
-[dependencies]
-zeroize = { version = "0.9", default-features = false, optional = true, path = "../zeroize" }
+[dependencies.zeroize]
+version = "0.10"
+optional = true
+default-features = false
+path = "../zeroize"
 
 [features]
 default = ["base64", "hex", "std"]

--- a/zeroize/CHANGES.md
+++ b/zeroize/CHANGES.md
@@ -1,6 +1,16 @@
+## [0.10.0] (2019-08-19)
+
+Barring unforeseen circumstances, this release aims to be the last `0.x`
+release prior to a `zeroize` 1.0 release.
+
+- Disable `zeroize_derive` Cargo feature by default ([#247])
+- Remove `std` feature in favor of `alloc`; MSRV 1.36+ ([#246])
+- Deprecate `#[zeroize(no_drop)]` attribute ([#244])
+- Use 1.0 `proc-macro2`, `quote`, and `syn` crates ([#242])
+
 ## [0.9.3] (2019-07-27)
 
-- zeroize: Improved attribute parser; fixes nightly build ([#238])
+- Improved attribute parser; fixes nightly build ([#238])
 
 ## [0.9.2] (2019-06-28)
 
@@ -90,6 +100,11 @@ a pure Rust solution.
 
 - Initial release
 
+[0.10.0]: https://github.com/iqlusioninc/crates/pull/248
+[#247]: https://github.com/iqlusioninc/crates/pull/247
+[#246]: https://github.com/iqlusioninc/crates/pull/246
+[#244]: https://github.com/iqlusioninc/crates/pull/244
+[#242]: https://github.com/iqlusioninc/crates/pull/242
 [0.9.3]: https://github.com/iqlusioninc/crates/pull/239
 [#238]: https://github.com/iqlusioninc/crates/pull/238
 [0.9.2]: https://github.com/iqlusioninc/crates/pull/224

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -7,7 +7,7 @@ description = """
               Uses a portable pure Rust implementation that works everywhere,
               even WASM!
               """
-version     = "0.9.3" # Also update html_root_url in lib.rs when bumping this
+version     = "0.10.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0 OR MIT"
 edition     = "2018"
@@ -21,7 +21,7 @@ keywords    = ["memory", "memset", "secure", "volatile", "zero"]
 travis-ci = { repository = "iqlusioninc/crates", branch = "develop" }
 
 [dependencies]
-zeroize_derive = { version = "0.9", path = "../zeroize_derive", optional = true }
+zeroize_derive = { version = "0.10", path = "../zeroize_derive", optional = true }
 
 [features]
 default = ["alloc"]

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -194,7 +194,7 @@
 
 #![no_std]
 #![deny(warnings, missing_docs, trivial_casts, unused_qualifications)]
-#![doc(html_root_url = "https://docs.rs/zeroize/0.9.3")]
+#![doc(html_root_url = "https://docs.rs/zeroize/0.10.0")]
 
 #[cfg(feature = "alloc")]
 #[cfg_attr(test, macro_use)]

--- a/zeroize_derive/Cargo.toml
+++ b/zeroize_derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "zeroize_derive"
 description = "Custom derive support for zeroize"
-version     = "0.9.3"
+version     = "0.10.0"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0 OR MIT"
 edition     = "2018"


### PR DESCRIPTION
- Disable `zeroize_derive` Cargo feature by default (#247)
- Remove `std` feature in favor of `alloc`; MSRV 1.36+ (#246)
- Deprecate `#[zeroize(no_drop)]` attribute (#244)
- Use 1.0 `proc-macro2`, `quote`, and `syn` crates (#242)