### PR TITLE
zeroize: Add `From<Z: Zeroize>` impl for `Zeroizing<Z>`

### DIFF
--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -349,6 +349,15 @@ where
 {
     /// Wrap a value in `Zeroizing`, ensuring it's zeroized on drop.
     pub fn new(value: Z) -> Self {
+        value.into()
+    }
+}
+
+impl<Z> From<Z> for Zeroizing<Z>
+where
+    Z: Zeroize,
+{
+    fn from(value: Z) -> Zeroizing<Z> {
         Zeroizing(value)
     }
 }


### PR DESCRIPTION
Allows moving an owned `Z` into a `Zeroizing` wrapper using `From`/`Into`.