### PR TITLE
tai64: Add serde support

### DIFF
--- a/tai64/Cargo.toml
+++ b/tai64/Cargo.toml
@@ -13,14 +13,15 @@ keywords    = ["tai64", "time", "timestamps", "chrono"]
 
 [badges]
 maintenance = { status = "passively-maintained" }
-travis-ci = { repository = "iqlusioninc/crates", branch = "develop" }
 
 [dependencies]
 chrono = { version = "0.4", optional = true, default-features = false }
+serde =  { version = "*", optional = true, default-features = false }
 
 [features]
 default = ["std"]
 std = []
+derive_serde = ["serde"]
 
 [dev-dependencies]
 quickcheck = "0.8"

--- a/tai64/src/lib.rs
+++ b/tai64/src/lib.rs
@@ -398,3 +398,146 @@ mod tests {
         }
     }
 }
+
+// Serde Impls
+
+#[cfg(feature = "derive_serde")]
+use serde::de::{Deserialize, Deserializer, SeqAccess};
+#[cfg(feature = "derive_serde")]
+use serde::Serialize;
+#[cfg(feature = "derive_serde")]
+impl Serialize for TAI64{
+    
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where S: serde::ser::Serializer, {
+        use serde::ser::SerializeTupleStruct;
+
+        let mut state = serializer.serialize_tuple_struct("TAI64", 1)?;
+        state.serialize_field(&self.0)?;
+        state.end()
+    }
+}
+#[cfg(feature = "derive_serde")]
+impl<'de> Deserialize<'de> for TAI64 {
+    
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
+        struct Visitor;
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = TAI64;
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("tuple struct TAI64")
+            }
+            fn visit_newtype_struct<E>(self,e: E) -> Result<Self::Value, E::Error> where E: Deserializer<'de> {
+                let field0: u64 = match <u64 as serde::Deserialize>::deserialize(e) {
+                    Ok(val) => val,
+                    Err(err) => {
+                        return Err(err);
+                    }
+                };
+                Ok(TAI64(field0))
+            }
+            
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error> where A: SeqAccess<'de> {
+                let field0 = match match SeqAccess::next_element::<u64>(&mut seq) {
+                        Ok(val) => val,
+                        Err(err) => {
+                            return Err(err);
+                        }
+                    } 
+                    {
+                        Some(value) => value,
+                        None => {
+                            return Err(serde::de::Error::invalid_length(
+                                0usize,
+                                &"tuple struct TAI64 with 1 element",
+                            ));
+                        }
+                    };
+                Ok(TAI64(field0))
+            }
+        }
+
+        deserializer.deserialize_newtype_struct("TAI64",Visitor)
+    }
+}
+#[cfg(feature = "derive_serde")]
+impl Serialize for TAI64N{
+    
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut serde_state =
+            match serde::Serializer::serialize_tuple_struct(serializer, "TAI64N", 0 + 1 + 1)
+            {
+                Ok(val) => val,
+                Err(err) => {
+                    return Err(err);
+                }
+            };
+        match serde::ser::SerializeTupleStruct::serialize_field(&mut serde_state, &self.0) {
+            Ok(val) => val,
+            Err(err) => {
+                return Err(err);
+            }
+        };
+        match serde::ser::SerializeTupleStruct::serialize_field(&mut serde_state, &self.1) {
+            Ok(val) => val,
+            Err(err) => {
+                return Err(err);
+            }
+        };
+        serde::ser::SerializeTupleStruct::end(serde_state)
+    }
+}
+#[cfg(feature = "derive_serde")]
+impl<'de> Deserialize<'de> for TAI64N {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = TAI64N;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("tuple struct TAI64N")
+            }
+            
+            fn visit_seq<A>(self,mut seq: A) -> Result<Self::Value, A::Error> where A: SeqAccess<'de> {
+                let field0 =
+                    match match serde::de::SeqAccess::next_element::<TAI64>(&mut seq) {
+                        Ok(val) => val,
+                        Err(err) => {
+                            return Err(err);
+                        }
+                    }
+                    {
+                        Some(value) => value,
+                        None => {
+                            return Err(serde::de::Error::invalid_length(
+                                0usize,
+                                &"tuple struct TAI64N with 2 elements",
+                            ));
+                        }
+                    };
+                let field1 =
+                    match match serde::de::SeqAccess::next_element::<u32>(&mut seq) {
+                        Ok(val) => val,
+                        Err(err) => {
+                            return Err(err);
+                        }
+                    }
+                    {
+                        Some(value) => value,
+                        None => {
+                            return Err(serde::de::Error::invalid_length(
+                                1usize,
+                                &"tuple struct TAI64N with 2 elements",
+                            ));
+                        }
+                    };
+                Ok(TAI64N(field0, field1))
+            }
+        }
+        deserializer.deserialize_tuple_struct("TAI64N", 2usize, Visitor)
+    }
+}

--- a/tai64/src/lib.rs
+++ b/tai64/src/lib.rs
@@ -406,10 +406,11 @@ use serde::de::{Deserialize, Deserializer, SeqAccess};
 #[cfg(feature = "derive_serde")]
 use serde::Serialize;
 #[cfg(feature = "derive_serde")]
