### PR TITLE
secrecy/zeroize: Cleanups for `bytes` feature; remove `Bytes` impls

### DIFF
--- a/secrecy/Cargo.toml
+++ b/secrecy/Cargo.toml
@@ -23,9 +23,8 @@ travis-ci = { repository = "iqlusioninc/crates", branch = "develop" }
 [dependencies]
 serde = { version = "1", optional = true }
 zeroize = { version = "0.10", path = "../zeroize", default-features = false }
-bytes_crate = { package = "bytes", version = "0.4.12", optional = true }
+bytes = { version = "0.4", optional = true }
 
 [features]
 default = ["alloc"]
 alloc = ["zeroize/alloc"]
-bytes = ["zeroize/bytes", "bytes_crate"]

--- a/secrecy/src/bytes.rs
+++ b/secrecy/src/bytes.rs
@@ -1,14 +1,10 @@
-//! Secret bytes
+//! Optional `Secret` wrapper type for the `bytes::BytesMut` crate.
 
 use super::{CloneableSecret, DebugSecret, Secret};
-use bytes_crate::{Bytes, BytesMut};
+use bytes::BytesMut;
 
-/// Secret bytes
-pub type SecretBytes = Secret<Bytes>;
-/// Secret bytes_mut
+/// Alias for `Secret<BytesMut>`
 pub type SecretBytesMut = Secret<BytesMut>;
 
-impl DebugSecret for Bytes {}
-impl CloneableSecret for Bytes {}
 impl DebugSecret for BytesMut {}
 impl CloneableSecret for BytesMut {}

--- a/secrecy/src/lib.rs
+++ b/secrecy/src/lib.rs
@@ -28,7 +28,7 @@ mod vec;
 pub use self::{boxed::SecretBox, string::SecretString, vec::SecretVec};
 
 #[cfg(feature = "bytes")]
-pub use self::{bytes::SecretBytes, bytes::SecretBytesMut};
+pub use self::bytes::SecretBytesMut;
 
 use core::fmt::{self, Debug};
 #[cfg(feature = "serde")]

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -26,9 +26,8 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 zeroize_derive = { version = "0.10", path = "../zeroize_derive", optional = true }
-bytes_crate = { package = "bytes", version = "0.4.12", optional = true }
+bytes = { version = "0.4", optional = true }
 
 [features]
 default = ["alloc"]
 alloc = []
-bytes = ["bytes_crate"]

--- a/zeroize/src/bytes.rs
+++ b/zeroize/src/bytes.rs
@@ -1,0 +1,32 @@
+//! `Zeroize` impl for the `BytesMut` type from the `bytes` crate
+
+// TODO(tarcieri): upstream this?
+
+use super::Zeroize;
+use ::bytes::BytesMut;
+
+#[cfg(feature = "bytes")]
+impl Zeroize for BytesMut {
+    fn zeroize(&mut self) {
+        self.resize(self.capacity(), Default::default());
+        self.as_mut().zeroize();
+        self.clear();
+        debug_assert!(self.iter().all(|b| *b == 0));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zeroize_bytes() {
+        let mut data = BytesMut::from("data");
+        data.zeroize();
+        assert!(data.is_empty());
+
+        let mut data = BytesMut::from("data");
+        data.zeroize();
+        assert!(data.is_empty());
+    }
+}


### PR DESCRIPTION
- Removes the redundant `bytes` feature; imports it as `bytes`
- Removes the `Bytes` impl for `Zeroize`
- Removes the `SecretBytes` type

I will open another PR with a proper solution for `Bytes`. It's a particularly tricky problem, but one I think has an effective and safe solution. This PR is just to clear the dust in advance.

cc @gakonst 