### PR TITLE
zeroize_derive v1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1473,7 +1473,7 @@ checksum = "81a974bcdd357f0dca4d41677db03436324d45a4c9ed2d0b873a5a360ce41c36"
 
 [[package]]
 name = "zeroize_derive"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/zeroize/derive/CHANGES.md
+++ b/zeroize/derive/CHANGES.md
@@ -1,3 +1,9 @@
+## 1.1.0 (2021-04-19)
+
+- Bump MSRV to 1.47+ ([#685])
+
+[#685]: https://github.com/iqlusioninc/crates/pull/685
+
 ## 1.0.1 (2019-09-15)
 
 - Add docs for the `Zeroize` proc macro ([#504])

--- a/zeroize/derive/Cargo.toml
+++ b/zeroize/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "zeroize_derive"
 description = "Custom derive support for zeroize"
-version     = "1.0.1"
+version     = "1.1.0"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0 OR MIT"
 edition     = "2018"


### PR DESCRIPTION
- Bump MSRV to 1.47+ ([#685])

[#685]: https://github.com/iqlusioninc/crates/pull/685