### PR TITLE
secrecy: add From<T> impl on Secret<T>

### DIFF
--- a/secrecy/src/lib.rs
+++ b/secrecy/src/lib.rs
@@ -283,3 +283,9 @@ where
         self.expose_secret().serialize(serializer)
     }
 }
+
+impl<T: Zeroize> From<T> for Secret<T> {
+    fn from(val: T) -> Self {
+        Self::new(val)
+    }
+}


### PR DESCRIPTION
Allows `Secret<T>` to take ownership of a value retroactively.