### PR TITLE
secrecy v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "secrecy"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/secrecy/CHANGES.md
+++ b/secrecy/CHANGES.md
@@ -1,3 +1,7 @@
+## [0.5.0] (2019-10-13)
+
+- Upgrade to `zeroize` v1.0.0 ([#279])
+
 ## [0.4.1] (2019-10-13)
 
 - Upgrade to `zeroize` v1.0.0-pre ([#268])
@@ -33,6 +37,8 @@
 
 - Initial release
 
+[0.5.0]: https://github.com/iqlusioninc/crates/pull/282
+[#279]: https://github.com/iqlusioninc/crates/pull/279
 [0.4.1]: https://github.com/iqlusioninc/crates/pull/274
 [#268]: https://github.com/iqlusioninc/crates/pull/268
 [0.4.0]: https://github.com/iqlusioninc/crates/pull/263

--- a/secrecy/Cargo.toml
+++ b/secrecy/Cargo.toml
@@ -6,7 +6,7 @@ they aren't accidentally copied, logged, or otherwise exposed
 (as much as possible), and also ensure secrets are securely wiped
 from memory when dropped.
 """
-version     = "0.4.1" # Also update html_root_url in lib.rs when bumping this
+version     = "0.5.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0 OR MIT"
 edition     = "2018"

--- a/secrecy/src/lib.rs
+++ b/secrecy/src/lib.rs
@@ -4,7 +4,7 @@
 #![no_std]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
-#![doc(html_root_url = "https://docs.rs/secrecy/0.4.1")]
+#![doc(html_root_url = "https://docs.rs/secrecy/0.5.0")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;


### PR DESCRIPTION
- Upgrade to `zeroize` v1.0.0 (#279)