### PR TITLE
hkd32 v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "hkd32"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "getrandom 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/hkd32/CHANGES.md
+++ b/hkd32/CHANGES.md
@@ -1,3 +1,9 @@
+## [0.2.0] (2019-08-20)
+
+- Vendor (simplified) BIP39 implementation from `tiny-bip39` ([#251])
+- `subtle-encoding` v0.4.0 ([#249])
+- `zeroize` v0.10.0 ([#248])
+
 ## [0.1.2] (2019-07-23)
 
 - Fix docs typo ([#235])
@@ -10,6 +16,10 @@
 
 - Initial release
 
+[0.2.0]: https://github.com/iqlusioninc/crates/pull/252
+[#249]: https://github.com/iqlusioninc/crates/pull/251
+[#249]: https://github.com/iqlusioninc/crates/pull/249
+[#248]: https://github.com/iqlusioninc/crates/pull/248
 [0.1.2]: https://github.com/iqlusioninc/crates/pull/236
 [#235]: https://github.com/iqlusioninc/crates/pull/235
 [0.1.1]: https://github.com/iqlusioninc/crates/pull/233

--- a/hkd32/Cargo.toml
+++ b/hkd32/Cargo.toml
@@ -4,9 +4,10 @@ description = """
               HMAC-based Hierarchical Key Derivation: deterministically derive
               a hierarchy of symmetric keys from initial keying material through
               repeated applications of the Hash-based Message Authentication Code
-              (HMAC) construction.
+              (HMAC) construction. Optionally supports storing root derivation
+              passwords as a 24-word mnemonic phrase (i.e. BIP39).
               """
-version     = "0.1.2" # Also update html_root_url in lib.rs when bumping this
+version     = "0.2.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0"
 edition     = "2018"

--- a/hkd32/src/lib.rs
+++ b/hkd32/src/lib.rs
@@ -38,7 +38,7 @@
 
 #![no_std]
 #![deny(warnings, missing_docs, unused_qualifications, unsafe_code)]
-#![doc(html_root_url = "https://docs.rs/hkd32/0.1.2")]
+#![doc(html_root_url = "https://docs.rs/hkd32/0.2.0")]
 
 #[cfg(feature = "alloc")]
 #[cfg_attr(any(feature = "mnemonic", test), macro_use)]


### PR DESCRIPTION
- Vendor (simplified) BIP39 implementation from `tiny-bip39` (#251)
- `subtle-encoding` v0.4.0 (#249)
- `zeroize` v0.10.0 (#248)