### PR TITLE
zeroize: gate custom derive rustdoc on the `derive` feature

### DIFF
--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -73,22 +73,28 @@
 //! Example which derives `Drop`:
 //!
 //! ```
+//! # #[cfg(feature = "derive")]
+//! # {
 //! use zeroize::Zeroize;
 //!
 //! // This struct will be zeroized on drop
 //! #[derive(Zeroize)]
 //! #[zeroize(drop)]
 //! struct MyStruct([u8; 32]);
+//! # }
 //! ```
 //!
 //! Example which does not derive `Drop` (useful for e.g. `Copy` types)
 //!
 //! ```
+//! #[cfg(feature = "derive")]
+//! # {
 //! use zeroize::Zeroize;
 //!
 //! // This struct will *NOT* be zeroized on drop
 //! #[derive(Copy, Clone, Zeroize)]
 //! struct MyStruct([u8; 32]);
+//! # }
 //! ```
 //!
 //! ## `Zeroizing<Z>`: wrapper for zeroizing arbitrary values on drop


### PR DESCRIPTION
Closes #474

Adds a `#[cfg(feature = "derive")]` to the `zeroize` doctests.

This allows the doctests to pass when the feature is disabled.