### PR TITLE
iqhttp: URI serialization helpers

### DIFF
--- a/.github/workflows/iqhttp.yml
+++ b/.github/workflows/iqhttp.yml
@@ -38,4 +38,5 @@ jobs:
       - run: cargo test --release
       - run: cargo test --release --features json
       - run: cargo test --release --features proxy
+      - run: cargo test --release --features serde
       - run: cargo test --release --all-features

--- a/iqhttp/Cargo.toml
+++ b/iqhttp/Cargo.toml
@@ -21,6 +21,7 @@ edition    = "2018"
 hyper = "0.14"
 hyper-rustls = { version = "0.22", features = ["rustls-native-certs"] }
 
+# optional dependencies
 hyper-proxy = { version = "=0.9.1", optional = true } # carefully vet changes before bumping version
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }

--- a/iqhttp/src/lib.rs
+++ b/iqhttp/src/lib.rs
@@ -11,6 +11,10 @@
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
+#[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
+pub mod serializers;
+
 mod error;
 mod https_client;
 mod query;

--- a/iqhttp/src/serializers.rs
+++ b/iqhttp/src/serializers.rs
@@ -1,0 +1,56 @@
+//! Serde serialization helpers.
+
+/// Helpers for serializing fields containing a [`Uri`][`crate::Uri`].
+///
+/// Annotate fields with `#[serde(with = "iqhttp::serializers::uri)]` to use these.
+pub mod uri {
+    use crate::Uri;
+    use serde::{de, ser, Deserialize, Serialize};
+
+    /// Deserialize [`Uri`].
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Uri, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        String::deserialize(deserializer)?
+            .parse()
+            .map_err(de::Error::custom)
+    }
+
+    /// Serialize [`Uri`].
+    pub fn serialize<S>(uri: &Uri, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        uri.to_string().serialize(serializer)
+    }
+}
+
+/// Helpers for serializing fields containing an optional [`Uri`][`crate::Uri`].
+///
+/// Annotate fields with `#[serde(with = "iqhttp::serializers::uri_optional)]` to use these.
+pub mod uri_optional {
+    use crate::Uri;
+    use serde::{de, ser, Deserialize};
+
+    /// Deserialize an optional [`Uri`].
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Uri>, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        Option::<String>::deserialize(deserializer)?
+            .map(|uri| uri.parse().map_err(de::Error::custom))
+            .transpose()
+    }
+
+    /// Serialize an optional [`Uri`].
+    pub fn serialize<S>(maybe_uri: &Option<Uri>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        match maybe_uri {
+            Some(uri) => serializer.serialize_some(&uri.to_string()),
+            None => serializer.serialize_none(),
+        }
+    }
+}

--- a/mintscan/Cargo.toml
+++ b/mintscan/Cargo.toml
@@ -9,7 +9,7 @@ homepage   = "https://github.com/iqlusioninc/crates/"
 repository = "https://github.com/iqlusioninc/crates/tree/main/mintscan"
 license    = "Apache-2.0 OR MIT"
 categories = ["api-bindings", "cryptography::cryptocurrencies"]
-keywords   = ["api", "client", "cosmos", "explorer"]
+keywords   = ["api", "client", "cosmos", "explorer", "tendermint"]
 readme     = "README.md"
 edition    = "2018"
 


### PR DESCRIPTION
Unfortunately `hyper` doesn't provide `serde` serializers for `hyper::Uri` (even in the `hyper_serde` crate).

This adds a small helper annotation:

    #[serde(with = "iqhttp::serializers::uri)]

This can be added to fields to serialize/deserialize `iqhttp::Uri` (a re-export of `hyper::Uri`) using serde.