### PR TITLE
hkd32: Split out `bip39` cargo feature

### DIFF
--- a/hkd32/Cargo.toml
+++ b/hkd32/Cargo.toml
@@ -42,7 +42,8 @@ path = "../zeroize"
 default = ["alloc", "bech32", "getrandom"]
 alloc = ["zeroize/alloc"]
 bech32 = ["alloc", "subtle-encoding/bech32-preview"]
-mnemonic = ["alloc", "getrandom", "lazy_static", "pbkdf2"]
+mnemonic = ["alloc", "getrandom", "lazy_static"]
+bip39 = ["mnemonic", "pbkdf2"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/hkd32/src/lib.rs
+++ b/hkd32/src/lib.rs
@@ -46,7 +46,7 @@
 #![doc(html_root_url = "https://docs.rs/hkd32/0.2.0")]
 
 #[cfg(feature = "alloc")]
-#[cfg_attr(any(feature = "mnemonic", test), macro_use)]
+#[cfg_attr(any(feature = "bip39", test), macro_use)]
 extern crate alloc;
 
 mod key_material;

--- a/hkd32/src/mnemonic.rs
+++ b/hkd32/src/mnemonic.rs
@@ -8,6 +8,9 @@
 mod bits;
 mod language;
 mod phrase;
+#[cfg(feature = "bip39")]
 mod seed;
 
-pub use self::{language::Language, phrase::Phrase, seed::Seed};
+#[cfg(feature = "bip39")]
+pub use self::seed::Seed;
+pub use self::{language::Language, phrase::Phrase};

--- a/hkd32/src/mnemonic/phrase.rs
+++ b/hkd32/src/mnemonic/phrase.rs
@@ -1,18 +1,23 @@
 //! BIP39 mnemonic phrases
 
+#[cfg(feature = "bip39")]
+use super::seed::{Seed, SEED_SIZE};
 use super::{
     bits::{BitWriter, IterExt},
     language::Language,
-    seed::{Seed, SEED_SIZE},
 };
 use crate::{Error, KeyMaterial, Path, KEY_SIZE};
 use alloc::string::String;
 use core::convert::TryInto;
+#[cfg(feature = "bip39")]
 use hmac::Hmac;
-use sha2::{Digest, Sha256, Sha512};
+#[cfg(feature = "bip39")]
+use sha2::Sha512;
+use sha2::{Digest, Sha256};
 use zeroize::{Zeroize, Zeroizing};
 
 /// Number of PBKDF2 rounds to perform when deriving the seed
+#[cfg(feature = "bip39")]
 const PBKDF2_ROUNDS: usize = 2048;
 
 /// Source entropy for a BIP39 mnemonic phrase
@@ -135,7 +140,10 @@ impl Phrase {
         KeyMaterial::from(self).derive_subkey(path)
     }
 
-    /// Convert this mnemonic phrase into the BIP39 seed value
+    /// Convert this mnemonic phrase into the BIP39 seed value.
+    ///
+    /// This is only available when the `bip39` Cargo feature is enabled.
+    #[cfg(feature = "bip39")]
     pub fn to_seed(&self, password: &str) -> Seed {
         let salt = Zeroizing::new(format!("mnemonic{}", password));
         let mut seed = [0u8; SEED_SIZE];

--- a/hkd32/src/mnemonic/seed.rs
+++ b/hkd32/src/mnemonic/seed.rs
@@ -13,7 +13,7 @@ const BIP39_BASE_DERIVATION_KEY: [u8; 12] = [
 /// Number of bytes of PBKDF2 output to extract
 pub const SEED_SIZE: usize = 64;
 
-/// BIP39 seeds
+/// BIP39 seeds. Requires the `bip39` cargo feature is enabled.
 pub struct Seed(pub(crate) [u8; SEED_SIZE]);
 
 impl Seed {

--- a/hkd32/tests/bip39_vectors.rs
+++ b/hkd32/tests/bip39_vectors.rs
@@ -1,6 +1,6 @@
 //! BIP39 test vectors
 
-#[cfg(feature = "mnemonic")]
+#[cfg(feature = "bip39")]
 mod mnemonic {
     use core::convert::TryInto;
     use hkd32::mnemonic;


### PR DESCRIPTION
Allows use of a simpler derivation without dependence on the `pbkdf2` crate for cases that don't require full BIP39 compatibility.