### PR TITLE
stdtx: initial Protocol Buffers support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -109,7 +109,7 @@ jobs:
           - macos-latest
           - windows-latest
         toolchain:
-          - 1.44.0
+          - 1.45.0
           - stable
     runs-on: ${{ matrix.platform }}
     steps:
@@ -172,7 +172,7 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.45.0
           override: true
 
       - name: Install clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,6 +34,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "anomaly"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "550632e31568ae1a5f47998c3aa48563030fc49b9ec91913ca337cf64fbc5ccb"
+dependencies = [
+ "backtrace",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf8dcb5b4bbaa28653b647d8c77bd4ed40183b48882e130c1f1ffb73de069fd7"
+
+[[package]]
+name = "async-trait"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b246867b8b3b6ae56035f1eb1ed557c1d8eae97f0d53696138a50fa0e3a3b8c0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,8 +143,12 @@ version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
+ "libc",
  "num-integer",
  "num-traits",
+ "serde",
+ "time",
+ "winapi",
 ]
 
 [[package]]
@@ -154,6 +184,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8492de420e9e60bc9a1d66e2dbb91825390b738a388606600663fc529b4b307"
+dependencies = [
+ "byteorder",
+ "digest",
+ "rand_core",
+ "subtle",
+ "zeroize 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,6 +214,31 @@ dependencies = [
  "elliptic-curve",
  "hmac 0.9.0",
  "signature",
+]
+
+[[package]]
+name = "ed25519"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37c66a534cbb46ab4ea03477eae19d5c22c01da8258030280b7bd9d8433fb6ef"
+dependencies = [
+ "serde",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand",
+ "serde",
+ "serde_bytes",
+ "sha2",
+ "zeroize 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -243,6 +311,101 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ba62103ce691c2fd80fbae2213dfdda9ce60804973ac6b6e97de818ea7f52c8"
 
 [[package]]
+name = "futures"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b3b0c040a1fe6529d30b3c5944b280c7f0dcb2930d2c3062bca967b602583d0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b7109687aa4e177ef6fe84553af6280ef2778bdb7783ba44c9dc3399110fe64"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "847ce131b72ffb13b6109a221da9ad97a64cbe48feb1028356b836b47b8f1748"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4caa2b2b68b880003057c1dd49f1ed937e38f22fcf6c212188a121f08cf40a65"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "611834ce18aaa1bd13c4b374f5d653e1027cf99b6b502584ff8c9a64413b30bb"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77408a692f1f97bcc61dc001d752e00643408fbc922e4d634c655df50d595556"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f878195a49cee50e006b02b93cf7e0a95a38ac7b776b4c4d9cc1207cd20fcb3d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c554eb5bf48b2426c4771ab68c6b14468b6e76cc90996f528c3338d761a4d0d"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "futures-util"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d304cff4a7b99cfb7986f7d43fbe93d175e72e704a8860787cc95e9ffd85cbd2"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project",
+ "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,7 +423,7 @@ checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -296,7 +459,7 @@ dependencies = [
  "pbkdf2",
  "rand_core",
  "sha2",
- "subtle-encoding",
+ "subtle-encoding 0.5.1",
  "zeroize 1.1.1",
 ]
 
@@ -321,6 +484,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ibc-proto"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc4ebe4b5b45847252446d017e3414189baca08e6546090c372eea297e77d64f"
+dependencies = [
+ "anomaly 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.6",
+ "prost",
+ "prost-types",
+ "tendermint-proto 0.1.0",
+ "thiserror",
+]
+
+[[package]]
 name = "indenter"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,6 +508,15 @@ name = "itertools"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d47946d458e94a1b7bcabbf6521ea7c037062c81f534615abcad76e84d4970d"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
 dependencies = [
  "either",
 ]
@@ -391,6 +577,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,10 +634,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ccc2237c2c489783abd8c4c80e5450fc0e98644555b1364da68cc29aa151ca7"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8e8d2bf0b23038a4424865103a4df472855692821aab4e4f5c3312d461d9e5f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"
@@ -449,6 +684,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid",
+]
+
+[[package]]
+name = "prost"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
+dependencies = [
+ "bytes 0.5.6",
+ "prost-derive",
 ]
 
 [[package]]
