### PR TITLE
anomaly v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ dependencies = [
 
 [[package]]
 name = "anomaly"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/anomaly/CHANGES.md
+++ b/anomaly/CHANGES.md
@@ -1,3 +1,10 @@
+## [0.1.1] (2019-12-31)
+
+- Use `$crate` when referencing nested macros ([#319])
+
 ## 0.1.0 (2019-12-31)
 
 - Initial release
+
+[0.1.1]: https://github.com/iqlusioninc/crates/pull/320
+[#319]: https://github.com/iqlusioninc/crates/pull/319

--- a/anomaly/Cargo.toml
+++ b/anomaly/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "anomaly"
 description = "Error context library with support for type-erased sources and backtraces"
-version     = "0.1.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.1.1" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0 OR MIT"
 edition     = "2018"

--- a/anomaly/src/lib.rs
+++ b/anomaly/src/lib.rs
@@ -3,7 +3,7 @@
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
-#![doc(html_root_url = "https://docs.rs/anomaly/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/anomaly/0.1.1")]
 
 #[macro_use]
 mod macros;


### PR DESCRIPTION
- Use `$crate` when referencing nested macros (#319)