### PR TITLE
stdtx: replace `signatory-secp256k1` with `k256`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2838fdd79e8776dbe07a106c784b0f8dda571a21b2750a092cc4cbaa653c8e"
+dependencies = [
+ "funty",
+ "radium",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,12 +94,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.0.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dae9c4b8fedcae85592ba623c4fd08cfdab3e3b72d6df780c6ead964a69bfff"
-
-[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,6 +108,12 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d9162b7289a46e86208d6af2c686ca5bfde445878c41a458a9fac706252d0b"
 
 [[package]]
 name = "cpuid-bool"
@@ -131,13 +142,12 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.6.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb6ba8a681d3a9c48875d277f2b11c81934ad690a60a20bcc4eef500ff68e25d"
+checksum = "765a6f9c0938fef990bb7af306fe1e534721bc52a1eb918cc938c5212d6e07eb"
 dependencies = [
  "elliptic-curve",
- "k256",
- "sha2",
+ "hmac",
  "signature",
 ]
 
@@ -149,12 +159,17 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.4.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2298f66754d859f4c099b0e645cfd258d2dfdfd1bac9496fd514d603ff6a5c6b"
+checksum = "82e7e174baa250269c92f2e0d59abaeb14c7d8072abd130dee996cc61141825a"
 dependencies = [
+ "bitvec",
+ "const-oid",
+ "digest",
+ "ff",
  "generic-array",
- "getrandom",
+ "group",
+ "rand_core",
  "subtle",
  "zeroize 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -177,6 +192,23 @@ checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
 dependencies = [
  "backtrace",
 ]
+
+[[package]]
+name = "ff"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01646e077d4ebda82b73f1bca002ea1e91561a77df2431a9e79729bcc31950ef"
+dependencies = [
+ "bitvec",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "funty"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ba62103ce691c2fd80fbae2213dfdda9ce60804973ac6b6e97de818ea7f52c8"
 
 [[package]]
 name = "generic-array"
@@ -206,6 +238,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
 
 [[package]]
+name = "group"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc11f9f5fbf1943b48ae7c2bf6846e7d827a512d1be4f23af708f5ca5d01dde1"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "harp"
 version = "0.1.0"
 dependencies = [
@@ -221,7 +264,7 @@ dependencies = [
  "lazy_static",
  "pbkdf2",
  "sha2",
- "subtle-encoding 0.5.1",
+ "subtle-encoding",
  "zeroize 1.1.1",
 ]
 
@@ -252,11 +295,14 @@ checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "k256"
-version = "0.3.0"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34f5cb67f9625a99c159fc0776e75d2e37f988cdf31c115e9c25225e61d858c"
+checksum = "be18b15cf00d98162fc37081a5098647f41168604d96174726fb1dff59c18a22"
 dependencies = [
+ "cfg-if",
+ "ecdsa",
  "elliptic-curve",
+ "sha2",
 ]
 
 [[package]]
@@ -397,6 +443,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64de9a0c5361e034f1aefc9f71a86871ec870e766fe31a009734a989b329286a"
+
+[[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,24 +545,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
-name = "secp256k1"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2932dc07acd2066ff2e3921a4419606b220ba6cd03a9935123856cc534877056"
-dependencies = [
- "secp256k1-sys",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab2c26f0d3552a0f12e639ae8a64afc2e3db9c52fe32f5fc6c289d38519f220"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "secrecy"
 version = "0.7.0"
 dependencies = [
@@ -564,50 +598,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "signatory"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c20cbcf205bedce2ce5944ab41dd2e10b1dcee2831a0a2a071806761ed6eaba"
-dependencies = [
- "ecdsa",
- "getrandom",
- "sha2",
- "signature",
- "subtle-encoding 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "signatory-secp256k1"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a50b18b66b81b859f8ee57b0e85658e1777fe2683ac37b7e756380f0a28f6e"
-dependencies = [
- "secp256k1",
- "signatory",
- "signature",
-]
-
-[[package]]
 name = "signature"
-version = "1.1.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65211b7b6fc3f14ff9fc7a2011a434e3e6880585bd2e9e9396315ae24cbf7852"
+checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
 dependencies = [
  "digest",
- "signature_derive",
-]
-
-[[package]]
-name = "signature_derive"
-version = "1.0.0-pre.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0656c180103507cca4b82519908e813225b2f6b90b2bd59ee119f46155ae872"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
+ "rand_core",
 ]
 
 [[package]]
@@ -622,14 +619,15 @@ version = "0.2.1"
 dependencies = [
  "anomaly",
  "ecdsa",
+ "k256",
  "prost-amino",
  "prost-amino-derive",
+ "rand_core",
  "rust_decimal",
  "serde",
  "serde_json",
  "sha2",
- "signatory-secp256k1",
- "subtle-encoding 0.5.1",
+ "subtle-encoding",
  "thiserror",
  "toml",
 ]
@@ -645,15 +643,6 @@ name = "subtle-encoding"
 version = "0.5.1"
 dependencies = [
  "zeroize 1.1.1",
-]
-
-[[package]]
-name = "subtle-encoding"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dcb1ed7b8330c5eed5441052651dd7a12c75e2ed88f2ec024ae1fa3a5e59945"
-dependencies = [
- "zeroize 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -786,6 +775,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "zeroize"

--- a/stdtx/Cargo.toml
+++ b/stdtx/Cargo.toml
@@ -16,7 +16,8 @@ circle-ci = { repository = "tendermint/kms" }
 
 [dependencies]
 anomaly = { version = "0.2", path = "../anomaly" }
-ecdsa = { version = "0.6", features = ["k256"] }
+ecdsa = { version = "0.8", features = ["std"] }
+k256 = { version = "0.5", features = ["ecdsa", "sha256"] }
 prost-amino = "0.6"
 prost-amino-derive = "0.6"
 rust_decimal = "1.7"
@@ -32,4 +33,4 @@ features = ["bech32-preview"]
 path = "../subtle-encoding"
 
 [dev-dependencies]
-signatory-secp256k1 = "0.20"
+rand_core = { version = "0.5", features = ["std"] }

--- a/stdtx/src/lib.rs
+++ b/stdtx/src/lib.rs
@@ -22,7 +22,8 @@
 //!
 //! ```
 //! use stdtx::Builder;
-//! use signatory_secp256k1::{SecretKey, EcdsaSigner};
+//! use k256::ecdsa::SigningKey;
+//! use rand_core::OsRng; // requires `std` feature of `rand_core`
 //!
 //! /// Example account number
 //! const ACCOUNT_NUMBER: u64 = 946827;
@@ -98,9 +99,9 @@
 //! /// boxed ECDSA secp256k1 signer
 //! let builder = stdtx::Builder::new(schema, CHAIN_ID, ACCOUNT_NUMBER);
 //!
-//! /// Create ECDSA signer (ordinarily you wouldn't generate a random key
+//! /// Create ECDSA signing key (ordinarily you wouldn't generate a random key
 //! /// every time but reuse an existing one)
-//! let signer = EcdsaSigner::from(&SecretKey::generate());
+//! let signer = SigningKey::random(&mut OsRng);
 //!
 //! /// Create message to be included in the `StdTx` using the method defined above
 //! let msg = build_vote_msg(builder.schema()).unwrap();
@@ -145,8 +146,7 @@ pub use self::{
     type_name::TypeName,
 };
 
-/// Fixed-width ECDSA secp256k1 signature
-pub use ecdsa::curve::secp256k1::FixedSignature as Signature;
+pub use k256::ecdsa::Signature;
 
 /// Transaction signer for ECDSA secp256k1 signatures
 pub type Signer = dyn ecdsa::signature::Signer<Signature>;


### PR DESCRIPTION
The `k256` crate is now capable of producing ECDSA signatures.