### PR TITLE
hkd32 v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "hkd32"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "getrandom",
  "hmac",

--- a/hkd32/CHANGES.md
+++ b/hkd32/CHANGES.md
@@ -1,3 +1,12 @@
+## [0.4.0] (2020-06-17)
+
+- Update `hmac` to v0.8 ([#435])
+- Update `pbkdf2` to v0.4 ([#435])
+- Update `sha2` to v0.9 ([#435])
+
+[0.4.0]: https://github.com/iqlusioninc/crates/pull/442
+[#435]: https://github.com/iqlusioninc/crates/pull/435
+
 ## [0.3.1] (2019-10-13)
 
 - Upgrade to `subtle-encoding` v0.5.0 ([#283])

--- a/hkd32/Cargo.toml
+++ b/hkd32/Cargo.toml
@@ -7,7 +7,7 @@ repeated applications of the Hash-based Message Authentication Code
 (HMAC) construction. Optionally supports storing root derivation
 passwords as a 24-word mnemonic phrase (i.e. BIP39).
 """
-version     = "0.3.1" # Also update html_root_url in lib.rs when bumping this
+version     = "0.4.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0"
 edition     = "2018"

--- a/hkd32/src/lib.rs
+++ b/hkd32/src/lib.rs
@@ -43,7 +43,7 @@
     unused_lifetimes,
     unused_qualifications
 )]
-#![doc(html_root_url = "https://docs.rs/hkd32/0.3.1")]
+#![doc(html_root_url = "https://docs.rs/hkd32/0.4.0")]
 
 #[cfg(feature = "alloc")]
 #[cfg_attr(any(feature = "bip39", test), macro_use)]


### PR DESCRIPTION
- Update `hmac` to v0.8 ([#435])
- Update `pbkdf2` to v0.4 ([#435])
- Update `sha2` to v0.9 ([#435])

[#435]: https://github.com/iqlusioninc/crates/pull/435