### PR TITLE
hkd32: namespace Seed::SIZE; expose [u8; 64]

### DIFF
--- a/bip32/src/extended_secret_key.rs
+++ b/bip32/src/extended_secret_key.rs
@@ -5,7 +5,7 @@ use crate::{
     Error, Result, KEY_SIZE,
 };
 use core::{convert::TryInto, str::FromStr};
-use hkd32::BIP39_BASE_DERIVATION_KEY;
+use hkd32::mnemonic::{Seed, BIP39_DOMAIN_SEPARATOR};
 use hmac::{Hmac, Mac, NewMac};
 use sha2::Sha512;
 
@@ -33,10 +33,13 @@ where
     pub const MAX_DEPTH: Depth = u8::MAX;
 
     /// Derive a child key from the given [`DerivationPath`].
-    pub fn derive_child_from_path(seed: &[u8], path: &DerivationPath) -> Result<Self> {
+    pub fn derive_child_from_path<S>(seed: S, path: &DerivationPath) -> Result<Self>
+    where
+        S: AsRef<[u8; Seed::SIZE]>,
+    {
         // TODO(tarcieri): unify this with the equivalent logic in `hkd32`
-        let mut hmac = Hmac::<Sha512>::new_from_slice(&BIP39_BASE_DERIVATION_KEY)?;
-        hmac.update(seed);
+        let mut hmac = Hmac::<Sha512>::new_from_slice(&BIP39_DOMAIN_SEPARATOR)?;
+        hmac.update(seed.as_ref());
 
         let result = hmac.finalize().into_bytes();
         let (secret_key, chain_code) = result.split_at(KEY_SIZE);

--- a/hkd32/src/lib.rs
+++ b/hkd32/src/lib.rs
@@ -52,6 +52,7 @@ pub mod mnemonic;
 
 mod key_material;
 mod path;
+
 #[cfg(feature = "alloc")]
 mod pathbuf;
 
@@ -59,10 +60,6 @@ pub use self::{key_material::*, path::*};
 
 #[cfg(feature = "alloc")]
 pub use self::pathbuf::PathBuf;
-
-#[cfg(feature = "bip39")]
-#[cfg_attr(docsrs, doc(cfg(feature = "bip39")))]
-pub use self::mnemonic::seed::BIP39_BASE_DERIVATION_KEY;
 
 /// Delimiter used for strings containing paths
 pub const DELIMITER: char = '/';

--- a/hkd32/src/mnemonic.rs
+++ b/hkd32/src/mnemonic.rs
@@ -8,9 +8,11 @@
 mod bits;
 mod language;
 mod phrase;
+
 #[cfg(feature = "bip39")]
 pub(crate) mod seed;
 
-#[cfg(feature = "bip39")]
-pub use self::seed::Seed;
 pub use self::{language::Language, phrase::Phrase};
+
+#[cfg(feature = "bip39")]
+pub use self::seed::{Seed, BIP39_DOMAIN_SEPARATOR};

--- a/hkd32/src/mnemonic/phrase.rs
+++ b/hkd32/src/mnemonic/phrase.rs
@@ -12,11 +12,7 @@ use sha2::{Digest, Sha256};
 use zeroize::{Zeroize, Zeroizing};
 
 #[cfg(feature = "bip39")]
-use {
-    super::seed::{Seed, SEED_SIZE},
-    hmac::Hmac,
-    sha2::Sha512,
-};
+use {super::seed::Seed, hmac::Hmac, sha2::Sha512};
 
 /// Number of PBKDF2 rounds to perform when deriving the seed
 #[cfg(feature = "bip39")]
@@ -147,7 +143,7 @@ impl Phrase {
     #[cfg_attr(docsrs, doc(cfg(feature = "bip39")))]
     pub fn to_seed(&self, password: &str) -> Seed {
         let salt = Zeroizing::new(format!("mnemonic{}", password));
-        let mut seed = [0u8; SEED_SIZE];
+        let mut seed = [0u8; Seed::SIZE];
         pbkdf2::pbkdf2::<Hmac<Sha512>>(
             &self.phrase.as_bytes(),
             salt.as_bytes(),

--- a/hkd32/src/mnemonic/seed.rs
+++ b/hkd32/src/mnemonic/seed.rs
@@ -5,27 +5,28 @@ use hmac::{Hmac, Mac, NewMac};
 use sha2::Sha512;
 use zeroize::Zeroize;
 
-/// Base derivation secret for BIP39 keys
-pub const BIP39_BASE_DERIVATION_KEY: [u8; 12] = [
+/// Base derivation secret for BIP39 keys.
+#[cfg_attr(docsrs, doc(cfg(feature = "bip39")))]
+pub const BIP39_DOMAIN_SEPARATOR: [u8; 12] = [
     0x42, 0x69, 0x74, 0x63, 0x6f, 0x69, 0x6e, 0x20, 0x73, 0x65, 0x65, 0x64,
 ];
 
-/// Number of bytes of PBKDF2 output to extract
-pub const SEED_SIZE: usize = 64;
-
 /// BIP39 seeds.
 #[cfg_attr(docsrs, doc(cfg(feature = "bip39")))]
-pub struct Seed(pub(crate) [u8; SEED_SIZE]);
+pub struct Seed(pub(crate) [u8; Seed::SIZE]);
 
 impl Seed {
+    /// Number of bytes of PBKDF2 output to extract.
+    pub const SIZE: usize = 64;
+
     /// Get the inner secret byte slice
-    pub fn as_bytes(&self) -> &[u8] {
+    pub fn as_bytes(&self) -> &[u8; Seed::SIZE] {
         &self.0
     }
 
     /// Derive a BIP32 subkey from this seed
     pub fn derive_subkey(self, path: impl AsRef<Path>) -> KeyMaterial {
-        let mut hmac = Hmac::<Sha512>::new_from_slice(&BIP39_BASE_DERIVATION_KEY)
+        let mut hmac = Hmac::<Sha512>::new_from_slice(&BIP39_DOMAIN_SEPARATOR)
             .expect("HMAC key size incorrect");
         hmac.update(&self.0);
 
@@ -33,6 +34,12 @@ impl Seed {
         let root_key = KeyMaterial::from_bytes(&hmac.finalize().into_bytes()[KEY_SIZE..]).unwrap();
 
         root_key.derive_subkey(path)
+    }
+}
+
+impl AsRef<[u8; Seed::SIZE]> for Seed {
+    fn as_ref(&self) -> &[u8; Seed::SIZE] {
+        self.as_bytes()
     }
 }
 


### PR DESCRIPTION
Moves the `SEED_SIZE` constant to `Seed::SIZE`, and exposes a sized array (`[u8; 64]`) from the `as_bytes()` method.

Additionally adds an `AsRef` impl on `Seed`, and bounds the `bip32` crate's `ExtendedSecretKey` derivation on a seed-sized value.

Finally, it renames `BIP39_DOMAIN_SEPARATOR` as it's a non-secret value.