### PR TITLE
secrecy: Add support for alloc types

### DIFF
--- a/hkd32/CHANGES.md
+++ b/hkd32/CHANGES.md
@@ -17,7 +17,7 @@
 - Initial release
 
 [0.2.0]: https://github.com/iqlusioninc/crates/pull/252
-[#249]: https://github.com/iqlusioninc/crates/pull/251
+[#251]: https://github.com/iqlusioninc/crates/pull/251
 [#249]: https://github.com/iqlusioninc/crates/pull/249
 [#248]: https://github.com/iqlusioninc/crates/pull/248
 [0.1.2]: https://github.com/iqlusioninc/crates/pull/236

--- a/secrecy/Cargo.toml
+++ b/secrecy/Cargo.toml
@@ -17,8 +17,13 @@ categories  = ["cryptography", "memory-management", "no-std", "os"]
 keywords    = ["clear", "memory", "secret", "secure", "wipe"]
 
 [badges]
+maintenance = { status = "passively-maintained" }
 travis-ci = { repository = "iqlusioninc/crates", branch = "develop" }
 
 [dependencies]
 serde = { version = "1", optional = true }
 zeroize = { version = "0.10", path = "../zeroize", default-features = false }
+
+[features]
+default = ["alloc"]
+alloc = []

--- a/secrecy/README.md
+++ b/secrecy/README.md
@@ -3,7 +3,7 @@
 [![Crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
 ![Apache 2.0/MIT Licensed][license-image]
-![Rust 1.35+][rustc-image]
+![MSRV][rustc-image]
 [![Safety Dance][safety-image]][safety-link]
 [![Build Status][build-image]][build-link]
 [![Gitter Chat][gitter-image]][gitter-link]
@@ -25,7 +25,7 @@ from memory when dropped.
 
 ## Requirements
 
-- Rust 1.35+
+- Rust **1.36+**
 
 ## serde support
 
@@ -69,7 +69,7 @@ without any additional terms or conditions.
 [docs-image]: https://docs.rs/secrecy/badge.svg
 [docs-link]: https://docs.rs/secrecy/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.35+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.36+-blue.svg
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
 [build-image]: https://travis-ci.com/iqlusioninc/crates.svg?branch=develop

--- a/secrecy/src/boxed.rs
+++ b/secrecy/src/boxed.rs
@@ -1,0 +1,12 @@
+//! `Box` types containing secrets
+
+use super::{DebugSecret, Secret};
+use alloc::boxed::Box;
+use zeroize::Zeroize;
+
+/// `Box` types containing a secret value
+#[cfg(feature = "alloc")]
+pub type SecretBox<S> = Secret<Box<S>>;
+
+#[cfg(feature = "alloc")]
+impl<S: DebugSecret + Zeroize> DebugSecret for Box<S> {}

--- a/secrecy/src/lib.rs
+++ b/secrecy/src/lib.rs
@@ -6,6 +6,19 @@
 #![forbid(unsafe_code)]
 #![doc(html_root_url = "https://docs.rs/secrecy/0.2.2")]
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+#[cfg(feature = "alloc")]
+mod boxed;
+#[cfg(feature = "alloc")]
+mod string;
+#[cfg(feature = "alloc")]
+mod vec;
+
+#[cfg(feature = "alloc")]
+pub use self::{boxed::SecretBox, string::SecretString, vec::SecretVec};
+
 use core::fmt::{self, Debug};
 #[cfg(feature = "serde")]
 use serde::de::{Deserialize, DeserializeOwned, Deserializer};

--- a/secrecy/src/string.rs
+++ b/secrecy/src/string.rs
@@ -1,0 +1,9 @@
+//! Secret strings
+
+use super::{DebugSecret, Secret};
+use alloc::string::String;
+
+/// Secret strings
+pub type SecretString = Secret<String>;
+
+impl DebugSecret for String {}

--- a/secrecy/src/vec.rs
+++ b/secrecy/src/vec.rs
@@ -1,0 +1,12 @@
+//! Secret `Vec` types
+
+use super::{DebugSecret, Secret};
+use alloc::vec::Vec;
+use zeroize::Zeroize;
+
+/// `Vec` types containing secret value
+#[cfg(feature = "alloc")]
+pub type SecretVec<S> = Secret<Vec<S>>;
+
+#[cfg(feature = "alloc")]
+impl<S: DebugSecret + Zeroize> DebugSecret for Vec<S> {}


### PR DESCRIPTION
Adds impls and type aliases for `Secret` wrappers for `Box`, `String`, and `Vec`.