### PR TITLE
zeroize: Rename `bytes` feature to `bytes-preview`

### DIFF
--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -30,3 +30,4 @@ bytes = { version = "0.4", optional = true }
 [features]
 default = ["alloc"]
 alloc = []
+bytes-preview = ["bytes"]

--- a/zeroize/src/bytes.rs
+++ b/zeroize/src/bytes.rs
@@ -5,7 +5,6 @@
 use super::Zeroize;
 use ::bytes::BytesMut;
 
-#[cfg(feature = "bytes")]
 impl Zeroize for BytesMut {
     fn zeroize(&mut self) {
         self.resize(self.capacity(), Default::default());

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -104,6 +104,19 @@
 //! }
 //! ```
 //!
+//! ## `bytes-preview` feature: `Zeroize` support for `BytesMut`
+//!
+//! This crate contains an impl of `Zeroize` for the `BytesMut` type from the
+//! `bytes` crate.
+//!
+//! As `bytes` is not yet 1.0, this is a "preview" feature which we do not
+//! include in SemVer guarantees around the `zeroize` crate. Ideally, we can
+//! upstream the implementation and remove the feature entirely.
+//!
+//! Whenever we make any changes to how the `bytes-preview` feature works,
+//! such as upgrading the `bytes` crate version or removing it after
+//! successfully upstreaming, it will be done with a minor version bump.
+//!
 //! ## What guarantees does this crate provide?
 //!
 //! This crate guarantees the following:
@@ -200,7 +213,7 @@
 #[cfg_attr(test, macro_use)]
 extern crate alloc;
 
-#[cfg(feature = "bytes")]
+#[cfg(feature = "bytes-preview")]
 mod bytes;
 
 #[cfg(feature = "zeroize_derive")]


### PR DESCRIPTION
Since `bytes` isn't 1.0 yet and we'd like to reserve the right to either upgrade it to another 0.x version in the future, or upstream the implementation so we can remove the feature entirely, this changes the
feature name to `bytes-preview` and explicitly calls it out as not included in the SemVer guarantees for `zeroize`.

Ideally I think we can upstream it, especially after a 1.0 release of `zeroize` itself.