### PR TITLE
zeroize: zeroize entire capacity of `Vec`

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -15,5 +15,6 @@ contributions under the terms of the [Apache License, Version 2.0]
 * David Tolnay ([@dtolnay](https://github.com/dtolnay))
 * Kai Ren ([@tyranron](https://github.com/tyranron))
 * Murarth ([@murarth](https://github.com/murarth))
+* Niclas Schwarzlose ([@aticu](https://github.com/aticu))
 * Yin Guanhao ([@sopium](https://github.com/sopium))
 * Will Speak ([@iwillspeak](https://github.com/iwillspeak))


### PR DESCRIPTION
Re-implement #180, but without any additional required trait bounds, which is why #180 was reverted in  #276.