### PR TITLE
zeroize: add support for x86(_64) SIMD registers

### DIFF
--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -29,4 +29,4 @@ alloc = []
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "-Ctarget_cpu=sandybridge"]

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -219,6 +219,9 @@ extern crate alloc;
 #[cfg_attr(docsrs, doc(cfg(feature = "zeroize_derive")))]
 pub use zeroize_derive::Zeroize;
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+mod x86;
+
 use core::{ops, ptr, slice::IterMut, sync::atomic};
 
 #[cfg(feature = "alloc")]

--- a/zeroize/src/x86.rs
+++ b/zeroize/src/x86.rs
@@ -1,0 +1,40 @@
+//! [`Zeroize`] impls for x86 SIMD registers
+
+use crate::{atomic_fence, volatile_write, Zeroize};
+
+#[cfg(target_arch = "x86")]
+use core::arch::x86::*;
+
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::*;
+
+macro_rules! impl_zeroize_for_simd_register {
+    ($type:ty, $feature:expr, $zero_value:ident) => {
+        #[cfg_attr(docsrs, doc(cfg(target_arch = "x86")))] // also `x86_64`
+        #[cfg_attr(docsrs, doc(cfg(target_feature = $feature)))]
+        impl Zeroize for $type {
+            fn zeroize(&mut self) {
+                volatile_write(self, unsafe { $zero_value() });
+                atomic_fence();
+            }
+        }
+    };
+}
+
+#[cfg(target_feature = "sse")]
+impl_zeroize_for_simd_register!(__m128, "sse", _mm_setzero_ps);
+
+#[cfg(target_feature = "sse2")]
+impl_zeroize_for_simd_register!(__m128d, "sse2", _mm_setzero_pd);
+
+#[cfg(target_feature = "sse2")]
+impl_zeroize_for_simd_register!(__m128i, "sse2", _mm_setzero_si128);
+
+#[cfg(target_feature = "avx")]
+impl_zeroize_for_simd_register!(__m256, "avx", _mm256_setzero_ps);
+
+#[cfg(target_feature = "avx")]
+impl_zeroize_for_simd_register!(__m256d, "avx", _mm256_setzero_pd);
+
+#[cfg(target_feature = "avx")]
+impl_zeroize_for_simd_register!(__m256i, "avx", _mm256_setzero_si256);


### PR DESCRIPTION
Adds `Zeroize` impls for the following x86/x86_64 SIMD register types, gated on the corresponding `target_feature`s they depend upon:

- `__m128`
- `__m128d`
- `__m128i`
- `__m256`
- `__m256d`
- `__m256i`