### PR TITLE
bip32: add ExtendedKey type

### DIFF
--- a/.github/workflows/bip32.yml
+++ b/.github/workflows/bip32.yml
@@ -36,6 +36,7 @@ jobs:
           override: true
           profile: minimal
       - run: cargo test --release
+      - run: cargo test --release --features zeroize
       - run: cargo test --release --all-features
 
   wasm:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,7 @@ dependencies = [
  "hmac 0.11.0",
  "k256",
  "sha2",
+ "zeroize 1.3.0",
 ]
 
 [[package]]
@@ -138,6 +139,9 @@ name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
+dependencies = [
+ "sha2",
+]
 
 [[package]]
 name = "bumpalo"

--- a/bip32/Cargo.toml
+++ b/bip32/Cargo.toml
@@ -12,10 +12,16 @@ categories  = ["cryptography", "no-std"]
 keywords    = ["crypto", "bip32", "bip39", "derivation", "mnemonic"]
 
 [dependencies]
-bs58 = "0.4"
+bs58 = { version = "0.4", default-features = false, features = ["check"] }
 hmac = "0.11"
-hkd32 = { version = "0.5", default-features = false, features = ["bip39", "mnemonic"], path = "../hkd32" }
 sha2 = "0.9"
+zeroize = { version = "1", optional = true, default-features = false, path = "../zeroize" }
+
+[dependencies.hkd32]
+version = "0.5"
+default-features = false
+features = ["bip39", "mnemonic"]
+path = "../hkd32"
 
 [dependencies.k256]
 version = "0.7"

