### PR TITLE
subtle-encoding v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,7 +208,7 @@ dependencies = [
  "getrandom 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "subtle-encoding 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle-encoding 0.4.0",
  "tiny-bip39 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 0.10.0",
 ]
@@ -603,19 +603,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "subtle-encoding"
-version = "0.3.7"
+version = "0.4.0"
 dependencies = [
  "zeroize 0.10.0",
-]
-
-[[package]]
-name = "subtle-encoding"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -744,11 +734,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "zeroize"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "zeroize"
 version = "0.10.0"
 dependencies = [
  "zeroize_derive 0.10.0",
@@ -837,7 +822,6 @@ dependencies = [
 "checksum slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1cc9c640a4adbfbcc11ffb95efe5aa7af7309e002adab54b185507dbf2377b99"
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
-"checksum subtle-encoding 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "661a0cd6c74eca6fab1a5b452d9f2201fbac9004e958bd70d5b4f288b1aed479"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "158521e6f544e7e3dcfc370ac180794aa38cb34a1b1e07609376d4adcf429b93"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
@@ -852,4 +836,3 @@ dependencies = [
 "checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-"checksum zeroize 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "45af6a010d13e4cf5b54c94ba5a2b2eba5596b9e46bf5875612d332a1f2b3f86"

--- a/hkd32/Cargo.toml
+++ b/hkd32/Cargo.toml
@@ -24,14 +24,18 @@ travis-ci = { repository = "iqlusioninc/crates", branch = "develop" }
 getrandom = { version = "0.1", optional = true }
 hmac = { version = "0.7", default-features = false }
 sha2 = { version = "0.8", default-features = false }
-subtle-encoding = { version = "0.3", optional = true }
 tiny-bip39 = { version = "0.6", default-features = false, optional = true }
+
+[dependencies.subtle-encoding]
+version = "0.4"
+optional = true
+path = "../subtle-encoding"
 
 [dependencies.zeroize]
 version = "0.10"
-path = "../zeroize"
 default-features = false
 features = ["zeroize_derive"]
+path = "../zeroize"
 
 [features]
 default = ["alloc", "bech32", "getrandom"]

--- a/subtle-encoding/CHANGES.md
+++ b/subtle-encoding/CHANGES.md
@@ -1,3 +1,8 @@
+## [0.4.0] (2019-08-19)
+
+- Remove `failure` ([#245])
+- Use `alloc` for heap allocations; MSRV 1.36+ ([#245])
+
 ## [0.3.7] (2019-05-19)
 
 - `zeroize` v0.9.0 ([#215])
@@ -56,6 +61,8 @@
 
 - Initial release
 
+[0.4.0]: https://github.com/iqlusioninc/crates/pull/249
+[#215]: https://github.com/iqlusioninc/crates/pull/245
 [0.3.7]: https://github.com/iqlusioninc/crates/pull/218
 [#215]: https://github.com/iqlusioninc/crates/pull/215
 [0.3.5]: https://github.com/iqlusioninc/crates/pull/187

--- a/subtle-encoding/Cargo.toml
+++ b/subtle-encoding/Cargo.toml
@@ -6,7 +6,7 @@ description = """
               provide "best effort" constant time. Useful for encoding/decoding
               secret values such as cryptographic keys.
               """
-version     = "0.3.7" # Also update html_root_url in lib.rs when bumping this
+version     = "0.4.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0 OR MIT"
 edition     = "2018"

--- a/subtle-encoding/src/lib.rs
+++ b/subtle-encoding/src/lib.rs
@@ -15,7 +15,7 @@
 #![no_std]
 #![deny(warnings, missing_docs, unused_import_braces, unused_qualifications)]
 #![forbid(unsafe_code)]
-#![doc(html_root_url = "https://docs.rs/subtle-encoding/0.3.7")]
+#![doc(html_root_url = "https://docs.rs/subtle-encoding/0.4.0")]
 
 #[cfg(feature = "alloc")]
 #[macro_use]

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -19,6 +19,7 @@ keywords    = ["memory", "memset", "secure", "volatile", "zero"]
 
 [badges]
 travis-ci = { repository = "iqlusioninc/crates", branch = "develop" }
+maintenance = { status = "actively-developed" }
 
 [dependencies]
 zeroize_derive = { version = "0.10", path = "../zeroize_derive", optional = true }

--- a/zeroize/README.md
+++ b/zeroize/README.md
@@ -74,6 +74,6 @@ without any additional terms or conditions.
 [Zeroing memory securely is hard]: http://www.daemonology.net/blog/2014-09-04-how-to-zero-a-buffer.html
 [core::ptr::write_volatile]: https://doc.rust-lang.org/core/ptr/fn.write_volatile.html
 [core::sync::atomic]: https://doc.rust-lang.org/stable/core/sync/atomic/index.html
-[good cryptographic hygiene]: https://cryptocoding.net/index.php/Coding_rules#Clean_memory_of_secret_data
+[good cryptographic hygiene]: https://github.com/veorq/cryptocoding#clean-memory-of-secret-data
 [LICENSE]: https://github.com/iqlusioninc/crates/blob/develop/LICENSE
 [LICENSE-MIT]: https://github.com/iqlusioninc/crates/blob/develop/zeroize/LICENSE-MIT

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -41,8 +41,8 @@
 //!
 //! Additionally, it's implemented on slices and `IterMut`s of the above types.
 //!
-//! When the `std` feature is enabled (which it is by default), it's also impl'd
-//! for `Vec`s of the above types as well as `String`, where it provides
+//! When the `alloc` feature is enabled (which it is by default), it's also
+//! impl'd for `Vec<T>` for the above types as well as `String`, where it provides
 //! [Vec::clear()] / [String::clear()]-like behavior (truncating to zero-length)
 //! but ensures the backing memory is securely zeroed with some caveats.
 //! (NOTE: see "Stack/Heap Zeroing Notes" for important `Vec`/`String` details)
@@ -190,7 +190,7 @@
 //! [Ordering::SeqCst]: https://doc.rust-lang.org/std/sync/atomic/enum.Ordering.html#variant.SeqCst
 //! [compiler_fence]: https://doc.rust-lang.org/stable/core/sync/atomic/fn.compiler_fence.html
 //! [pin]: https://doc.rust-lang.org/std/pin/struct.Pin.html
-//! [good cryptographic hygiene]: https://cryptocoding.net/index.php/Coding_rules#Clean_memory_of_secret_data
+//! [good cryptographic hygiene]: https://github.com/veorq/cryptocoding#clean-memory-of-secret-data
 
 #![no_std]
 #![deny(warnings, missing_docs, trivial_casts, unused_qualifications)]


### PR DESCRIPTION
- Remove `failure` (#245)
- Use `alloc` for heap allocations; MSRV 1.36+ (#245)