### PR TITLE
Add an implementation of Zeroize for Box.

### DIFF
--- a/secrecy/src/boxed.rs
+++ b/secrecy/src/boxed.rs
@@ -1,11 +1,42 @@
 //! `Box` types containing secrets
 
-use super::{DebugSecret, Secret};
+use super::{DebugSecret, ExposeSecret, Secret};
 use alloc::boxed::Box;
 use zeroize::Zeroize;
 
 /// `Box` types containing a secret value
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-pub type SecretBox<S> = Secret<Box<S>>;
+pub struct SecretBox<S: Zeroize>(Secret<Box<S>>);
 
-impl<S: DebugSecret + Zeroize> DebugSecret for Box<S> {}
+impl<S: Zeroize> SecretBox<S> {
+    /// Construct a `SecretBox` type containing a secret value
+    pub fn new(secret: S) -> Self {
+        SecretBox(Secret::new(Box::new(secret)))
+    }
+}
+
+impl<S: Zeroize> ExposeSecret<S> for SecretBox<S> {
+    fn expose_secret(&self) -> &S {
+        &**self.0.expose_secret()
+    }
+}
+
+impl<S: Zeroize> Zeroize for SecretBox<S> {
+    fn zeroize(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+impl<S: DebugSecret> DebugSecret for Box<S> {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn build_secret_box() {
+        let secret = [42_u8; 32];
+        let mut secret_box = SecretBox::new(secret);
+        secret_box.zeroize();
+        assert_eq!(secret_box.expose_secret(), &[0_u8; 32])
+    }
+}

--- a/secrecy/src/lib.rs
+++ b/secrecy/src/lib.rs
@@ -131,6 +131,15 @@ where
     }
 }
 
+impl<S> Zeroize for Secret<S>
+where
+    S: Zeroize,
+{
+    fn zeroize(&mut self) {
+        self.inner_secret.zeroize();
+    }
+}
+
 impl<S> ExposeSecret<S> for Secret<S>
 where
     S: Zeroize,
@@ -149,7 +158,7 @@ where
     }
 }
 
-impl<S> Clone for Secret<S>
+impl<S: Zeroize> Clone for Secret<S>
 where
     S: CloneableSecret,
 {
@@ -182,14 +191,14 @@ where
 }
 
 /// Marker trait for secrets which are allowed to be cloned
-pub trait CloneableSecret: Clone + Zeroize {}
+pub trait CloneableSecret: Clone {}
 
 /// Implement `CloneableSecret` on arrays of types that impl `Clone` and
 /// `Zeroize`.
 macro_rules! impl_cloneable_secret_for_array {
     ($($size:expr),+) => {
         $(
-            impl<T: Clone + Zeroize> CloneableSecret for [T; $size] {}
+            impl<T: Clone> CloneableSecret for [T; $size] {}
         )+
      };
 }

--- a/zeroize/examples/impl_zeroize.rs
+++ b/zeroize/examples/impl_zeroize.rs
@@ -1,0 +1,28 @@
+use zeroize::{DefaultIsZeroes, Zeroize};
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+struct Foo {
+    f1: u8,
+    f2: u8,
+}
+
+impl Default for Foo {
+    fn default() -> Self {
+        Foo { f1: 42, f2: 42 }
+    }
+}
+
+impl DefaultIsZeroes for Foo {}
+
+impl Zeroize for Foo {
+    fn zeroize(&mut self) {
+        self.default_zeroize();
+    }
+}
+
+fn main() {
+    let mut foo = Foo::default();
+    foo.f1 = 0;
+    foo.zeroize();
+    assert_eq!(foo, Foo::default());
+}


### PR DESCRIPTION
In the absence of specialisation, this is currently the best I could come up with. Given that in the absence of stack-bleaching `Secret` is going to be most useful as `SecretBox`, implementing `Zeroize` for `Box` is probably a priority. To stop conflicting implementations the implementation of `Zeroize` cannot be autoimplemented for `DefaultIsZeroes`.
To keep downstream users from having to use their own unsafe blocks, the zeroize crate could provide a default implementation of the method `default_zeroize`  in the `DefaultIsZeroes` trait, and implementing `Zeroize` for a concrete type means referring to the `default_zeroize` method, which could be done by a proc macro
`#[derive(ZeroizeDefault)]`.

I've written an example in the zeroize crate of how this would work.

Also, I made `SecretBox` a struct because I think type aliases are a bit awkward when not used as arguments or return values, and `SecretBox` is probably going to be constructed manually, so having a constructor is neat. I don't feel strongly about it though, so I can revert if you want.