### PR TITLE
secrecy v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,7 +552,7 @@ dependencies = [
 
 [[package]]
 name = "secrecy"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bytes",
  "serde",

--- a/secrecy/CHANGES.md
+++ b/secrecy/CHANGES.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (2020-07-08)
+### Added
+- Re-export zeroize ([#466])
+- `rustdoc` improvements ([#464], [#465])
+
+### Changed
+- Have `DebugSecret` take a formatter ([#467])
+- Make `FromStr` impl for `SecretString` be `Infallible` ([#323])
+
+### Fixed
+- Use `SerializableSecret` in `Serialize` bounds ([#463])
+
+[#467]: https://github.com/iqlusioninc/crates/pull/467
+[#466]: https://github.com/iqlusioninc/crates/pull/466
+[#465]: https://github.com/iqlusioninc/crates/pull/465
+[#464]: https://github.com/iqlusioninc/crates/pull/464
+[#463]: https://github.com/iqlusioninc/crates/pull/463
+[#323]: https://github.com/iqlusioninc/crates/pull/323
+
 ## 0.6.0 (2019-12-12)
 
 - Impl `CloneableSecret` for `Secret<[T; N]>` where `T: Clone` ([#311])

--- a/secrecy/Cargo.toml
+++ b/secrecy/Cargo.toml
@@ -6,7 +6,7 @@ they aren't accidentally copied, logged, or otherwise exposed
 (as much as possible), and also ensure secrets are securely wiped
 from memory when dropped.
 """
-version     = "0.6.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.7.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0 OR MIT"
 edition     = "2018"

--- a/secrecy/src/lib.rs
+++ b/secrecy/src/lib.rs
@@ -74,7 +74,7 @@
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc(html_root_url = "https://docs.rs/secrecy/0.6.0")]
+#![doc(html_root_url = "https://docs.rs/secrecy/0.7.0")]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 


### PR DESCRIPTION
### Added
- Re-export zeroize ([#466])
- `rustdoc` improvements ([#464], [#465])

### Changed
- Have `DebugSecret` take a formatter ([#467])
- Make `FromStr` impl for `SecretString` be `Infallible` ([#323])

### Fixed
- Use `SerializableSecret` in `Serialize` bounds ([#463])

[#467]: https://github.com/iqlusioninc/crates/pull/467
[#466]: https://github.com/iqlusioninc/crates/pull/466
[#465]: https://github.com/iqlusioninc/crates/pull/465
[#464]: https://github.com/iqlusioninc/crates/pull/464
[#463]: https://github.com/iqlusioninc/crates/pull/463
[#323]: https://github.com/iqlusioninc/crates/pull/323