### PR TITLE
Improve lints and deny policy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ rust:
 
 os: linux
 
+env:
+  - RUSTFLAGS="-D warnings"
+
 matrix:
   fast_finish: true
   allow_failures:
@@ -26,30 +29,34 @@ matrix:
     - name: "Rust: 1.36"
       os: windows
       rust: 1.36.0
+    - name: audit
+      rust: stable
+      install:
+        - command -v cargo-audit >/dev/null 2>&1 || cargo install cargo-audit
+      script:
+        - cargo audit
+    - name: rustfmt
+      rust: stable
+      install:
+        - rustup component add rustfmt
+      script:
+        - cargo fmt --version
+        - cargo fmt --all -- --check
+    - name: clippy
+      rust: stable
+      install:
+        - rustup component add clippy
+      script:
+        - cargo clippy --version
+        - cargo clippy --all
     - name: "Rust: stable (wasm32)"
+      install:
+        - rustup target add wasm32-unknown-unknown
       rust: stable
       script:
-      - cargo build --package secrecy --target wasm32-unknown-unknown
-      - cargo build --package subtle-encoding --target wasm32-unknown-unknown
-      - cargo build --package tai64 --target wasm32-unknown-unknown
-      - cargo build --package zeroize --target wasm32-unknown-unknown
-
-install:
-  - rustup component add rustfmt
-  - rustup component add clippy
-  - rustup target add wasm32-unknown-unknown
-  - command -v cargo-audit >/dev/null 2>&1 || cargo install cargo-audit
+      - cargo build --all --exclude canonical-path,gaunt --target wasm32-unknown-unknown
 
 script:
-  # audit
-  - cargo audit
-
-  # lint
-  - cargo fmt --version
-  - cargo fmt --all -- --check
-  - cargo clippy --version
-  - cargo clippy --all
-
   # test without default features
   - cargo test --all --no-default-features --release
 

--- a/canonical-path/src/lib.rs
+++ b/canonical-path/src/lib.rs
@@ -5,10 +5,9 @@
 //! are canonical, or at least, were canonical at the time they were created.
 
 #![deny(
-    warnings,
     missing_docs,
-    trivial_numeric_casts,
-    unused_import_braces,
+    rust_2018_idioms,
+    unused_lifetimes,
     unused_qualifications
 )]
 #![doc(html_root_url = "https://docs.rs/canonical-path/2.0.2")]
@@ -95,21 +94,21 @@ macro_rules! impl_path {
 
         /// Produces an iterator over the `Component`s of a path
         #[inline]
-        pub fn components(&self) -> Components {
+        pub fn components(&self) -> Components<'_> {
             self.0.components()
         }
 
         /// Produces an iterator over the path's components viewed as
         /// `OsStr` slices.
          #[inline]
-        pub fn iter(&self) -> Iter {
+        pub fn iter(&self) -> Iter<'_> {
             self.0.iter()
         }
 
         /// Returns an object that implements `Display` for safely printing
         /// paths that may contain non-Unicode data.
         #[inline]
-        pub fn display(&self) -> Display {
+        pub fn display(&self) -> Display<'_> {
             self.0.display()
         }
 

--- a/gaunt/src/error.rs
+++ b/gaunt/src/error.rs
@@ -46,7 +46,7 @@ impl Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.kind.fmt(f)
     }
 }
@@ -84,7 +84,7 @@ pub enum ErrorKind {
 }
 
 impl fmt::Display for ErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let description = match self {
             ErrorKind::AddrInvalid => "address invalid",
             ErrorKind::IoError => "I/O error",

--- a/gaunt/src/lib.rs
+++ b/gaunt/src/lib.rs
@@ -1,7 +1,13 @@
 //! **gaunt.rs**: high-level, self-contained, minimalist HTTP toolkit.
 
 #![no_std]
-#![deny(warnings, missing_docs, unused_import_braces, unused_qualifications)]
+#![deny(
+    missing_docs,
+    rust_2018_idioms,
+    trivial_casts,
+    unused_lifetimes,
+    unused_qualifications
+)]
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://storage.googleapis.com/iqlusion-production-web/github/gaunt/gaunt-logo.svg",

--- a/gaunt/src/path.rs
+++ b/gaunt/src/path.rs
@@ -35,7 +35,7 @@ impl AsRef<str> for PathBuf {
 
 #[cfg(feature = "alloc")]
 impl Display for PathBuf {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }
 }

--- a/hkd32/src/lib.rs
+++ b/hkd32/src/lib.rs
@@ -37,7 +37,12 @@
 //! [bip32]: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
 
 #![no_std]
-#![deny(warnings, missing_docs, unused_qualifications, unsafe_code)]
+#![deny(
+    missing_docs,
+    rust_2018_idioms,
+    unused_lifetimes,
+    unused_qualifications
+)]
 #![doc(html_root_url = "https://docs.rs/hkd32/0.2.0")]
 
 #[cfg(feature = "alloc")]

--- a/hkd32/src/path.rs
+++ b/hkd32/src/path.rs
@@ -63,7 +63,7 @@ impl Path {
     }
 
     /// Obtain a component iterator for this path.
-    pub fn components(&self) -> Components {
+    pub fn components(&self) -> Components<'_> {
         Components::new(&self.0)
     }
 

--- a/secrecy/src/lib.rs
+++ b/secrecy/src/lib.rs
@@ -2,7 +2,13 @@
 //! (e.g. passwords, cryptographic keys, access tokens or other credentials)
 
 #![no_std]
