### PR TITLE
hkd32 v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "hkd32"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "getrandom 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/hkd32/CHANGES.md
+++ b/hkd32/CHANGES.md
@@ -1,3 +1,8 @@
+## [0.3.0] (2019-10-13)
+
+- Split out `bip39` cargo feature ([#280])
+- Upgrade to `zeroize` v1.0.0 ([#279])
+
 ## [0.2.0] (2019-08-20)
 
 - Vendor (simplified) BIP39 implementation from `tiny-bip39` ([#251])
@@ -16,6 +21,9 @@
 
 - Initial release
 
+[0.3.0]: https://github.com/iqlusioninc/crates/pull/281
+[#280]: https://github.com/iqlusioninc/crates/pull/280
+[#279]: https://github.com/iqlusioninc/crates/pull/279
 [0.2.0]: https://github.com/iqlusioninc/crates/pull/252
 [#251]: https://github.com/iqlusioninc/crates/pull/251
 [#249]: https://github.com/iqlusioninc/crates/pull/249

--- a/hkd32/Cargo.toml
+++ b/hkd32/Cargo.toml
@@ -7,7 +7,7 @@ description = """
               (HMAC) construction. Optionally supports storing root derivation
               passwords as a 24-word mnemonic phrase (i.e. BIP39).
               """
-version     = "0.2.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.3.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0"
 edition     = "2018"

--- a/hkd32/src/lib.rs
+++ b/hkd32/src/lib.rs
@@ -43,7 +43,7 @@
     unused_lifetimes,
     unused_qualifications
 )]
-#![doc(html_root_url = "https://docs.rs/hkd32/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/hkd32/0.3.0")]
 
 #[cfg(feature = "alloc")]
 #[cfg_attr(any(feature = "bip39", test), macro_use)]


### PR DESCRIPTION
- Split out `bip39` cargo feature (#280)
- Upgrade to `zeroize` v1.0.0 (#279)