### PR TITLE
secrecy: Add (optional) concrete `SecretBytes` type

### DIFF
--- a/secrecy/Cargo.toml
+++ b/secrecy/Cargo.toml
@@ -23,8 +23,9 @@ travis-ci = { repository = "iqlusioninc/crates", branch = "develop" }
 [dependencies]
 serde = { version = "1", optional = true }
 zeroize = { version = "0.10", path = "../zeroize", default-features = false }
-bytes = { version = "0.4", optional = true }
+bytes_crate = { package = "bytes", version = "0.4", optional = true }
 
 [features]
 default = ["alloc"]
 alloc = ["zeroize/alloc"]
+bytes = ["bytes_crate", "zeroize/bytes"]

--- a/secrecy/src/bytes.rs
+++ b/secrecy/src/bytes.rs
@@ -1,7 +1,62 @@
 //! Optional `Secret` wrapper type for the `bytes::BytesMut` crate.
 
-use super::{CloneableSecret, DebugSecret, Secret};
-use bytes::BytesMut;
+use super::{CloneableSecret, DebugSecret, ExposeSecret, Secret};
+use bytes_crate::{Bytes, BytesMut};
+use core::fmt;
+use zeroize::Zeroize;
+
+/// Instance of `Bytes` protected by a type that impls the `ExposeSecret`
+/// trait like `Secret<T>`.
+///
+/// Because of the nature of how the `Bytes` type works, it needs some special
+/// care in order to have a proper zeroizing drop handler.
+#[derive(Clone)]
+pub struct SecretBytes(Option<Bytes>);
+
+impl SecretBytes {
+    /// Wrap bytes in `SecretBytes`
+    pub fn new(bytes: impl Into<Bytes>) -> SecretBytes {
+        SecretBytes(Some(bytes.into()))
+    }
+}
+
+impl ExposeSecret<Bytes> for SecretBytes {
+    fn expose_secret(&self) -> &Bytes {
+        self.0.as_ref().unwrap()
+    }
+}
+
+impl fmt::Debug for SecretBytes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "SecretBytes(...)")
+    }
+}
+
+impl From<Bytes> for SecretBytes {
+    fn from(bytes: Bytes) -> SecretBytes {
+        SecretBytes::new(bytes)
+    }
+}
+
+impl From<BytesMut> for SecretBytes {
+    fn from(bytes: BytesMut) -> SecretBytes {
+        SecretBytes::new(bytes)
+    }
+}
+
+impl Drop for SecretBytes {
+    fn drop(&mut self) {
+        // To zero the contents of `Bytes`, we have to take ownership of it
+        // and then attempt to convert it to a `BytesMut`. If that succeeds,
+        // we are holding the last reference to the inner byte buffer, which
+        // indicates its lifetime has ended and it's ready to be zeroed.
+        if let Some(bytes) = self.0.take() {
+            if let Ok(mut bytes_mut) = bytes.try_mut() {
+                bytes_mut.zeroize();
+            }
+        }
+    }
+}
 
 /// Alias for `Secret<BytesMut>`
 pub type SecretBytesMut = Secret<BytesMut>;

--- a/secrecy/src/lib.rs
+++ b/secrecy/src/lib.rs
@@ -28,7 +28,7 @@ mod vec;
 pub use self::{boxed::SecretBox, string::SecretString, vec::SecretVec};
 
 #[cfg(feature = "bytes")]
-pub use self::bytes::SecretBytesMut;
+pub use self::bytes::{SecretBytes, SecretBytesMut};
 
 use core::fmt::{self, Debug};
 #[cfg(feature = "serde")]


### PR DESCRIPTION
Zeroizing `Bytes` is tricky because it's explicitly designed to provide an immutable, shared view of bytes.

There's one escape hatch though: `Bytes::try_mut()`, which takes ownership of `Bytes`, returning a `BytesMut` if it has an exclusive view of the data, or the original `Bytes` if other readers still have a shared view of it. That's ok though, because we don't want to zero out the bytes until the last reader is finished with it.

Using that, and a hack where the `Bytes` are kept in an `Option` and moved out with `Option::take` in the drop handler, it's possible for the drop handler to take ownership of the `Bytes`, attempt a conversion to `BytesMut`, and if it succeeds calling `BytesMut::zeroize()`.

cc @gakonst 