### PR TITLE
anomaly: Use $crate when referencing nested macros

### DIFF
--- a/anomaly/README.md
+++ b/anomaly/README.md
@@ -35,16 +35,9 @@ its error `Kind` type. We recommend [`thiserror`] for that purpose.
 
 ## What makes anomaly.rs different?
 
-Error crates like [`failure`] and [`anyhow`] use either full type erasure
-or "stringly typed" approach to handling errors, with [`failure`] using
-a `Fail` trait, and [`anyhow`] defining its own [`anyhow::Error`] trait.
-
-**anomaly.rs** instead uses a context generic around a concrete `Kind`
-type, and only uses type erasure (based on [`std::error::Error`]) when
-constructing error chains.
-
-In other words, it supports the full functionality of these other libraries,
-but doesn't require everything be type erased. Or, in bullet point form:
+[`anomaly::Context`] is generic around a concrete `Kind` type, and only
+uses type erasure (based on [`std::error::Error`]) when constructing
+error chains:
 
 - Concrete (generic) types for immediate errors
 - Type erasure for error sources

--- a/anomaly/src/macros.rs
+++ b/anomaly/src/macros.rs
@@ -23,7 +23,7 @@ macro_rules! format_err {
 #[macro_export]
 macro_rules! fail {
     ($kind:expr, $msg:expr) => {
-        return Err(format_err!($kind, $msg).into());
+        return Err($crate::format_err!($kind, $msg).into());
     };
     ($kind:expr, $fmt:expr, $($arg:tt)+) => {
         fail!($kind, &format!($fmt, $($arg)+));
@@ -35,7 +35,7 @@ macro_rules! fail {
 macro_rules! ensure {
     ($cond:expr, $kind:expr, $msg:expr) => {
         if !($cond) {
-            return Err(format_err!($kind, $msg).into());
+            return Err($crate::format_err!($kind, $msg).into());
         }
     };
     ($cond:expr, $kind:expr, $fmt:expr, $($arg:tt)+) => {


### PR DESCRIPTION
...to avoid having to import them.