### PR TITLE
zeroize 1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ dependencies = [
  "digest",
  "rand_core",
  "subtle",
- "zeroize 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.1.1",
 ]
 
 [[package]]
@@ -277,7 +277,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "sha2",
- "zeroize 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.1.1",
 ]
 
 [[package]]
@@ -300,7 +300,7 @@ dependencies = [
  "group",
  "rand_core",
  "subtle",
- "zeroize 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.1.1",
 ]
 
 [[package]]
@@ -571,7 +571,7 @@ dependencies = [
  "rand_core",
  "sha2",
  "subtle-encoding 0.5.1",
- "zeroize 1.1.1",
+ "zeroize 1.2.0",
 ]
 
 [[package]]
@@ -1266,7 +1266,7 @@ version = "0.7.0"
 dependencies = [
  "bytes 0.6.0",
  "serde",
- "zeroize 1.1.1",
+ "zeroize 1.2.0",
 ]
 
 [[package]]
@@ -1432,7 +1432,7 @@ checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
 name = "subtle-encoding"
 version = "0.5.1"
 dependencies = [
- "zeroize 1.1.1",
+ "zeroize 1.2.0",
 ]
 
 [[package]]
@@ -1441,7 +1441,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dcb1ed7b8330c5eed5441052651dd7a12c75e2ed88f2ec024ae1fa3a5e59945"
 dependencies = [
- "zeroize 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.1.1",
 ]
 
 [[package]]
@@ -1474,7 +1474,7 @@ dependencies = [
  "chrono",
  "quickcheck",
  "serde",
- "zeroize 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.1.1",
 ]
 
 [[package]]
@@ -1519,7 +1519,7 @@ dependencies = [
  "tendermint-proto 0.17.0-rc3",
  "thiserror",
  "toml",
- "zeroize 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.1.1",
 ]
 
 [[package]]
@@ -1804,17 +1804,17 @@ checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 [[package]]
 name = "zeroize"
 version = "1.1.1"
-dependencies = [
- "zeroize_derive 1.0.1",
-]
-
-[[package]]
-name = "zeroize"
-version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f33972566adbd2d3588b0491eb94b98b43695c4ef897903470ede4f3f5a28a"
 dependencies = [
  "zeroize_derive 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.2.0"
+dependencies = [
+ "zeroize_derive 1.0.1",
 ]
 
 [[package]]

--- a/zeroize/CHANGES.md
+++ b/zeroize/CHANGES.md
@@ -1,3 +1,21 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 1.2.0 (2020-12-09)
+### Added
+- `Zeroize` support for x86(_64) SIMD registers ([#577])
+
+### Changed
+- Simplify `String::zeroize` ([#563])
+- MSRV 1.44+ ([#515])
+
+[#577]: https://github.com/iqlusioninc/crates/pull/577
+[#563]: https://github.com/iqlusioninc/crates/pull/563
+[#515]: https://github.com/iqlusioninc/crates/pull/515
+
 ## 1.1.1 (2020-09-15)
 
 - Add `doc_cfg`([#505])

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -7,7 +7,7 @@ operation will not be 'optimized away' by the compiler.
 Uses a portable pure Rust implementation that works everywhere,
 even WASM!
 """
-version     = "1.1.1" # Also update html_root_url in lib.rs when bumping this
+version     = "1.2.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0 OR MIT"
 edition     = "2018"
@@ -16,9 +16,6 @@ repository  = "https://github.com/iqlusioninc/crates/tree/develop/zeroize"
 readme      = "README.md"
 categories  = ["cryptography", "memory-management", "no-std", "os"]
 keywords    = ["memory", "memset", "secure", "volatile", "zero"]
-
-[badges]
-maintenance = { status = "passively-maintained" }
 
 [dependencies]
 zeroize_derive = { version = "1", path = "derive", optional = true }

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -208,7 +208,7 @@
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc(html_root_url = "https://docs.rs/zeroize/1.1.1")]
+#![doc(html_root_url = "https://docs.rs/zeroize/1.2.0")]
 #![warn(missing_docs, rust_2018_idioms, trivial_casts, unused_qualifications)]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
### Added
- `Zeroize` support for x86(_64) SIMD registers ([#577])

### Changed
- Simplify `String::zeroize` ([#563])
- MSRV 1.44+ ([#515])

[#577]: https://github.com/iqlusioninc/crates/pull/577
[#563]: https://github.com/iqlusioninc/crates/pull/563
[#515]: https://github.com/iqlusioninc/crates/pull/515