### PR TITLE
.github: Add macos-latest to the build matrix

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,28 +8,6 @@ on:
 name: Rust
 
 jobs:
-  audit:
-    name: Audit
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v1
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-
-      - name: Install cargo audit
-        run: cargo install cargo-audit
-
-      - name: Run cargo audit
-        uses: actions-rs/cargo@v1
-        with:
-          command: audit
-          args: --deny-warnings
-
   build:
     name: Build (wasm32-unknown-unknown)
     runs-on: ubuntu-latest
@@ -70,6 +48,7 @@ jobs:
       matrix:
         platform:
           - ubuntu-latest
+          - macos-latest
           - windows-latest
         toolchain:
           - 1.39.0
@@ -152,3 +131,26 @@ jobs:
         with:
           command: clippy
           args: -- -D warnings
+
+  # TODO: use actions-rs/audit-check
+  security_audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v1
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Install cargo audit
+        run: cargo install cargo-audit
+
+      - name: Run cargo audit
+        uses: actions-rs/cargo@v1
+        with:
+          command: audit
+          args: --deny-warnings


### PR DESCRIPTION
We claim we test on macOS (and used to). This was lost in the GitHub Actions migration.