### PR TITLE
bip32: support for deriving extended k256::ecdsa::SigningKey

### DIFF
--- a/bip32/Cargo.toml
+++ b/bip32/Cargo.toml
@@ -15,8 +15,13 @@ keywords   = ["crypto", "bip32", "bip39", "derivation", "mnemonic"]
 bs58 = "0.4"
 hmac = "0.10"
 hkd32 = { version = "0.5", default-features = false, features = ["bip39", "mnemonic"], path = "../hkd32" }
-k256 = { version = "0.7", optional = true, default-features = false, features = ["arithmetic", "zeroize"] }
 sha2 = "0.9"
+
+[dependencies.k256]
+version = "0.7"
+optional = true
+default-features = false
+features = ["arithmetic", "ecdsa", "zeroize"]
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/bip32/src/error.rs
+++ b/bip32/src/error.rs
@@ -23,3 +23,10 @@ impl From<k256::elliptic_curve::Error> for Error {
         Error
     }
 }
+
+#[cfg(feature = "secp256k1")]
+impl From<k256::ecdsa::Error> for Error {
+    fn from(_: k256::ecdsa::Error) -> Error {
+        Error
+    }
+}

--- a/bip32/src/secret_key.rs
+++ b/bip32/src/secret_key.rs
@@ -55,3 +55,26 @@ impl SecretKey for k256::SecretKey {
             .expect("malformed public key")
     }
 }
+
+#[cfg(feature = "secp256k1")]
+impl SecretKey for k256::ecdsa::SigningKey {
+    type PublicKey = [u8; 33];
+
+    fn from_bytes(bytes: &SecretKeyBytes) -> Result<Self> {
+        Ok(k256::ecdsa::SigningKey::from_bytes(bytes)?)
+    }
+
+    fn to_bytes(&self) -> SecretKeyBytes {
+        k256::ecdsa::SigningKey::to_bytes(self).into()
+    }
+
+    fn derive_child(&self, derivation_key: &SecretKeyBytes) -> Result<Self> {
+        k256::SecretKey::from(self)
+            .derive_child(derivation_key)
+            .map(Into::into)
+    }
+
+    fn public_key(&self) -> Self::PublicKey {
+        SecretKey::public_key(&k256::SecretKey::from(self))
+    }
+}


### PR DESCRIPTION
Impls the `bip32::secret_key::SecretKey` trait for `k256::ecdsa::SigningKey`, allowing derivation of verification keys.