-#![deny(warnings, missing_docs, trivial_casts, unused_qualifications)]
+#![deny(
+    missing_docs,
+    rust_2018_idioms,
+    trivial_casts,
+    unused_lifetimes,
+    unused_qualifications
+)]
 #![forbid(unsafe_code)]
 #![doc(html_root_url = "https://docs.rs/secrecy/0.3.0")]
 

--- a/subtle-encoding/src/error.rs
+++ b/subtle-encoding/src/error.rs
@@ -30,7 +30,7 @@ pub enum Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let description = match self {
             Error::ChecksumInvalid => "checksum mismatch",
             Error::EncodingInvalid => "bad encoding",

--- a/subtle-encoding/src/lib.rs
+++ b/subtle-encoding/src/lib.rs
@@ -13,7 +13,13 @@
 //! [bech32]: https://docs.rs/subtle-encoding/0.2.3/subtle_encoding/bech32/index.html
 
 #![no_std]
-#![deny(warnings, missing_docs, unused_import_braces, unused_qualifications)]
+#![deny(
+    missing_docs,
+    rust_2018_idioms,
+    trivial_casts,
+    unused_lifetimes,
+    unused_qualifications
+)]
 #![forbid(unsafe_code)]
 #![doc(html_root_url = "https://docs.rs/subtle-encoding/0.4.0")]
 
@@ -23,9 +29,6 @@ extern crate alloc;
 
 #[cfg(any(feature = "std", test))]
 extern crate std;
-
-#[cfg(feature = "zeroize")]
-extern crate zeroize;
 
 #[macro_use]
 mod error;

--- a/tai64/src/lib.rs
+++ b/tai64/src/lib.rs
@@ -1,7 +1,13 @@
 //! TAI64(N) timestamp generation, parsing and calculation.
 
 #![no_std]
-#![deny(warnings, missing_docs, rust_2018_idioms, unused_qualifications)]
+#![deny(
+    missing_docs,
+    rust_2018_idioms,
+    trivial_casts,
+    unused_lifetimes,
+    unused_qualifications
+)]
 #![forbid(unsafe_code)]
 #![doc(html_root_url = "https://docs.rs/tai64/3.0.0")]
 

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -193,7 +193,13 @@
 //! [good cryptographic hygiene]: https://github.com/veorq/cryptocoding#clean-memory-of-secret-data
 
 #![no_std]
-#![deny(warnings, missing_docs, trivial_casts, unused_qualifications)]
+#![deny(
+    missing_docs,
+    rust_2018_idioms,
+    trivial_casts,
+    unused_lifetimes,
+    unused_qualifications
+)]
 #![doc(html_root_url = "https://docs.rs/zeroize/0.10.0")]
 
 #[cfg(feature = "alloc")]

--- a/zeroize_derive/src/lib.rs
+++ b/zeroize_derive/src/lib.rs
@@ -1,10 +1,13 @@
 //! Custom derive support for `zeroize`
 
 #![crate_type = "proc-macro"]
-#![deny(warnings, unused_import_braces, unused_qualifications)]
+#![deny(
+    rust_2018_idioms,
+    trivial_casts,
+    unused_lifetimes,
+    unused_qualifications
+)]
 #![forbid(unsafe_code)]
-
-extern crate proc_macro;
 
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -15,7 +18,7 @@ use synstructure::{decl_derive, BindStyle};
 const ZEROIZE_ATTR: &str = "zeroize";
 
 /// Custom derive for `Zeroize`
-fn derive_zeroize(s: synstructure::Structure) -> TokenStream {
+fn derive_zeroize(s: synstructure::Structure<'_>) -> TokenStream {
     let attributes = DeriveAttrs::parse(&s);
 
     // NOTE: These are split into named functions to simplify testing with
@@ -26,6 +29,7 @@ fn derive_zeroize(s: synstructure::Structure) -> TokenStream {
         derive_zeroize_without_drop(s)
     }
 }
+
 decl_derive!([Zeroize, attributes(zeroize)] => derive_zeroize);
 
 /// Custom derive attributes for `Zeroize`
@@ -37,7 +41,7 @@ struct DeriveAttrs {
 
 impl DeriveAttrs {
     /// Parse attributes from the incoming AST
-    fn parse(s: &synstructure::Structure) -> Self {
+    fn parse(s: &synstructure::Structure<'_>) -> Self {
         let mut result = Self::default();
 
         for v in s.variants().iter() {
@@ -92,7 +96,7 @@ impl DeriveAttrs {
 }
 
 /// Custom derive for `Zeroize` (without `Drop`)
-fn derive_zeroize_without_drop(mut s: synstructure::Structure) -> TokenStream {
+fn derive_zeroize_without_drop(mut s: synstructure::Structure<'_>) -> TokenStream {
     s.bind_with(|_| BindStyle::RefMut);
 
     let zeroizers = s.each(|bi| quote! { #bi.zeroize(); });
@@ -110,7 +114,7 @@ fn derive_zeroize_without_drop(mut s: synstructure::Structure) -> TokenStream {
 }
 
 /// Custom derive for `Zeroize` and `Drop`
-fn derive_zeroize_with_drop(s: synstructure::Structure) -> TokenStream {
+fn derive_zeroize_with_drop(s: synstructure::Structure<'_>) -> TokenStream {
     let drop_impl = s.gen_impl(quote! {
         gen impl Drop for @Self {
             fn drop(&mut self) {


### PR DESCRIPTION
- Replace `deny` on `warnings` and `missing_docs` with CI `-D` flags
- Add `rust_2018_idioms` and `unused_lifetimes` to all crates
- Split out `rustfmt`, `clippy`, and `cargo audit` in CI matrix