### PR TITLE
zeroize v1.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,7 +254,7 @@ dependencies = [
  "pkcs8",
  "rand_core 0.5.1",
  "subtle",
- "zeroize 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.2.0",
 ]
 
 [[package]]
@@ -469,7 +469,7 @@ dependencies = [
  "rand_core 0.5.1",
  "sha2",
  "subtle-encoding",
- "zeroize 1.2.0",
+ "zeroize 1.3.0",
 ]
 
 [[package]]
@@ -1072,7 +1072,7 @@ version = "0.7.0"
 dependencies = [
  "bytes 1.0.1",
  "serde",
- "zeroize 1.2.0",
+ "zeroize 1.3.0",
 ]
 
 [[package]]
@@ -1218,7 +1218,7 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 name = "subtle-encoding"
 version = "0.5.1"
 dependencies = [
- "zeroize 1.2.0",
+ "zeroize 1.3.0",
 ]
 
 [[package]]
@@ -1251,7 +1251,7 @@ dependencies = [
  "chrono",
  "quickcheck",
  "serde",
- "zeroize 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.2.0",
 ]
 
 [[package]]
@@ -1461,15 +1461,15 @@ checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 [[package]]
 name = "zeroize"
 version = "1.2.0"
-dependencies = [
- "zeroize_derive",
-]
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81a974bcdd357f0dca4d41677db03436324d45a4c9ed2d0b873a5a360ce41c36"
 
 [[package]]
 name = "zeroize"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a974bcdd357f0dca4d41677db03436324d45a4c9ed2d0b873a5a360ce41c36"
+version = "1.3.0"
+dependencies = [
+ "zeroize_derive",
+]
 
 [[package]]
 name = "zeroize_derive"

--- a/zeroize/CHANGES.md
+++ b/zeroize/CHANGES.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.3.0 (2021-04-19)
+### Added
+- impl `Zeroize` for `Box<[Z]>` ([#615])
+- Clear residual space within `Option` ([#687])
+
+### Changed
+- Ensure `Option` is `None` when zeroized ([#649])
+- Bump MSRV to 1.47 ([#685])
+
+[#615]: https://github.com/iqlusioninc/crates/pull/615
+[#649]: https://github.com/iqlusioninc/crates/pull/649
+[#685]: https://github.com/iqlusioninc/crates/pull/685
+[#687]: https://github.com/iqlusioninc/crates/pull/687
+
 ## 1.2.0 (2020-12-09)
 ### Added
 - `Zeroize` support for x86(_64) SIMD registers ([#577])

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -7,7 +7,7 @@ operation will not be 'optimized away' by the compiler.
 Uses a portable pure Rust implementation that works everywhere,
 even WASM!
 """
-version     = "1.2.0" # Also update html_root_url in lib.rs when bumping this
+version     = "1.3.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0 OR MIT"
 edition     = "2018"

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -208,7 +208,7 @@
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc(html_root_url = "https://docs.rs/zeroize/1.2.0")]
+#![doc(html_root_url = "https://docs.rs/zeroize/1.3.0")]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
### Added
- impl `Zeroize` for `Box<[Z]>` ([#615])
- Clear residual space within `Option` ([#687])

### Changed
- Ensure `Option` is `None` when zeroized ([#649])
- Bump MSRV to 1.47 ([#685])

[#615]: https://github.com/iqlusioninc/crates/pull/615
[#649]: https://github.com/iqlusioninc/crates/pull/649
[#685]: https://github.com/iqlusioninc/crates/pull/685
[#687]: https://github.com/iqlusioninc/crates/pull/687