### PR TITLE
stdtx v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,7 +690,7 @@ checksum = "1cc9c640a4adbfbcc11ffb95efe5aa7af7309e002adab54b185507dbf2377b99"
 
 [[package]]
 name = "stdtx"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anomaly",
  "ecdsa",

--- a/stdtx/CHANGES.md
+++ b/stdtx/CHANGES.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.1 (2020-06-23)
+### Changed
+- Bump `prost-amino`/`prost-amino-derive` to v0.6 ([#451])
+
+[#451]: https://github.com/iqlusioninc/crates/pull/451
+
 ## 0.2.0 (2020-06-18)
 ### Added
 - `StdTx::new` method ([#446])

--- a/stdtx/Cargo.toml
+++ b/stdtx/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "stdtx"
 description = "Extensible schema-driven Cosmos StdTx builder and Amino serializer"
-version     = "0.2.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.2.1" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0"
 homepage    = "https://github.com/iqlusioninc/crates/"

--- a/stdtx/src/lib.rs
+++ b/stdtx/src/lib.rs
@@ -121,7 +121,7 @@
 //! [`yubihsm`]: https://docs.rs/yubihsm
 //! [`stdtx::Builder`]: https://docs.rs/stdtx/latest/stdtx/stdtx/struct.Builder.html
 
-#![doc(html_root_url = "https://docs.rs/stdtx/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/stdtx/0.2.1")]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 


### PR DESCRIPTION
### Changed
- Bump `prost-amino`/`prost-amino-derive` to v0.6 ([#451])

[#451]: https://github.com/iqlusioninc/crates/pull/451