### PR TITLE
secrecy v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "secrecy"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 0.10.0",

--- a/secrecy/CHANGES.md
+++ b/secrecy/CHANGES.md
@@ -1,3 +1,9 @@
+## [0.3.0] (2019-08-20)
+
+- Add support for `alloc` types ([#253])
+- `zeroize` v0.10.0 ([#248])
+- Add a default impl for `DebugSecret` trait ([#241])
+
 ## [0.2.2] (2019-06-28)
 
 - README.md: add Gitter badges; update image links ([#221])
@@ -14,6 +20,10 @@
 
 - Initial release
 
+[0.3.0]: https://github.com/iqlusioninc/crates/pull/254
+[#253]: https://github.com/iqlusioninc/crates/pull/253
+[#248]: https://github.com/iqlusioninc/crates/pull/248
+[#241]: https://github.com/iqlusioninc/crates/pull/241
 [0.2.2]: https://github.com/iqlusioninc/crates/pull/223
 [#221]: https://github.com/iqlusioninc/crates/pull/221
 [0.2.1]: https://github.com/iqlusioninc/crates/pull/216

--- a/secrecy/Cargo.toml
+++ b/secrecy/Cargo.toml
@@ -6,7 +6,7 @@ description = """
               (as much as possible), and also ensure secrets are securely wiped
               from memory when dropped.
               """
-version     = "0.2.2" # Also update html_root_url in lib.rs when bumping this
+version     = "0.3.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0 OR MIT"
 edition     = "2018"

--- a/secrecy/src/lib.rs
+++ b/secrecy/src/lib.rs
@@ -4,7 +4,7 @@
 #![no_std]
 #![deny(warnings, missing_docs, trivial_casts, unused_qualifications)]
 #![forbid(unsafe_code)]
-#![doc(html_root_url = "https://docs.rs/secrecy/0.2.2")]
+#![doc(html_root_url = "https://docs.rs/secrecy/0.3.0")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;


### PR DESCRIPTION
- Add support for `alloc` types (#253)
- `zeroize` v0.10.0 (#248)
- Add a default impl for `DebugSecret` trait (#241)