--- a/bip32/src/extended_key.rs
+++ b/bip32/src/extended_key.rs
@@ -1,0 +1,131 @@
+//! Parser for extended key types (i.e. `xprv` and `xpub`)
+
+use crate::{ChainCode, Error, Result, KEY_SIZE};
+use core::{convert::TryInto, str::FromStr};
+
+#[cfg(feature = "zeroize")]
+use zeroize::Zeroize;
+
+/// Size of an extended key when deserialized into bytes from Base58.
+const EXTENDED_KEY_BYTES: usize = 78;
+
+/// Serialized extended key (`xprv` and `xpub`).
+pub(crate) struct ExtendedKey {
+    /// Version
+    pub version: u32,
+
+    /// Depth
+    pub depth: u8,
+
+    /// Parent fingerprint
+    pub parent_fingerprint: u32,
+
+    /// Child number
+    pub child_number: u32,
+
+    /// Chain code
+    pub chain_code: ChainCode,
+
+    /// Key material
+    pub key_bytes: [u8; KEY_SIZE],
+}
+
+impl FromStr for ExtendedKey {
+    type Err = Error;
+
+    fn from_str(base58: &str) -> Result<Self> {
+        let mut bytes = [0u8; EXTENDED_KEY_BYTES + 4];
+        let decoded_len = bs58::decode(base58)
+            .with_check(None)
+            .into(&mut bytes)
+            .map_err(|_| Error)?;
+
+        if decoded_len != EXTENDED_KEY_BYTES {
+            return Err(Error);
+        }
+
+        let version = u32::from_be_bytes(bytes[..4].try_into()?);
+        let depth = bytes[4];
+        let parent_fingerprint = u32::from_be_bytes(bytes[5..9].try_into()?);
+        let child_number = u32::from_be_bytes(bytes[9..13].try_into()?);
+        let chain_code = bytes[13..45].try_into()?;
+        let key_bytes = bytes[46..78].try_into()?;
+
+        #[cfg(feature = "zeroize")]
+        bytes.zeroize();
+
+        Ok(ExtendedKey {
+            version,
+            depth,
+            parent_fingerprint,
+            child_number,
+            chain_code,
+            key_bytes,
+        })
+    }
+}
+
+#[cfg(feature = "zeroize")]
+impl Zeroize for ExtendedKey {
+    fn zeroize(&mut self) {
+        self.version.zeroize();
+        self.depth.zeroize();
+        self.parent_fingerprint.zeroize();
+        self.child_number.zeroize();
+        self.chain_code.zeroize();
+        self.key_bytes.zeroize();
+    }
+}
+
+#[cfg(feature = "zeroize")]
+impl Drop for ExtendedKey {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+// TODO(tarcieri): consolidate test vectors
+#[cfg(test)]
+mod tests {
+    use super::ExtendedKey;
+    use hex_literal::hex;
+
+    #[test]
+    fn bip32_test_vector_1() {
+        let xprv: ExtendedKey = "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPP\
+             qjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi"
+            .parse()
+            .unwrap();
+
+        assert_eq!(xprv.version, 0x0488ADE4); // "xprv"
+        assert_eq!(xprv.depth, 0);
+        assert_eq!(xprv.parent_fingerprint, 0);
+        assert_eq!(xprv.child_number, 0);
+        assert_eq!(
+            xprv.chain_code,
+            hex!("873DFF81C02F525623FD1FE5167EAC3A55A049DE3D314BB42EE227FFED37D508")
+        );
+        assert_eq!(
+            xprv.key_bytes,
+            hex!("E8F32E723DECF4051AEFAC8E2C93C9C5B214313817CDB01A1494B917C8436B35")
+        );
+
+        let xpub: ExtendedKey = "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhe\
+             PY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8"
+            .parse()
+            .unwrap();
+
+        assert_eq!(xpub.version, 0x0488B21E);
+        assert_eq!(xpub.depth, 0);
+        assert_eq!(xpub.parent_fingerprint, 0);
+        assert_eq!(xpub.child_number, 0);
+        assert_eq!(
+            xpub.chain_code,
+            hex!("873DFF81C02F525623FD1FE5167EAC3A55A049DE3D314BB42EE227FFED37D508")
+        );
+        assert_eq!(
+            xpub.key_bytes,
+            hex!("39A36013301597DAEF41FBE593A02CC513D0B55527EC2DF1050E2E8FF49C85C2")
+        );
+    }
+}

--- a/bip32/src/extended_secret_key.rs
+++ b/bip32/src/extended_secret_key.rs
@@ -1,7 +1,8 @@
 //! Extended secret keys
 
 use crate::{
-    secret_key::SecretKey, ChainCode, ChildNumber, DerivationPath, Error, Result, KEY_SIZE,
+    extended_key::ExtendedKey, secret_key::SecretKey, ChainCode, ChildNumber, DerivationPath,
+    Error, Result, KEY_SIZE,
 };
 use core::{convert::TryInto, str::FromStr};
 use hkd32::BIP39_BASE_DERIVATION_KEY;
@@ -108,18 +109,13 @@ where
 {
     type Err = Error;
 
-    // TODO(tarcieri): yprv, zprv
     fn from_str(xprv: &str) -> Result<Self> {
-        let data = bs58::decode(xprv).into_vec().map_err(|_| Error)?;
+        let decoded = ExtendedKey::from_str(xprv)?;
 
-        if data.len() == 82 {
-            Ok(ExtendedSecretKey {
-                chain_code: data[13..45].try_into()?,
-                secret_key: SecretKey::from_bytes(data[46..78].try_into()?)?,
-                depth: data[4],
-            })
-        } else {
-            Err(Error)
-        }
+        Ok(Self {
+            chain_code: decoded.chain_code,
+            secret_key: SecretKey::from_bytes(&decoded.key_bytes)?,
+            depth: decoded.depth,
+        })
     }
 }

--- a/bip32/src/lib.rs
+++ b/bip32/src/lib.rs
@@ -5,14 +5,16 @@
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![deny(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc(html_root_url = "https://docs.rs/bip32/0.0.0")]
+#![deny(missing_docs, rust_2018_idioms, unused_qualifications)]
+#![forbid(unsafe_code, clippy::unwrap_used)]
 
 extern crate alloc;
 
 mod child_number;
 mod derivation_path;
 mod error;
+mod extended_key;
 mod extended_secret_key;
 mod secret_key;
 


### PR DESCRIPTION
Extracts xpub/xprv parsing into an `ExtendedKey` type which handles Base58Check decoding and parsing of the encoded fields.