@@ -468,11 +713,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bbb97577964b9ff334506e319a7628af460f59a6be1da592b5bdccb6a78e921"
 dependencies = [
  "failure",
- "itertools",
+ "itertools 0.7.11",
  "proc-macro2",
  "quote",
  "sha2",
  "syn",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
+dependencies = [
+ "anyhow",
+ "itertools 0.8.2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
+dependencies = [
+ "bytes 0.5.6",
+ "prost",
 ]
 
 [[package]]
@@ -617,6 +885,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -636,6 +913,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc6b7951b17b051f3210b063f12cc17320e2fe30ae05b0fe2a3abb068551c76"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -662,6 +950,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+
+[[package]]
 name = "slog"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -673,15 +967,19 @@ version = "0.4.0-pre"
 dependencies = [
  "ecdsa",
  "eyre",
+ "ibc-proto",
  "k256",
+ "prost",
  "prost-amino",
  "prost-amino-derive",
+ "prost-types",
  "rand_core",
  "rust_decimal",
  "serde",
  "serde_json",
  "sha2",
- "subtle-encoding",
+ "subtle-encoding 0.5.1",
+ "tendermint",
  "thiserror",
  "toml",
 ]
@@ -697,6 +995,15 @@ name = "subtle-encoding"
 version = "0.5.1"
 dependencies = [
  "zeroize 1.1.1",
+]
+
+[[package]]
+name = "subtle-encoding"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcb1ed7b8330c5eed5441052651dd7a12c75e2ed88f2ec024ae1fa3a5e59945"
+dependencies = [
+ "zeroize 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -747,6 +1054,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "tendermint"
+version = "0.17.0-rc3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469c73d90e4f6ae15f68e2475db9e7cd3ebcf71321d30910acefa92b83c70804"
+dependencies = [
+ "anomaly 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait",
+ "bytes 0.5.6",
+ "chrono",
+ "ed25519",
+ "ed25519-dalek",
+ "futures",
+ "num-traits",
+ "once_cell",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "serde_repr",
+ "sha2",
+ "signature",
+ "subtle",
+ "subtle-encoding 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tendermint-proto 0.17.0-rc3",
+ "thiserror",
+ "toml",
+ "zeroize 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tendermint-proto"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c4fdc9387721336d43a783b5dd2e2595708ff2454133aba79ee0270817bfe30"
+dependencies = [
+ "anomaly 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.6",
+ "prost",
+ "prost-types",
+ "thiserror",
+]
+
+[[package]]
+name = "tendermint-proto"
+version = "0.17.0-rc3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e38abad428d9414b61b20a252441a04dff48daf68e9562352f10201df5a3cb6"
+dependencies = [
+ "anomaly 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.6",
+ "chrono",
+ "num-derive",
+ "num-traits",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_bytes",
+ "subtle-encoding 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,6 +1143,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
 ]
 
 [[package]]
@@ -809,6 +1190,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,7 +1227,7 @@ checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 name = "zeroize"
 version = "1.1.1"
 dependencies = [
- "zeroize_derive",
+ "zeroize_derive 1.0.1",
 ]
 
 [[package]]
@@ -848,10 +1235,25 @@ name = "zeroize"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f33972566adbd2d3588b0491eb94b98b43695c4ef897903470ede4f3f5a28a"
+dependencies = [
+ "zeroize_derive 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "zeroize_derive"
 version = "1.0.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f369ddb18862aba61aa49bf31e74d29f0f162dec753063200e1dc084345d16"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/stdtx/Cargo.toml
+++ b/stdtx/Cargo.toml
@@ -17,7 +17,10 @@ circle-ci = { repository = "tendermint/kms" }
 [dependencies]
 ecdsa = { version = "0.8", features = ["std"] }
 eyre = "0.6"
+ibc-proto = "0.4"
 k256 = { version = "0.5", features = ["ecdsa", "sha256"] }
+prost = "0.6"
+prost-types = "0.6"
 prost-amino = { version = "0.6", optional = true }
 prost-amino-derive = { version = "0.6", optional = true }
 rust_decimal = "1.7"
@@ -25,6 +28,7 @@ serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
 sha2 = "0.9"
 subtle-encoding = { version = "0.5", features = ["bech32-preview"], path = "../subtle-encoding" }
+tendermint = "0.17.0-rc3"
 thiserror = "1"
 toml = "0.5"
 

--- a/stdtx/src/lib.rs
+++ b/stdtx/src/lib.rs
@@ -122,13 +122,14 @@
 pub mod address;
 pub mod decimal;
 pub mod error;
+pub mod proto;
 
 #[cfg(feature = "amino")]
 pub mod amino;
 
 pub use self::{address::Address, decimal::Decimal, error::Error};
 
-pub use k256::ecdsa::Signature;
+pub use k256::ecdsa::{Signature, VerifyKey};
 
-/// Transaction signer for ECDSA secp256k1 signatures
+/// Transaction signer for ECDSA/secp256k1 signatures
 pub type Signer = dyn ecdsa::signature::Signer<Signature>;

--- a/stdtx/src/proto.rs
+++ b/stdtx/src/proto.rs
@@ -1,0 +1,4 @@
+//! Protocol Buffer-encoded transaction support
+
+pub mod builder;
+pub mod msg;

--- a/stdtx/src/proto/builder.rs
+++ b/stdtx/src/proto/builder.rs
@@ -1,0 +1,127 @@
+//! Protocol Buffer-encoded transaction builder
+
+// Includes code originally from ibc-rs:
+// <https://github.com/informalsystems/ibc-rs>
+// Copyright © 2020 Informal Systems Inc.
+// Licensed under the Apache 2.0 license
+
+use super::msg::Msg;
+use crate::{Signature, VerifyKey};
+use ecdsa::signature::Signer;
+use eyre::Result;
+use ibc_proto::cosmos::tx::v1beta1::{
+    mode_info, AuthInfo, Fee, ModeInfo, SignDoc, SignerInfo, TxBody, TxRaw,
+};
+use tendermint::block;
+
+/// Protocol Buffer-encoded transaction builder
+pub struct Builder {
+    /// Chain ID
+    chain_id: String,
+
+    /// Account number to include in transactions
+    account_number: u64,
+}
+
+impl Builder {
+    /// Create a new transaction builder
+    pub fn new(chain_id: impl Into<String>, account_number: u64) -> Self {
+        Self {
+            chain_id: chain_id.into(),
+            account_number,
+        }
+    }
+
+    /// Borrow this transaction builder's chain ID
+    pub fn chain_id(&self) -> &str {
+        &self.chain_id
+    }
+
+    /// Get this transaction builder's account number
+    pub fn account_number(&self) -> u64 {
+        self.account_number
+    }
+
+    /// Build and sign a transaction containing the given messages
+    pub fn sign_tx<S>(
+        &self,
+        signer: &S,
+        sequence: u64,
+        messages: &[Msg],
+        fee: Fee,
+        memo: impl Into<String>,
+        timeout_height: block::Height,
+    ) -> Result<Vec<u8>>
+    where
+        S: Signer<Signature>,
+        VerifyKey: for<'a> From<&'a S>,
+    {
+        // Create TxBody
+        let body = TxBody {
+            messages: messages.iter().map(|msg| msg.0.clone()).collect(),
+            memo: memo.into(),
+            timeout_height: timeout_height.into(),
+            extension_options: Default::default(),
+            non_critical_extension_options: Default::default(),
+        };
+
+        // A protobuf serialization of a TxBody
+        let mut body_buf = Vec::new();
+        prost::Message::encode(&body, &mut body_buf).unwrap();
+
+        let pk = VerifyKey::from(signer);
+        let mut pk_buf = Vec::new();
+        prost::Message::encode(&pk.to_bytes().to_vec(), &mut pk_buf).unwrap();
+
+        // Create a MsgSend proto Any message
+        // TODO(tarcieri): extract proper key type
+        let pk_any = prost_types::Any {
+            type_url: "/cosmos.crypto.secp256k1.PubKey".to_string(),
+            value: Vec::from(&pk.to_bytes()[..]),
+        };
+
+        let single = mode_info::Single { mode: 1 };
+        let mode = Some(ModeInfo {
+            sum: Some(mode_info::Sum::Single(single)),
+        });
+        let signer_info = SignerInfo {
+            public_key: Some(pk_any),
+            mode_info: mode,
+            sequence,
+        };
+
+        let auth_info = AuthInfo {
+            signer_infos: vec![signer_info],
+            fee: Some(fee),
+        };
+
+        // A protobuf serialization of a AuthInfo
+        let mut auth_buf = Vec::new();
+        prost::Message::encode(&auth_info, &mut auth_buf)?;
+
+        let sign_doc = SignDoc {
+            body_bytes: body_buf.clone(),
+            auth_info_bytes: auth_buf.clone(),
+            chain_id: self.chain_id.clone(),
+            account_number: self.account_number,
+        };
+
+        // A protobuf serialization of a SignDoc
+        let mut signdoc_buf = Vec::new();
+        prost::Message::encode(&sign_doc, &mut signdoc_buf)?;
+
+        // Sign the signdoc
+        let signed = signer.sign(&signdoc_buf);
+
+        let tx_raw = TxRaw {
+            body_bytes: body_buf,
+            auth_info_bytes: auth_buf,
+            signatures: vec![signed.as_ref().to_vec()],
+        };
+
+        let mut txraw_buf = Vec::new();
+        prost::Message::encode(&tx_raw, &mut txraw_buf)?;
+
+        Ok(txraw_buf)
+    }
+}

--- a/stdtx/src/proto/msg.rs
+++ b/stdtx/src/proto/msg.rs
@@ -1,0 +1,28 @@
+//! Transaction messages
+
+use prost_types::Any;
+
+/// Transaction messages
+pub struct Msg(pub(crate) Any);
+
+impl Msg {
+    /// Create a new message type
+    pub fn new(type_url: impl Into<String>, value: impl Into<Vec<u8>>) -> Self {
+        Msg(Any {
+            type_url: type_url.into(),
+            value: value.into(),
+        })
+    }
+}
+
+impl From<Any> for Msg {
+    fn from(any: Any) -> Msg {
+        Msg(any)
+    }
+}
+
+impl From<Msg> for Any {
+    fn from(msg: Msg) -> Any {
+        msg.0
+    }
+}


### PR DESCRIPTION
Adds preliminary (untested) support for creating and signing transactions in the new Protocol Buffers-based transaction format (presently in `v1beta1` format).

Uses the `ibc-proto` crate for Protobuf definitions. Code largely adapted from `ibc-rs` (with credit).