### PR TITLE
secrecy: Add CloneableSecret impls for arrays

### DIFF
--- a/secrecy/src/lib.rs
+++ b/secrecy/src/lib.rs
@@ -98,6 +98,23 @@ where
 /// Marker trait for secrets which are allowed to be cloned
 pub trait CloneableSecret: Clone + Zeroize {}
 
+/// Implement `CloneableSecret` on arrays of types that impl `Clone` and
+/// `Zeroize`.
+macro_rules! impl_cloneable_secret_for_array {
+    ($($size:expr),+) => {
+        $(
+            impl<T: Clone + Zeroize> CloneableSecret for [T; $size] {}
+        )+
+     };
+}
+
+// TODO(tarcieri): const generics
+impl_cloneable_secret_for_array!(
+    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
+    27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
+    51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64
+);
+
 /// Expose a reference to an inner secret
 pub trait ExposeSecret<S> {
     /// Expose secret
@@ -114,7 +131,7 @@ pub trait DebugSecret {
     }
 }
 
-/// Implement `Zeroize` on arrays of types that impl `Zeroize`
+/// Implement `DebugSecret` on arrays of types that impl `Debug`.
 macro_rules! impl_debug_secret_for_array {
     ($($size:expr),+) => {
         $(


### PR DESCRIPTION
This PR adds `CloneableSecret` impls for arrays.