### PR TITLE
hkd32 v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "hkd32"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "hmac 0.10.1",
  "once_cell",

--- a/hkd32/CHANGES.md
+++ b/hkd32/CHANGES.md
@@ -1,49 +1,59 @@
-## [0.4.0] (2020-06-17)
+## 0.5.0 (2020-10-19)
+
+- Replace `getrandom` with `rand_core` ([#540])
+- Replace `lazy_static` with `once_cell` ([#539])
+- Bump `hmac` to v0.10; pbkdf2 to v0.6 ([#538])
+- MSRV 1.44+ ([#515])
+
+[#540]: https://github.com/iqlusioninc/crates/pull/540
+[#539]: https://github.com/iqlusioninc/crates/pull/539
+[#538]: https://github.com/iqlusioninc/crates/pull/538
+[#515]: https://github.com/iqlusioninc/crates/pull/515
+
+## 0.4.0 (2020-06-17)
 
 - Update `hmac` to v0.8 ([#435])
 - Update `pbkdf2` to v0.4 ([#435])
 - Update `sha2` to v0.9 ([#435])
 
-[0.4.0]: https://github.com/iqlusioninc/crates/pull/442
 [#435]: https://github.com/iqlusioninc/crates/pull/435
 
-## [0.3.1] (2019-10-13)
+## 0.3.1 (2019-10-13)
 
 - Upgrade to `subtle-encoding` v0.5.0 ([#283])
 
-## [0.3.0] (2019-10-13)
+[#283]: https://github.com/iqlusioninc/crates/pull/283
+
+## 0.3.0 (2019-10-13)
 
 - Split out `bip39` cargo feature ([#280])
 - Upgrade to `zeroize` v1.0.0 ([#279])
 
-## [0.2.0] (2019-08-20)
+[#280]: https://github.com/iqlusioninc/crates/pull/280
+[#279]: https://github.com/iqlusioninc/crates/pull/279
+
+## 0.2.0 (2019-08-20)
 
 - Vendor (simplified) BIP39 implementation from `tiny-bip39` ([#251])
 - `subtle-encoding` v0.4.0 ([#249])
 - `zeroize` v0.10.0 ([#248])
 
-## [0.1.2] (2019-07-23)
+[#251]: https://github.com/iqlusioninc/crates/pull/251
+[#249]: https://github.com/iqlusioninc/crates/pull/249
+[#248]: https://github.com/iqlusioninc/crates/pull/248
+
+## 0.1.2 (2019-07-23)
 
 - Fix docs typo ([#235])
 
-## [0.1.1] (2019-07-21)
+[#235]: https://github.com/iqlusioninc/crates/pull/235
+
+## 0.1.1 (2019-07-21)
 
 - Fix docs typo ([#232])
+
+[#232]: https://github.com/iqlusioninc/crates/pull/232
 
 ## 0.1.0 (2019-07-21)
 
 - Initial release
-
-[0.3.1]: https://github.com/iqlusioninc/crates/pull/284
-[#283]: https://github.com/iqlusioninc/crates/pull/283
-[0.3.0]: https://github.com/iqlusioninc/crates/pull/281
-[#280]: https://github.com/iqlusioninc/crates/pull/280
-[#279]: https://github.com/iqlusioninc/crates/pull/279
-[0.2.0]: https://github.com/iqlusioninc/crates/pull/252
-[#251]: https://github.com/iqlusioninc/crates/pull/251
-[#249]: https://github.com/iqlusioninc/crates/pull/249
-[#248]: https://github.com/iqlusioninc/crates/pull/248
-[0.1.2]: https://github.com/iqlusioninc/crates/pull/236
-[#235]: https://github.com/iqlusioninc/crates/pull/235
-[0.1.1]: https://github.com/iqlusioninc/crates/pull/233
-[#232]: https://github.com/iqlusioninc/crates/pull/232

--- a/hkd32/Cargo.toml
+++ b/hkd32/Cargo.toml
@@ -7,7 +7,7 @@ repeated applications of the Hash-based Message Authentication Code
 (HMAC) construction. Optionally supports storing root derivation
 passwords as a 24-word mnemonic phrase (i.e. BIP39).
 """
-version     = "0.4.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.5.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0"
 edition     = "2018"

--- a/hkd32/src/lib.rs
+++ b/hkd32/src/lib.rs
@@ -45,7 +45,7 @@
     unused_lifetimes,
     unused_qualifications
 )]
-#![doc(html_root_url = "https://docs.rs/hkd32/0.4.0")]
+#![doc(html_root_url = "https://docs.rs/hkd32/0.5.0")]
 
 #[cfg(feature = "alloc")]
 #[cfg_attr(any(feature = "bip39", test), macro_use)]


### PR DESCRIPTION
- Replace `getrandom` with `rand_core` ([#540])
- Replace `lazy_static` with `once_cell` ([#539])
- Bump `hmac` to v0.10; pbkdf2 to v0.6 ([#538])
- MSRV 1.44+ ([#515])

[#540]: https://github.com/iqlusioninc/crates/pull/540
[#539]: https://github.com/iqlusioninc/crates/pull/539
[#538]: https://github.com/iqlusioninc/crates/pull/538
[#515]: https://github.com/iqlusioninc/crates/pull/515