### PR TITLE
secrecy: Replace `bytes-serde` feature with custom deserializer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,9 +46,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "bytes"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "c2-chacha"

--- a/secrecy/Cargo.toml
+++ b/secrecy/Cargo.toml
@@ -27,7 +27,6 @@ bytes = { version = "0.5", optional = true }
 [features]
 default = ["alloc"]
 alloc = ["zeroize/alloc"]
-bytes-serde = ["bytes/serde", "serde"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
It's tricky with Rust's feature system to represent the combination of features in such a way that it can conditionally activate another feature of one of the crates when that crate is itself a feature.

This instead handles feature unification for `bytes` and `serde` through a not-too-terribly-compilicated custom deserializer such that merely having both features active is enough to receive the impl.