-impl Serialize for TAI64{
-    
+impl Serialize for TAI64 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where S: serde::ser::Serializer, {
+    where
+        S: serde::ser::Serializer,
+    {
         use serde::ser::SerializeTupleStruct;
 
         let mut state = serializer.serialize_tuple_struct("TAI64", 1)?;
@@ -419,15 +420,20 @@ impl Serialize for TAI64{
 }
 #[cfg(feature = "derive_serde")]
 impl<'de> Deserialize<'de> for TAI64 {
-    
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
         struct Visitor;
         impl<'de> serde::de::Visitor<'de> for Visitor {
             type Value = TAI64;
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("tuple struct TAI64")
             }
-            fn visit_newtype_struct<E>(self,e: E) -> Result<Self::Value, E::Error> where E: Deserializer<'de> {
+            fn visit_newtype_struct<E>(self, e: E) -> Result<Self::Value, E::Error>
+            where
+                E: Deserializer<'de>,
+            {
                 let field0: u64 = match <u64 as serde::Deserialize>::deserialize(e) {
                     Ok(val) => val,
                     Err(err) => {
@@ -436,40 +442,40 @@ impl<'de> Deserialize<'de> for TAI64 {
                 };
                 Ok(TAI64(field0))
             }
-            
-            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error> where A: SeqAccess<'de> {
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
                 let field0 = match match SeqAccess::next_element::<u64>(&mut seq) {
-                        Ok(val) => val,
-                        Err(err) => {
-                            return Err(err);
-                        }
-                    } 
-                    {
-                        Some(value) => value,
-                        None => {
-                            return Err(serde::de::Error::invalid_length(
-                                0usize,
-                                &"tuple struct TAI64 with 1 element",
-                            ));
-                        }
-                    };
+                    Ok(val) => val,
+                    Err(err) => {
+                        return Err(err);
+                    }
+                } {
+                    Some(value) => value,
+                    None => {
+                        return Err(serde::de::Error::invalid_length(
+                            0usize,
+                            &"tuple struct TAI64 with 1 element",
+                        ));
+                    }
+                };
                 Ok(TAI64(field0))
             }
         }
 
-        deserializer.deserialize_newtype_struct("TAI64",Visitor)
+        deserializer.deserialize_newtype_struct("TAI64", Visitor)
     }
 }
 #[cfg(feature = "derive_serde")]
-impl Serialize for TAI64N{
-    
+impl Serialize for TAI64N {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
         let mut serde_state =
-            match serde::Serializer::serialize_tuple_struct(serializer, "TAI64N", 0 + 1 + 1)
-            {
+            match serde::Serializer::serialize_tuple_struct(serializer, "TAI64N", 0 + 1 + 1) {
                 Ok(val) => val,
                 Err(err) => {
                     return Err(err);
@@ -492,7 +498,10 @@ impl Serialize for TAI64N{
 }
 #[cfg(feature = "derive_serde")]
 impl<'de> Deserialize<'de> for TAI64N {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
         struct Visitor;
 
         impl<'de> serde::de::Visitor<'de> for Visitor {
@@ -501,40 +510,39 @@ impl<'de> Deserialize<'de> for TAI64N {
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("tuple struct TAI64N")
             }
-            
-            fn visit_seq<A>(self,mut seq: A) -> Result<Self::Value, A::Error> where A: SeqAccess<'de> {
-                let field0 =
-                    match match serde::de::SeqAccess::next_element::<TAI64>(&mut seq) {
-                        Ok(val) => val,
-                        Err(err) => {
-                            return Err(err);
-                        }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let field0 = match match serde::de::SeqAccess::next_element::<TAI64>(&mut seq) {
+                    Ok(val) => val,
+                    Err(err) => {
+                        return Err(err);
                     }
-                    {
-                        Some(value) => value,
-                        None => {
-                            return Err(serde::de::Error::invalid_length(
-                                0usize,
-                                &"tuple struct TAI64N with 2 elements",
-                            ));
-                        }
-                    };
-                let field1 =
-                    match match serde::de::SeqAccess::next_element::<u32>(&mut seq) {
-                        Ok(val) => val,
-                        Err(err) => {
-                            return Err(err);
-                        }
+                } {
+                    Some(value) => value,
+                    None => {
+                        return Err(serde::de::Error::invalid_length(
+                            0usize,
+                            &"tuple struct TAI64N with 2 elements",
+                        ));
                     }
-                    {
-                        Some(value) => value,
-                        None => {
-                            return Err(serde::de::Error::invalid_length(
-                                1usize,
-                                &"tuple struct TAI64N with 2 elements",
-                            ));
-                        }
-                    };
+                };
+                let field1 = match match serde::de::SeqAccess::next_element::<u32>(&mut seq) {
+                    Ok(val) => val,
+                    Err(err) => {
+                        return Err(err);
+                    }
+                } {
+                    Some(value) => value,
+                    None => {
+                        return Err(serde::de::Error::invalid_length(
+                            1usize,
+                            &"tuple struct TAI64N with 2 elements",
+                        ));
+                    }
+                };
                 Ok(TAI64N(field0, field1))
             }
         }


### PR DESCRIPTION
This is a solution to the previous merge failure where it was not yet formatted with Rustfmt. This PR adds support for serde using the `derive_serde` feature. A minor version release on crates.io will be appreciated