### PR TITLE
stdtx v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -712,7 +712,7 @@ checksum = "1cc9c640a4adbfbcc11ffb95efe5aa7af7309e002adab54b185507dbf2377b99"
 
 [[package]]
 name = "stdtx"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anomaly",
  "ecdsa",

--- a/stdtx/CHANGES.md
+++ b/stdtx/CHANGES.md
@@ -1,3 +1,32 @@
-## [0.1.0] (2020-01-27)
+# Changelog
+All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.2.0 (2020-06-18)
+### Added
+- `StdTx::new` method ([#446])
+- Derive `Copy` on `Address` ([#445])
+- `Msg::from_json_value` ([#443])
+- Impl `serde::Deserialize` for `Address` ([#439])
+
+### Changed
+- Use serde for `StdFee` serialization ([#444])
+- Have `stdtx::Builder` borrow signer ([#441])
+- Update `ecdsa`, `sha2`, `signatory-secp256k1` dependencies  ([#435])
+- Update `rust_decimal` to 1.6.0 ([#415])
+- Update `anomaly` to 0.2.0 ([#354])
+
+[#446]: https://github.com/iqlusioninc/crates/pull/446
+[#445]: https://github.com/iqlusioninc/crates/pull/445
+[#444]: https://github.com/iqlusioninc/crates/pull/444
+[#443]: https://github.com/iqlusioninc/crates/pull/443
+[#441]: https://github.com/iqlusioninc/crates/pull/441
+[#439]: https://github.com/iqlusioninc/crates/pull/439
+[#435]: https://github.com/iqlusioninc/crates/pull/435
+[#415]: https://github.com/iqlusioninc/crates/pull/415
+[#354]: https://github.com/iqlusioninc/crates/pull/354
+
+## 0.1.0 (2020-01-27)
 - Initial release

--- a/stdtx/Cargo.toml
+++ b/stdtx/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "stdtx"
 description = "Extensible schema-driven Cosmos StdTx builder and Amino serializer"
-version     = "0.1.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.2.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0"
 homepage    = "https://github.com/iqlusioninc/crates/"

--- a/stdtx/src/lib.rs
+++ b/stdtx/src/lib.rs
@@ -121,7 +121,7 @@
 //! [`yubihsm`]: https://docs.rs/yubihsm
 //! [`stdtx::Builder`]: https://docs.rs/stdtx/latest/stdtx/stdtx/struct.Builder.html
 
-#![doc(html_root_url = "https://docs.rs/stdtx/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/stdtx/0.2.0")]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 


### PR DESCRIPTION
### Added
- `StdTx::new` method ([#446])
- Derive `Copy` on `Address` ([#445])
- `Msg::from_json_value` ([#443])
- Impl `serde::Deserialize` for `Address` ([#439])

### Changed
- Use serde for `StdFee` serialization ([#444])
- Have `stdtx::Builder` borrow signer ([#441])
- Update `ecdsa`, `sha2`, `signatory-secp256k1` dependencies  ([#435])
- Update `rust_decimal` to 1.6.0 ([#415])
- Update `anomaly` to 0.2.0 ([#354])

[#446]: https://github.com/iqlusioninc/crates/pull/446
[#445]: https://github.com/iqlusioninc/crates/pull/445
[#444]: https://github.com/iqlusioninc/crates/pull/444
[#443]: https://github.com/iqlusioninc/crates/pull/443
[#441]: https://github.com/iqlusioninc/crates/pull/441
[#439]: https://github.com/iqlusioninc/crates/pull/439
[#435]: https://github.com/iqlusioninc/crates/pull/435
[#415]: https://github.com/iqlusioninc/crates/pull/415
[#354]: https://github.com/iqlusioninc/crates/pull/354