### PR TITLE
Add diesel support for secrecy, gated by the "diesel" feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,6 +193,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "diesel"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2de9deab977a153492a1468d1b1c0662c1cf39e5ea87d0c060ecd59ef18d8c"
+dependencies = [
+ "byteorder",
+ "diesel_derives",
+]
+
+[[package]]
+name = "diesel_derives"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45f5098f628d02a7a0f68ddba586fb61e80edec3bdc1be3b921f4ceec60858d3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1071,6 +1092,7 @@ name = "secrecy"
 version = "0.7.0"
 dependencies = [
  "bytes 1.0.1",
+ "diesel",
  "serde",
  "zeroize 1.2.0",
 ]

--- a/secrecy/Cargo.toml
+++ b/secrecy/Cargo.toml
@@ -20,6 +20,7 @@ keywords    = ["clear", "memory", "secret", "secure", "wipe"]
 serde = { version = "1", optional = true }
 zeroize = { version = "1.1", path = "../zeroize", default-features = false }
 bytes = { version = "1.0", optional = true }
+diesel = { version = "1.4.5", optional = true }
 
 [features]
 default = ["alloc"]

--- a/secrecy/README.md
+++ b/secrecy/README.md
@@ -40,6 +40,16 @@ accidentally make additional copies of the secret, but does the best it can
 with what it is given and tries to minimize risk of exposure as much as
 possible.
 
+## diesel support
+
+Optional `diesel` support for parsing owned secret values is available, gated
+under the `diesel` cargo feature.
+
+This doesn't guarantee `diesel` (or code providing input to `diesel`) won't
+accidentally make additional copies of the secret, but does the best it can
+with what it is given and tries to minimize risk of exposure as much as
+possible.
+
 ## License
 
 **secrecy** is distributed under the terms of either the MIT license


### PR DESCRIPTION
Diesel depends on the standard library, so enabling it will enable std too.