### PR TITLE
WIP: StdTx: Better JSON support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5ca2cd0adc3f48f9e9ea5a6bbdf9ccc0bfade884847e484d452414c7ccffb3"
+
+[[package]]
 name = "block-buffer"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,6 +791,7 @@ name = "stdtx"
 version = "0.1.0"
 dependencies = [
  "anomaly",
+ "base64",
  "ecdsa",
  "prost-amino",
  "prost-amino-derive",

--- a/stdtx/Cargo.toml
+++ b/stdtx/Cargo.toml
@@ -16,6 +16,7 @@ circle-ci = { repository = "tendermint/kms" }
 
 [dependencies]
 anomaly = { version = "0.2", path = "../anomaly" }
+base64 = "0.12.0"
 ecdsa = { version = "0.4", features = ["k256"] }
 prost-amino = "0.5"
 prost-amino-derive = "0.5"

--- a/stdtx/src/address.rs
+++ b/stdtx/src/address.rs
@@ -2,6 +2,7 @@
 
 use crate::error::{Error, ErrorKind};
 use anomaly::ensure;
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use std::convert::TryInto;
 use subtle_encoding::bech32;
 
@@ -31,6 +32,25 @@ impl Address {
     /// Encode this address as Bech32
     pub fn to_bech32(&self, hrp: &str) -> String {
         bech32::encode(hrp, &self.0)
+    }
+}
+
+impl Serialize for Address {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let s = self.to_bech32("cosmos"); // TODO: how to generalize?
+        s.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Address {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        let (_hrp, addr) =
+            Address::from_bech32(s).map_err(|e| de::Error::custom(format!("{:?}", e)))?;
+        Ok(addr)
     }
 }
 


### PR DESCRIPTION
I've been working on prototype of IBC txs in https://github.com/informalsystems/ibc-rs/pull/52.

Tried to use this lib where I could, but had a few issues. It's possible I misunderstood how to use it, so please let me know if I'm doing something super wrong, but here's what I found:

- Wasn't clear what the use case of defining Msgs in a toml is. I need to be able to define them in Rust (for now, later in proto)
- Seems it currently only works for Msgs with primitive and hardcoded types (?). I couldn't see how to use a Msg that eg. contained a Tendermint header
- Seems I can't get compliant JSON encodings.

To unblock my current work, I made a few changes here. I'm not sure exactly what the plans are with this crate, or if these changes make sense for it, but regardless I think Informal would be happy to maintain it, or something like it, in the ibc-rs.

The changes I made were:
- implement Serialize/Deserialize for the `Address` so it can be used in Msg types and properly bech32 encoded and decoded in JSON (I see the to_json_value methods but didn't quite figure out how to use them); one caveat here is the `cosmos` prefix is hardcoded, will take more work to generalize that (maybe it should be a field in the Address?)
- derive Serialize/Deserialize for Coin, StdFee, and StdSignature
- implement custom encoder/decoder to map u64 to string (for proto3 and tendermint JSON) 
- implement custom encoder/decoder to map bytes to base64 string (for proto3 and tendermint JSON)
- fix the pub_key field name in StdSignature

With these changes, and the StdTx I defined in https://github.com/informalsystems/ibc-rs/pull/52, I was able to create an unsinged StdTx JSON for an ibc message, sign it using gaiacli, unmarshal the signed JSON back into Rust, and then encode it as not-fully-correct Amino (that part's still a WIP). 

