### PR TITLE
Update `ecdsa`, `hmac`, `pbkdf2`,`sha2`, `signatory-secp256k1`  dependencies 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -127,7 +127,7 @@ jobs:
           - macos-latest
           - windows-latest
         toolchain:
-          - 1.39.0
+          - 1.41.0
           - stable
     runs-on: ${{ matrix.platform }}
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,14 +166,13 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a7aaf89875554fab12c9d0855d694803a8820b73bfb89cdc96546b6bcab69e4"
+checksum = "3a184c3e1b6bc72ac8de04ef553a238d57067cb3c9e5e9783578bdc2bb3c3283"
 dependencies = [
  "elliptic-curve",
- "generic-array 0.12.3",
  "k256",
- "sha2 0.8.2",
+ "sha2 0.9.0",
  "signature",
 ]
 
@@ -185,11 +184,11 @@ checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01f69be7d1feb7a7a04f158aaf32c7deaa7604e9bd58145525e536438c4e5096"
+checksum = "2298f66754d859f4c099b0e645cfd258d2dfdfd1bac9496fd514d603ff6a5c6b"
 dependencies = [
- "generic-array 0.12.3",
+ "generic-array 0.14.1",
  "getrandom",
  "subtle",
  "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -311,9 +310,9 @@ checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 
 [[package]]
 name = "k256"
-version = "0.1.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0afa79ea8238df7a342756fbf971d4e3ba16f389eaaf730658f3e3f58cf47da4"
+checksum = "c34f5cb67f9625a99c159fc0776e75d2e37f988cdf31c115e9c25225e61d858c"
 dependencies = [
  "elliptic-curve",
 ]
@@ -644,13 +643,13 @@ dependencies = [
 
 [[package]]
 name = "signatory"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ac23ba234e306afe0d90b1cc809e329622f49a89328aeebe3a6c37a8f8b8a3"
+checksum = "7c20cbcf205bedce2ce5944ab41dd2e10b1dcee2831a0a2a071806761ed6eaba"
 dependencies = [
  "ecdsa",
  "getrandom",
- "sha2 0.8.2",
+ "sha2 0.9.0",
  "signature",
  "subtle-encoding 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -658,9 +657,9 @@ dependencies = [
 
 [[package]]
 name = "signatory-secp256k1"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff08548248a4b10eb37a1976f2e821f6220ce3efea3cda17321c1f0d564216ba"
+checksum = "02a50b18b66b81b859f8ee57b0e85658e1777fe2683ac37b7e756380f0a28f6e"
 dependencies = [
  "secp256k1",
  "signatory",
@@ -669,11 +668,11 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "685e1c5b65c6cc6fd0eb9ba63c6cfb8431f7f9c7e078c626f23f50e13fa378d7"
+checksum = "65211b7b6fc3f14ff9fc7a2011a434e3e6880585bd2e9e9396315ae24cbf7852"
 dependencies = [
- "digest 0.8.1",
+ "digest 0.9.0",
  "signature_derive",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
- "sha2 0.8.2",
+ "sha2 0.9.0",
  "signatory-secp256k1",
  "subtle-encoding 0.5.1",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbcf92448676f82bb7a334c58bbce8b0d43580fb5362a9d608b18879d12a3d31"
+dependencies = [
+ "block-padding",
+ "byte-tools",
+ "byteorder",
+ "generic-array 0.14.1",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,6 +138,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+dependencies = [
+ "generic-array 0.14.1",
+ "subtle 2.2.2",
+]
+
+[[package]]
 name = "digest"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,6 +166,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array 0.14.1",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,7 +183,7 @@ dependencies = [
  "elliptic-curve",
  "generic-array 0.12.3",
  "k256",
- "sha2",
+ "sha2 0.8.2",
  "signature",
 ]
 
@@ -218,6 +249,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2664c2cf08049036f31015b04c6ac3671379a1d86f52ed2416893f16022deb"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,19 +289,19 @@ dependencies = [
  "hmac",
  "lazy_static",
  "pbkdf2",
- "sha2",
+ "sha2 0.9.0",
  "subtle-encoding 0.5.1",
  "zeroize 1.1.0",
 ]
 
 [[package]]
 name = "hmac"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
+checksum = "b87b580bd66811cc2324a27f3587de707cacf7525b96dca8122f7493e6cce0da"
 dependencies = [
- "crypto-mac",
- "digest 0.8.1",
+ "crypto-mac 0.8.0",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -353,7 +393,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "006c038a43a45995a9670da19e67600114740e8511d4333bf97a56e66a7542d9"
 dependencies = [
  "byteorder",
- "crypto-mac",
+ "crypto-mac 0.7.0",
 ]
 
 [[package]]
@@ -401,7 +441,7 @@ dependencies = [
  "itertools",
  "proc-macro2 0.4.30",
  "quote 0.6.13",
- "sha2",
+ "sha2 0.8.2",
  "syn 0.14.9",
 ]
 
@@ -595,8 +635,20 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.7.3",
  "digest 0.8.1",
+ "fake-simd",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72377440080fd008550fe9b441e854e43318db116f90181eef92e9ae9aedab48"
+dependencies = [
+ "block-buffer 0.8.0",
+ "digest 0.9.0",
  "fake-simd",
  "opaque-debug",
 ]
@@ -609,7 +661,7 @@ checksum = "09ac23ba234e306afe0d90b1cc809e329622f49a89328aeebe3a6c37a8f8b8a3"
 dependencies = [
  "ecdsa",
  "getrandom",
- "sha2",
+ "sha2 0.8.2",
  "signature",
  "subtle-encoding 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -665,7 +717,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.8.2",
  "signatory-secp256k1",
  "subtle-encoding 0.5.1",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "addr2line"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456d75cbb82da1ad150c8a9d97285ffcd21c9931dcb11e995903e7d75141b38b"
+checksum = "a49806b9dadc843c61e7c97e72490ad7f7220ae249012fbda9ad0609457c0543"
 dependencies = [
  "gimli",
 ]
@@ -129,22 +129,12 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
-dependencies = [
- "generic-array 0.12.3",
- "subtle 1.0.0",
-]
-
-[[package]]
-name = "crypto-mac"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
  "generic-array 0.14.1",
- "subtle 2.2.2",
+ "subtle",
 ]
 
 [[package]]
@@ -201,7 +191,7 @@ checksum = "01f69be7d1feb7a7a04f158aaf32c7deaa7604e9bd58145525e536438c4e5096"
 dependencies = [
  "generic-array 0.12.3",
  "getrandom",
- "subtle 2.2.2",
+ "subtle",
  "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -217,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "failure"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8529c2421efa3066a5cbd8063d2244603824daccb6936b079010bb2aa89464b"
+checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
 dependencies = [
  "backtrace",
 ]
@@ -300,7 +290,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b87b580bd66811cc2324a27f3587de707cacf7525b96dca8122f7493e6cce0da"
 dependencies = [
- "crypto-mac 0.8.0",
+ "crypto-mac",
  "digest 0.9.0",
 ]
 
@@ -321,9 +311,9 @@ checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 
 [[package]]
 name = "k256"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4407bc616f76afb6bccd8a813b86fe622752b15b43c5e60fec94d21af2393a72"
+checksum = "0afa79ea8238df7a342756fbf971d4e3ba16f389eaaf730658f3e3f58cf47da4"
 dependencies = [
  "elliptic-curve",
 ]
@@ -336,9 +326,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.68"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
+checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
 
 [[package]]
 name = "log"
@@ -388,19 +378,18 @@ checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "pbkdf2"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "006c038a43a45995a9670da19e67600114740e8511d4333bf97a56e66a7542d9"
+checksum = "216eaa586a190f0a738f2f918511eecfa90f13295abec0e457cdebcceda80cbd"
 dependencies = [
- "byteorder",
- "crypto-mac 0.7.0",
+ "crypto-mac",
 ]
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
+checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 
 [[package]]
 name = "proc-macro2"
@@ -524,9 +513,9 @@ checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
 name = "regex"
-version = "1.3.5"
+version = "1.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8900ebc1363efa7ea1c399ccc32daed870b4002651e0bed86e72d501ebbe0048"
+checksum = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -536,9 +525,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.17"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
+checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
 
 [[package]]
 name = "remove_dir_all"
@@ -567,9 +556,9 @@ checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 
 [[package]]
 name = "ryu"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "secp256k1"
@@ -615,14 +604,14 @@ checksum = "3f2c3ac8e6ca1e9c80b8be1023940162bf81ae3cffbb1809474152f2ce1eb250"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.30",
+ "syn 1.0.31",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.53"
+version = "1.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2"
+checksum = "ec2c5d7e739bc07a3e73381a39d61fdb5f671c60c1df26a130690665803d8226"
 dependencies = [
  "itoa",
  "ryu",
@@ -696,7 +685,7 @@ checksum = "b0656c180103507cca4b82519908e813225b2f6b90b2bd59ee119f46155ae872"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.30",
+ "syn 1.0.31",
  "synstructure",
 ]
 
@@ -726,15 +715,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "1.0.0"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
-
-[[package]]
-name = "subtle"
-version = "2.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c65d530b10ccaeac294f349038a597e435b18fb456aadd0840a623f83b9e941"
+checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
 
 [[package]]
 name = "subtle-encoding"
@@ -765,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93a56fabc59dce20fe48b6c832cc249c713e7ed88fa28b0ee0a3bfcaae5fe4e2"
+checksum = "b5304cfdf27365b7585c25d4af91b35016ed21ef88f17ced89c7093b43dba8b6"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
@@ -782,7 +765,7 @@ checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.30",
+ "syn 1.0.31",
  "unicode-xid 0.2.0",
 ]
 
@@ -827,7 +810,7 @@ checksum = "893582086c2f98cde18f906265a65b5030a074b1046c674ae898be6519a7f479"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.30",
+ "syn 1.0.31",
 ]
 
 [[package]]
@@ -850,9 +833,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.11.2"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
+checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
 name = "unicode-xid"
@@ -913,6 +896,6 @@ version = "1.0.0"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.30",
+ "syn 1.0.31",
  "synstructure",
 ]

--- a/hkd32/Cargo.toml
+++ b/hkd32/Cargo.toml
@@ -25,7 +25,7 @@ getrandom = { version = "0.1", optional = true }
 hmac = { version = "0.8", default-features = false }
 lazy_static = { version = "1", optional = true, default-features = false }
 sha2 = { version = "0.9", default-features = false }
-pbkdf2 = { version = "0.3", optional = true, default-features = false }
+pbkdf2 = { version = "0.4", optional = true, default-features = false }
 
 [dependencies.subtle-encoding]
 version = "0.5"

--- a/hkd32/Cargo.toml
+++ b/hkd32/Cargo.toml
@@ -22,9 +22,9 @@ maintenance = { status = "passively-maintained" }
 
 [dependencies]
 getrandom = { version = "0.1", optional = true }
-hmac = { version = "0.7", default-features = false }
+hmac = { version = "0.8", default-features = false }
 lazy_static = { version = "1", optional = true, default-features = false }
-sha2 = { version = "0.8", default-features = false }
+sha2 = { version = "0.9", default-features = false }
 pbkdf2 = { version = "0.3", optional = true, default-features = false }
 
 [dependencies.subtle-encoding]

--- a/hkd32/src/key_material.rs
+++ b/hkd32/src/key_material.rs
@@ -14,7 +14,8 @@ use alloc::string::String;
 use core::convert::TryFrom;
 #[cfg(feature = "getrandom")]
 use getrandom::getrandom;
-use hmac::{Hmac, Mac};
+use hmac::Hmac;
+use hmac::crypto_mac::{NewMac, Mac};
 use sha2::Sha512;
 #[cfg(feature = "bech32")]
 use subtle_encoding::bech32::Bech32;
@@ -97,9 +98,9 @@ impl KeyMaterial {
             .enumerate()
             .fold(self, |parent_key, (i, component)| {
                 let mut hmac = Hmac::<Sha512>::new_varkey(parent_key.as_bytes()).unwrap();
-                hmac.input(component.as_bytes());
+                hmac.update(component.as_bytes());
 
-                let mut hmac_result = hmac.result().code();
+                let mut hmac_result = hmac.finalize().into_bytes();
                 let (secret_key, chain_code) = hmac_result.split_at_mut(KEY_SIZE);
                 let mut child_key = [0u8; KEY_SIZE];
 

--- a/hkd32/src/key_material.rs
+++ b/hkd32/src/key_material.rs
@@ -14,8 +14,8 @@ use alloc::string::String;
 use core::convert::TryFrom;
 #[cfg(feature = "getrandom")]
 use getrandom::getrandom;
+use hmac::crypto_mac::{Mac, NewMac};
 use hmac::Hmac;
-use hmac::crypto_mac::{NewMac, Mac};
 use sha2::Sha512;
 #[cfg(feature = "bech32")]
 use subtle_encoding::bech32::Bech32;

--- a/hkd32/src/mnemonic/phrase.rs
+++ b/hkd32/src/mnemonic/phrase.rs
@@ -18,7 +18,7 @@ use zeroize::{Zeroize, Zeroizing};
 
 /// Number of PBKDF2 rounds to perform when deriving the seed
 #[cfg(feature = "bip39")]
-const PBKDF2_ROUNDS: usize = 2048;
+const PBKDF2_ROUNDS: u32 = 2048;
 
 /// Source entropy for a BIP39 mnemonic phrase
 pub type Entropy = [u8; KEY_SIZE];
@@ -47,7 +47,7 @@ impl Phrase {
     /// Create a new BIP39 mnemonic phrase from the given entropy
     pub fn from_entropy(entropy: Entropy, language: Language) -> Self {
         let wordlist = language.wordlist();
-        let checksum_byte = Sha256::digest(entropy.as_ref()).as_ref()[0];
+        let checksum_byte = Sha256::digest(entropy.as_ref()).as_slice()[0];
 
         // First, create a byte iterator for the given entropy and the first byte of the
         // hash of the entropy that will serve as the checksum (up to 8 bits for biggest
@@ -101,7 +101,7 @@ impl Phrase {
         // Truncate to get rid of the byte containing the checksum
         entropy.truncate(KEY_SIZE);
 
-        let expected_checksum = Sha256::digest(&entropy).as_ref()[0];
+        let expected_checksum = Sha256::digest(&entropy).as_slice()[0];
 
         if actual_checksum != expected_checksum {
             Err(Error)?;

--- a/hkd32/src/mnemonic/seed.rs
+++ b/hkd32/src/mnemonic/seed.rs
@@ -1,6 +1,7 @@
 //! BIP39 seed values
 
 use crate::{KeyMaterial, Path, KEY_SIZE};
+use hmac::crypto_mac::NewMac;
 use hmac::{Hmac, Mac};
 use sha2::Sha512;
 use zeroize::Zeroize;
@@ -25,10 +26,10 @@ impl Seed {
     /// Derive a BIP32 subkey from this seed
     pub fn derive_subkey(self, path: impl AsRef<Path>) -> KeyMaterial {
         let mut hmac = Hmac::<Sha512>::new_varkey(&BIP39_BASE_DERIVATION_KEY).unwrap();
-        hmac.input(&self.0);
+        hmac.update(&self.0);
 
         // Use the chain code of the derived key as the root key
-        let root_key = KeyMaterial::from_bytes(&hmac.result().code()[KEY_SIZE..]).unwrap();
+        let root_key = KeyMaterial::from_bytes(&hmac.finalize().into_bytes()[KEY_SIZE..]).unwrap();
 
         root_key.derive_subkey(path)
     }

--- a/stdtx/Cargo.toml
+++ b/stdtx/Cargo.toml
@@ -16,7 +16,7 @@ circle-ci = { repository = "tendermint/kms" }
 
 [dependencies]
 anomaly = { version = "0.2", path = "../anomaly" }
-ecdsa = { version = "0.5", features = ["k256"] }
+ecdsa = { version = "0.6", features = ["k256"] }
 prost-amino = "0.5"
 prost-amino-derive = "0.5"
 rust_decimal = "1.6"
@@ -32,4 +32,4 @@ features = ["bech32-preview"]
 path = "../subtle-encoding"
 
 [dev-dependencies]
-signatory-secp256k1 = "0.19"
+signatory-secp256k1 = "0.20"

--- a/stdtx/Cargo.toml
+++ b/stdtx/Cargo.toml
@@ -22,7 +22,7 @@ prost-amino-derive = "0.5"
 rust_decimal = "1.6"
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
-sha2 = "0.8"
+sha2 = "0.9"
 thiserror = "1"
 toml = "0.5"
 


### PR DESCRIPTION
Updates:
`ecdsa` => v0.6
`hmac` => v0.8
`pbkdf2` => v0.4
`sha2` => v0.9
`signatory-secp256k1`  => v0.20