### PR TITLE
secrecy v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "secrecy"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/secrecy/CHANGES.md
+++ b/secrecy/CHANGES.md
@@ -1,3 +1,8 @@
+## [0.4.0] (2019-09-03)
+
+- Add `SerializableSecret` ([#262])
+- Add (optional) concrete `SecretBytes` type ([#258], [#259], [#260], [#261])
+
 ## [0.3.1] (2019-08-26)
 
 - Impl `CloneableSecret` for `String` ([#256])
@@ -24,6 +29,12 @@
 
 - Initial release
 
+[0.4.0]: https://github.com/iqlusioninc/crates/pull/263
+[#262]: https://github.com/iqlusioninc/crates/pull/262
+[#261]: https://github.com/iqlusioninc/crates/pull/261
+[#260]: https://github.com/iqlusioninc/crates/pull/260
+[#259]: https://github.com/iqlusioninc/crates/pull/259
+[#258]: https://github.com/iqlusioninc/crates/pull/258
 [0.3.1]: https://github.com/iqlusioninc/crates/pull/257
 [#256]: https://github.com/iqlusioninc/crates/pull/256
 [0.3.0]: https://github.com/iqlusioninc/crates/pull/254

--- a/secrecy/Cargo.toml
+++ b/secrecy/Cargo.toml
@@ -6,7 +6,7 @@ description = """
               (as much as possible), and also ensure secrets are securely wiped
               from memory when dropped.
               """
-version     = "0.3.1" # Also update html_root_url in lib.rs when bumping this
+version     = "0.4.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0 OR MIT"
 edition     = "2018"
@@ -22,7 +22,7 @@ travis-ci = { repository = "iqlusioninc/crates", branch = "develop" }
 
 [dependencies]
 serde = { version = "1", optional = true }
-zeroize = { version = "0.10", path = "../zeroize", default-features = false }
+zeroize = { version = "0.10.1", path = "../zeroize", default-features = false }
 bytes_crate = { package = "bytes", version = "0.4", features = ["serde"], optional = true }
 
 [features]

--- a/secrecy/src/lib.rs
+++ b/secrecy/src/lib.rs
@@ -10,7 +10,7 @@
     unused_qualifications
 )]
 #![forbid(unsafe_code)]
-#![doc(html_root_url = "https://docs.rs/secrecy/0.3.1")]
+#![doc(html_root_url = "https://docs.rs/secrecy/0.4.0")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;


### PR DESCRIPTION
- Add `SerializableSecret` (#262)
- Add (optional) concrete `SecretBytes` type (#258, #259, #260, #261)