### PR TITLE
bip32: extract Version enum, add impls, and additional tests

### DIFF
--- a/bip32/src/child_number.rs
+++ b/bip32/src/child_number.rs
@@ -8,7 +8,7 @@ const HARDENED_FLAG: u32 = 1 << 31;
 
 /// Index of a particular child key for a given (extended) secret key.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub struct ChildNumber(u32);
+pub struct ChildNumber(pub u32);
 
 impl ChildNumber {
     /// Is this child number within the hardened range?
@@ -19,6 +19,18 @@ impl ChildNumber {
     /// Serialize this child number as bytes.
     pub fn to_bytes(self) -> [u8; 4] {
         self.0.to_be_bytes()
+    }
+}
+
+impl From<u32> for ChildNumber {
+    fn from(n: u32) -> ChildNumber {
+        ChildNumber(n)
+    }
+}
+
+impl From<ChildNumber> for u32 {
+    fn from(n: ChildNumber) -> u32 {
+        n.0
     }
 }
 

--- a/bip32/src/error.rs
+++ b/bip32/src/error.rs
@@ -18,6 +18,7 @@ impl From<hmac::crypto_mac::InvalidKeyLength> for Error {
 }
 
 #[cfg(feature = "secp256k1")]
+#[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
 impl From<k256::elliptic_curve::Error> for Error {
     fn from(_: k256::elliptic_curve::Error) -> Error {
         Error
@@ -25,6 +26,7 @@ impl From<k256::elliptic_curve::Error> for Error {
 }
 
 #[cfg(feature = "secp256k1")]
+#[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
 impl From<k256::ecdsa::Error> for Error {
     fn from(_: k256::ecdsa::Error) -> Error {
         Error

--- a/bip32/src/lib.rs
+++ b/bip32/src/lib.rs
@@ -6,8 +6,8 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(html_root_url = "https://docs.rs/bip32/0.0.0")]
-#![deny(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![forbid(unsafe_code, clippy::unwrap_used)]
+#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
 extern crate alloc;
 
@@ -15,14 +15,16 @@ mod child_number;
 mod derivation_path;
 mod error;
 mod extended_key;
-mod extended_secret_key;
-mod secret_key;
+mod extended_private_key;
+mod private_key;
+mod version;
 
 pub use self::{
     child_number::ChildNumber,
     derivation_path::DerivationPath,
     error::{Error, Result},
-    extended_secret_key::{Depth, ExtendedSecretKey},
+    extended_private_key::{Depth, ExtendedPrivateKey},
+    version::Version,
 };
 pub use hkd32::{
     mnemonic::{Language, Phrase as Mnemonic, Seed},
@@ -30,8 +32,14 @@ pub use hkd32::{
 };
 
 #[cfg(feature = "secp256k1")]
+#[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
 pub use k256 as secp256k1;
 
 /// Chain code: extension for both private and public keys which provides an
 /// additional 256-bits of entropy.
 pub type ChainCode = [u8; KEY_SIZE];
+
+/// Extended private secp256k1 ECDSA signing key.
+#[cfg(feature = "secp256k1")]
+#[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
+pub type XPrv = ExtendedPrivateKey<secp256k1::ecdsa::SigningKey>;

--- a/bip32/src/private_key.rs
+++ b/bip32/src/private_key.rs
@@ -5,8 +5,8 @@ use crate::{Result, KEY_SIZE};
 /// Bytes which represent a secret key.
 type SecretKeyBytes = [u8; KEY_SIZE];
 
-/// Derive a child key for this key.
-pub trait SecretKey: Sized {
+/// Trait for key types which can be derived using BIP32.
+pub trait PrivateKey: Sized {
     /// Serialized public key type.
     type PublicKey: AsRef<[u8]> + Sized;
 
@@ -24,7 +24,8 @@ pub trait SecretKey: Sized {
 }
 
 #[cfg(feature = "secp256k1")]
-impl SecretKey for k256::SecretKey {
+#[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
+impl PrivateKey for k256::SecretKey {
     type PublicKey = [u8; 33];
 
     fn from_bytes(bytes: &SecretKeyBytes) -> Result<Self> {
@@ -57,7 +58,8 @@ impl SecretKey for k256::SecretKey {
 }
 
 #[cfg(feature = "secp256k1")]
-impl SecretKey for k256::ecdsa::SigningKey {
+#[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
+impl PrivateKey for k256::ecdsa::SigningKey {
     type PublicKey = [u8; 33];
 
     fn from_bytes(bytes: &SecretKeyBytes) -> Result<Self> {
@@ -75,6 +77,6 @@ impl SecretKey for k256::ecdsa::SigningKey {
     }
 
     fn public_key(&self) -> Self::PublicKey {
-        SecretKey::public_key(&k256::SecretKey::from(self))
+        PrivateKey::public_key(&k256::SecretKey::from(self))
     }
 }

--- a/bip32/src/version.rs
+++ b/bip32/src/version.rs
@@ -1,0 +1,83 @@
+//! Version support.
+
+use crate::{Error, Result};
+use core::convert::{TryFrom, TryInto};
+
+/// BIP32 versions are the leading prefix of a Base58-encoded extended key
+/// interpreted as a 32-bit big endian integer after decoding.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum Version {
+    /// Mainnet public key.
+    XPub,
+
+    /// Mainnet private key.
+    XPrv,
+
+    /// Testnet public key.
+    TPub,
+
+    /// Testnet private key.
+    TPrv,
+
+    /// Other types of keys.
+    Other(u32),
+}
+
+impl Version {
+    /// Is this a mainnet key?
+    pub fn is_mainnet(self) -> bool {
+        matches!(self, Version::XPub | Version::XPrv)
+    }
+
+    /// Is this a testnet key?
+    pub fn is_testnet(self) -> bool {
+        matches!(self, Version::TPub | Version::TPrv)
+    }
+
+    /// Is this a public key?
+    pub fn is_public(self) -> bool {
+        matches!(self, Version::XPub | Version::TPub)
+    }
+
+    /// Is this a private key?
+    pub fn is_private(self) -> bool {
+        matches!(self, Version::XPrv | Version::TPrv)
+    }
+}
+
+impl From<u32> for Version {
+    fn from(n: u32) -> Version {
+        match n {
+            // `xpub` (mainnet public)
+            0x0488B21E => Version::XPub,
+            // `xprv` (mainnet private)
+            0x0488ADE4 => Version::XPrv,
+            // `tpub` (testnet public)
+            0x043587CF => Version::TPub,
+            // `tprv` (testnet private)
+            0x04358394 => Version::TPrv,
+            _ => Version::Other(n),
+        }
+    }
+}
+
+impl From<Version> for u32 {
+    fn from(v: Version) -> u32 {
+        match v {
+            Version::XPub => 0x0488B21E,
+            Version::XPrv => 0x0488ADE4,
+            Version::TPub => 0x043587CF,
+            Version::TPrv => 0x04358394,
+            Version::Other(n) => n,
+        }
+    }
+}
+
+impl TryFrom<&[u8]> for Version {
+    type Error = Error;
+
+    fn try_from(bytes: &[u8]) -> Result<Version> {
+        Ok(u32::from_be_bytes(bytes.try_into()?).into())
+    }
+}

--- a/hkd32/src/lib.rs
+++ b/hkd32/src/lib.rs
@@ -40,8 +40,8 @@
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![deny(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc(html_root_url = "https://docs.rs/hkd32/0.5.0")]
+#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
 #[cfg(feature = "alloc")]
 #[cfg_attr(any(feature = "bip39", test), macro_use)]

--- a/hkd32/src/mnemonic/seed.rs
+++ b/hkd32/src/mnemonic/seed.rs
@@ -19,6 +19,11 @@ impl Seed {
     /// Number of bytes of PBKDF2 output to extract.
     pub const SIZE: usize = 64;
 
+    /// Create a new seed from the given bytes.
+    pub fn new(bytes: [u8; Seed::SIZE]) -> Self {
+        Seed(bytes)
+    }
+
     /// Get the inner secret byte slice
     pub fn as_bytes(&self) -> &[u8; Seed::SIZE] {
         &self.0


### PR DESCRIPTION
- Adds a `Version` enum for parsing the leading version bytes in an extended key (e.g. `xprv` vs `xpub`)
- Uses "private key" nomenclature so as to better match the BIP32 spec
- Adds `From` impls and methods providing more granular creation and/or conversion of `ChildNumber`s and `ExtendedPrivateKey`
- Adds `XPrv` alias for `ExtendedPrivateKey<k256::ecdsa::SigningKey>`
- Tests that the derived root `XPrv` for a given seed matches the `XPrv` parsed from a string in the test vectors