### PR TITLE
secrecy: use Infallible for FromStr for SecretString

### DIFF
--- a/secrecy/src/string.rs
+++ b/secrecy/src/string.rs
@@ -11,7 +11,7 @@ impl DebugSecret for String {}
 impl CloneableSecret for String {}
 
 impl FromStr for SecretString {
-    type Err = ();
+    type Err = core::convert::Infallible;
     fn from_str(src: &str) -> Result<Self, Self::Err> {
         Ok(SecretString::new(src.to_string()))
     }


### PR DESCRIPTION
`core::convert::Infallible` can ensure the user that the error will
never happen. Further `Infallible` implements all the usual traits which
means that it doesn’t impact normal error handling through string
conversion (such as the unit type does because it does not implement
`Display`).