### PR TITLE
zeroize v1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ dependencies = [
  "pbkdf2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle-encoding 0.4.1",
- "zeroize 1.0.0-pre",
+ "zeroize 1.0.0",
 ]
 
 [[package]]
@@ -450,7 +450,7 @@ version = "0.4.1"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 1.0.0-pre",
+ "zeroize 1.0.0",
 ]
 
 [[package]]
@@ -483,7 +483,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "subtle-encoding"
 version = "0.4.1"
 dependencies = [
- "zeroize 1.0.0-pre",
+ "zeroize 1.0.0",
 ]
 
 [[package]]
@@ -582,15 +582,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "zeroize"
-version = "1.0.0-pre"
+version = "1.0.0"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize_derive 1.0.0-pre",
+ "zeroize_derive 1.0.0",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.0.0-pre"
+version = "1.0.0"
 dependencies = [
  "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/hkd32/Cargo.toml
+++ b/hkd32/Cargo.toml
@@ -33,7 +33,7 @@ optional = true
 path = "../subtle-encoding"
 
 [dependencies.zeroize]
-version = "1.0.0-pre"
+version = "1"
 default-features = false
 features = ["zeroize_derive"]
 path = "../zeroize"

--- a/secrecy/Cargo.toml
+++ b/secrecy/Cargo.toml
@@ -21,13 +21,13 @@ maintenance = { status = "passively-maintained" }
 
 [dependencies]
 serde = { version = "1", optional = true }
-zeroize = { version = "1.0.0-pre", path = "../zeroize", default-features = false }
+zeroize = { version = "1.0.0", path = "../zeroize", default-features = false }
 bytes_crate = { package = "bytes", version = "0.4", features = ["serde"], optional = true }
 
 [features]
 default = ["alloc"]
 alloc = ["zeroize/alloc"]
-bytes = ["bytes_crate", "zeroize/bytes"]
+bytes = ["bytes_crate", "zeroize/bytes-preview"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/subtle-encoding/Cargo.toml
+++ b/subtle-encoding/Cargo.toml
@@ -17,7 +17,7 @@ categories  = ["cryptography", "encoding", "no-std"]
 keywords    = ["base64", "bech32", "constant-time", "hex", "security"]
 
 [dependencies.zeroize]
-version = "1.0.0-pre"
+version = "1"
 optional = true
 default-features = false
 path = "../zeroize"

--- a/zeroize/CHANGES.md
+++ b/zeroize/CHANGES.md
@@ -1,3 +1,11 @@
+## [1.0.0] (2019-10-13)
+
+- Initial 1.0 release 🎉
+- zeroize_derive: Remove legacy `no_drop` attribute support ([#278])
+- Rename `bytes` feature to `bytes-preview` ([#277])
+- Further relax `Zeroize` trait bounds for `Vec` ([#276])
+- Derive `Clone`, `Debug`, and `Eq` for `Zeroizing` ([#275])
+
 ## [1.0.0-pre] (2019-09-30)
 
 - Loosen `Vec` trait bounds for `Zeroize` ([#267])
@@ -108,6 +116,11 @@ a pure Rust solution.
 
 - Initial release
 
+[1.0.0]: https://github.com/iqlusioninc/crates/pull/279
+[#278]: https://github.com/iqlusioninc/crates/pull/278
+[#277]: https://github.com/iqlusioninc/crates/pull/277
+[#276]: https://github.com/iqlusioninc/crates/pull/276
+[#275]: https://github.com/iqlusioninc/crates/pull/275
 [1.0.0-pre]: https://github.com/iqlusioninc/crates/pull/268
 [#267]: https://github.com/iqlusioninc/crates/pull/267
 [0.10.1]: https://github.com/iqlusioninc/crates/pull/264

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name        = "zeroize"
 description = """
-              Securely clear secrets from memory with a simple trait built on
-              stable Rust primitives which guarantee memory is zeroed using an
-              operation will not be 'optimized away' by the compiler.
-              Uses a portable pure Rust implementation that works everywhere,
-              even WASM!
-              """
-version     = "1.0.0-pre" # Also update html_root_url in lib.rs when bumping this
+Securely clear secrets from memory with a simple trait built on
+stable Rust primitives which guarantee memory is zeroed using an
+operation will not be 'optimized away' by the compiler.
+Uses a portable pure Rust implementation that works everywhere,
+even WASM!
+"""
+version     = "1.0.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0 OR MIT"
 edition     = "2018"
@@ -17,17 +17,17 @@ readme      = "README.md"
 categories  = ["cryptography", "memory-management", "no-std", "os"]
 keywords    = ["memory", "memset", "secure", "volatile", "zero"]
 
-[package.metadata.docs.rs]
-all-features = true
-
 [badges]
-maintenance = { status = "actively-developed" }
+maintenance = { status = "passively-maintained" }
 
 [dependencies]
-zeroize_derive = { version = "1.0.0-pre", path = "../zeroize_derive", optional = true }
+zeroize_derive = { version = "1.0.0", path = "../zeroize_derive", optional = true }
 bytes = { version = "0.4", optional = true }
 
 [features]
 default = ["alloc"]
 alloc = []
 bytes-preview = ["bytes"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/zeroize/README.md
+++ b/zeroize/README.md
@@ -35,9 +35,13 @@ thereof, implemented in pure Rust with no usage of FFI or assembly.
 - No functionality besides securely zeroing memory!
 - (Optional) Custom derive support for zeroing complex structures
 
-## Requirements
+## Minimum Supported Rust Version
 
-- Rust **1.36+**
+Requires Rust **1.36** or newer.
+
+In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
+for this crate's SemVer guarantees), however when we do it will be accompanied
+with a minor version bump.
 
 ## License
 

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -20,6 +20,14 @@
 //! - No functionality besides securely zeroing memory!
 //! - (Optional) Custom derive support for zeroing complex structures
 //!
+//! ## Minimum Supported Rust Version
+//!
+//! Requires Rust **1.36** or newer.
+//!
+//! In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
+//! for this crate's SemVer guarantees), however when we do it will be accompanied
+//! with a minor version bump.
+//!
 //! ## Usage
 //!
 //! ```

--- a/zeroize_derive/CHANGES.md
+++ b/zeroize_derive/CHANGES.md
@@ -1,0 +1,5 @@
+## [1.0.0] (2019-10-13)
+
+- Initial 1.0 release
+
+[1.0.0]: https://github.com/iqlusioninc/crates/pull/279

--- a/zeroize_derive/Cargo.toml
+++ b/zeroize_derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "zeroize_derive"
 description = "Custom derive support for zeroize"
-version     = "1.0.0-pre"
+version     = "1.0.0"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0 OR MIT"
 edition     = "2018"
@@ -13,6 +13,9 @@ keywords    = ["memory", "memset", "secure", "volatile", "zero"]
 
 [lib]
 proc-macro = true
+
+[badges]
+maintenance = { status = "passively-maintained" }
 
 [dependencies]
 proc-macro2 = "1"

--- a/zeroize_derive/README.md
+++ b/zeroize_derive/README.md
@@ -11,9 +11,13 @@ while avoiding compiler optimizations.
 This crate isn't intended to be used directly.
 See [zeroize] crate for documentation.
 
-## Requirements
+## Minimum Supported Rust Version
 
-- Rust **1.36+**
+Requires Rust **1.36** or newer.
+
+In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
+for this crate's SemVer guarantees), however when we do it will be accompanied
+with a minor version bump.
 
 ## License
 


### PR DESCRIPTION
- Initial 1.0 release 🎉:shipit:
- zeroize_derive: Remove legacy `no_drop` attribute support (#278)
- Rename `bytes` feature to `bytes-preview` (#277)
- Further relax `Zeroize` trait bounds for `Vec` (#276)
- Derive `Clone`, `Debug`, and `Eq` for `Zeroizing` (#275)