### PR TITLE
zeroize: Loosen `Vec` trait bounds for `Zeroize`

### DIFF
--- a/secrecy/src/bytes.rs
+++ b/secrecy/src/bytes.rs
@@ -62,7 +62,7 @@ impl Drop for SecretBytes {
 }
 
 #[cfg(feature = "serde")]
-impl<'de> Deserialize<'de> for SecretBytes where {
+impl<'de> Deserialize<'de> for SecretBytes {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -312,11 +312,15 @@ where
 #[cfg(feature = "alloc")]
 impl<Z> Zeroize for Vec<Z>
 where
-    Z: DefaultIsZeroes,
+    Z: Clone + Default + Zeroize,
 {
+    /// "Best effort" zeroization for `Vec`.
+    ///
+    /// Ensures the entire capacity of the `Vec` is zeroed. Cannot ensure that
+    /// previous reallocations did not leave values on the heap.
     fn zeroize(&mut self) {
         self.resize(self.capacity(), Default::default());
-        self.as_mut_slice().zeroize();
+        self.iter_mut().zeroize();
         self.clear();
     }
 }


### PR DESCRIPTION
Previously used `DefaultIsZeroes`, however this is only useful for primitive types, and can't support e.g. `Vec` of arrays.