### PR TITLE
anomaly: Add generic `Error` type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,7 @@ version = "0.1.2"
 dependencies = [
  "backtrace 0.3.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1354,7 +1355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "vint64"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "criterion 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion-cycles-per-byte 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/anomaly/Cargo.toml
+++ b/anomaly/Cargo.toml
@@ -15,6 +15,9 @@ keywords    = ["backtrace", "error-handling", "exception-reporting", "serde"]
 backtrace = { version = "0.3", optional = true }
 serde = { version = "1", optional = true, features = ["serde_derive"] }
 
+[dev-dependencies]
+thiserror = "1"
+
 [features]
 default = ["backtrace"]
 gimli-symbolize = ["backtrace/gimli-symbolize"]

--- a/anomaly/README.md
+++ b/anomaly/README.md
@@ -35,9 +35,9 @@ its error `Kind` type. We recommend [`thiserror`] for that purpose.
 
 ## What makes anomaly.rs different?
 
-[`anomaly::Context`] is generic around a concrete `Kind` type, and only
-uses type erasure (based on [`std::error::Error`]) when constructing
-error chains:
+[`anomaly::Context`] (and its `Box`-ed wrapper, [`anomaly::Error`] are
+generic around a concrete `Kind` type. Type erasure (based on
+[`std::error::Error`]) is only used when constructing error chains:
 
 - Concrete (generic) types for immediate errors
 - Type erasure for error sources
@@ -91,6 +91,7 @@ without any additional terms or conditions.
 [`failure`]: https://crates.io/crates/failure
 [`anyhow`]: https://crates.io/crates/anyhow
 [`anomaly::Context`]: https://docs.rs/anomaly/latest/anomaly/struct.Context.html
+[`anomaly::Error`]: https://docs.rs/anomaly/latest/anomaly/struct.Error.html
 [`std::error::Error`]: https://doc.rust-lang.org/std/error/trait.Error.html
 [`anomaly::BoxError`]: https://docs.rs/anomaly/latest/anomaly/type.BoxError.html
 [`anomaly::Message`]: https://docs.rs/anomaly/latest/anomaly/struct.Message.html

--- a/anomaly/src/context.rs
+++ b/anomaly/src/context.rs
@@ -9,7 +9,7 @@ use std::fmt::{self, Debug, Display};
 #[derive(Debug)]
 pub struct Context<Kind>
 where
-    Kind: Clone + Debug + Display + Eq + PartialEq + Into<BoxError>,
+    Kind: Clone + Debug + Display + Into<BoxError>,
 {
     /// Kind of error
     kind: Kind,
@@ -24,7 +24,7 @@ where
 
 impl<Kind> Context<Kind>
 where
-    Kind: Clone + Debug + Display + Eq + PartialEq + Into<BoxError>,
+    Kind: Clone + Debug + Display + Into<BoxError>,
 {
     /// Create a new error context
     pub fn new(kind: Kind, source: Option<BoxError>) -> Self {
@@ -50,7 +50,7 @@ where
 
 impl<Kind> Display for Context<Kind>
 where
-    Kind: Clone + Debug + Display + Eq + PartialEq + Into<BoxError>,
+    Kind: Clone + Debug + Display + Into<BoxError>,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", &self.kind)?;
@@ -65,7 +65,7 @@ where
 
 impl<Kind> From<Kind> for Context<Kind>
 where
-    Kind: Clone + Debug + Display + Eq + PartialEq + Into<BoxError>,
+    Kind: Clone + Debug + Display + Into<BoxError>,
 {
     fn from(kind: Kind) -> Context<Kind> {
         Self::new(kind, None)
@@ -74,7 +74,7 @@ where
 
 impl<Kind> std::error::Error for Context<Kind>
 where
-    Kind: Clone + Debug + Display + Eq + PartialEq + Into<BoxError>,
+    Kind: Clone + Debug + Display + Into<BoxError>,
 {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         self.source

--- a/anomaly/src/error.rs
+++ b/anomaly/src/error.rs
@@ -1,0 +1,63 @@
+//! Error type which is generic around a `Kind`
+
+use crate::{BoxError, Context};
+use std::{
+    fmt::{self, Debug, Display},
+    ops::Deref,
+};
+
+/// Error type which is generic around a `Kind`.
+///
+/// Provides a `Box`-ed wrapper around a [`Context`], ensuring error
+/// propagation is a cheap operation (pointer copy).
+#[derive(Debug)]
+pub struct Error<Kind>(Box<Context<Kind>>)
+where
+    Kind: Clone + Debug + Display + Into<BoxError>;
+
+impl<Kind> Deref for Error<Kind>
+where
+    Kind: Clone + Debug + Display + Into<BoxError>,
+{
+    type Target = Context<Kind>;
+
+    fn deref(&self) -> &Context<Kind> {
+        &self.0
+    }
+}
+
+impl<Kind> Display for Error<Kind>
+where
+    Kind: Clone + Debug + Display + Into<BoxError>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl<Kind> std::error::Error for Error<Kind>
+where
+    Kind: Clone + Debug + Display + Into<BoxError>,
+{
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.0.source()
+    }
+}
+
+impl<Kind> From<Kind> for Error<Kind>
+where
+    Kind: Clone + Debug + Display + Into<BoxError>,
+{
+    fn from(kind: Kind) -> Self {
+        Context::new(kind, None).into()
+    }
+}
+
+impl<Kind> From<Context<Kind>> for Error<Kind>
+where
+    Kind: Clone + Debug + Display + Into<BoxError>,
+{
+    fn from(context: Context<Kind>) -> Self {
+        Error(Box::new(context))
+    }
+}

--- a/anomaly/src/lib.rs
+++ b/anomaly/src/lib.rs
@@ -1,5 +1,70 @@
 //! **anomaly.rs**: Error context library with support for type-erased sources
-//! and backtraces
+//! and backtraces.
+//!
+//! # About
+//!
+//! **anomaly.rs** is an error library which provides support for concrete,
+//! generic error types along with type-erased error sources/chains and
+//! backtraces.
+//!
+//! Full support for all features is available on stable Rust.
+//!
+//! # Usage
+//!
+//! Below is some example boilerplate for how to define error types for your
+//! project using **anomaly.rs**.
+//!
+//! This example uses the [`thiserror`] crate to provide custom derive support,
+//! however it is not required: you can use any type which impls the standard
+//! set of error traits (`Display`, `Debug`, and `std::error::Error`) as your
+//! `ErrorKind` type:
+//!
+//! ```
+//! use anomaly::{BoxError, Context};
+//! use thiserror::Error;
+//!
+//! /// Use this type alias as your error type when returning `Result`.
+//! ///
+//! /// Internally it's defined as `Error(Box<Context<ErrorKind>>)` and
+//! /// ensures propagation of errors is a cheap pointer copy.
+//! pub type Error = anomaly::Error<ErrorKind>;
+//!
+//! /// An error kind type containing a domain-specific error categorization.
+//! ///
+//! /// You can convert this into the `Error` type above (and capture a
+//! /// backtrace in the process) by using `.into()`.
+//! ///
+//! /// This example uses the `thiserror::Error` procedural macro to impl the
+//! /// `Display` and `std::error::Error` traits, however you don't have to and
+//! /// can impl them yourself or using another error crate of your choosing.
+//! #[derive(Clone, Debug, Error)]
+//! pub enum ErrorKind {
+//!     /// See `thiserror` documentation for the `#[error]` attribute
+//!     #[error("invalid argument: {name}")]
+//!     Argument {
+//!         name: String
+//!     },
+//!
+//!     #[error("encoding error")]
+//!     Encoding,
+//!
+//!     #[error("value overflowed")]
+//!     Overflow
+//! }
+//!
+//! impl ErrorKind {
+//!    /// Add additional context (i.e. include a source error and capture
+//!    /// a backtrace).
+//!    ///
+//!    /// You can convert the resulting `Context` into an `Error` by calling
+//!    /// `.into()`.
+//!    pub fn context(self, source: impl Into<BoxError>) -> Context<ErrorKind> {
+//!        Context::new(self, Some(source.into()))
+//!    }
+//! }
+//! ```
+//!
+//! [`thiserror`]: https://github.com/dtolnay/thiserror
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
@@ -9,9 +74,10 @@
 mod macros;
 
 mod context;
+mod error;
 mod message;
 
-pub use self::{context::Context, message::Message};
+pub use self::{context::Context, error::Error, message::Message};
 #[cfg(feature = "backtrace")]
 pub use backtrace;
 


### PR DESCRIPTION
Provides an `Error` type containing a `Box<Context<Kind>>` which is useful for propagating errors. It impls `Deref` to the underlying `Context`, and also `Display` and `std::error::Error`

Unfortunately, having `anomaly` define this type (rather than the end-user crate) means that the end-user crate can no longer impl `From` to do automatic error conversions to this type.

An alternative solution would be to have `anomaly` provide a proc macro which derives the set of traits the `Error` type impls, allowing each crate to define their own `Error` type, but have them behave in the same way.

However, for now, this is better than nothing.