### PR TITLE
tai64: Add (optional) serde support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,6 +513,7 @@ version = "3.0.0"
 dependencies = [
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/tai64/Cargo.toml
+++ b/tai64/Cargo.toml
@@ -16,6 +16,7 @@ maintenance = { status = "passively-maintained" }
 
 [dependencies]
 chrono = { version = "0.4", optional = true, default-features = false }
+serde = { version = "1", optional = true, default-features = false }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
Adds serde serializers/deserializers which are simple thunks to the TAI64/TAI64N binary wire format.