### PR TITLE
bip32: standardize on "private key" nomenclature

### DIFF
--- a/bip32/src/child_number.rs
+++ b/bip32/src/child_number.rs
@@ -6,7 +6,7 @@ use core::str::FromStr;
 /// Hardened child keys use indices 2^31 through 2^32-1.
 const HARDENED_FLAG: u32 = 1 << 31;
 
-/// Index of a particular child key for a given (extended) secret key.
+/// Index of a particular child key for a given (extended) private key.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub struct ChildNumber(pub u32);
 

--- a/bip32/tests/bip39_vectors.rs
+++ b/bip32/tests/bip39_vectors.rs
@@ -97,8 +97,8 @@ fn test_xprv() {
 
         // TODO(tarcieri): `Eq` impl for `ExtendedPrivateKey`? (using `subtle` behind the scenes)
         assert_eq!(
-            expected_xprv.secret_key().to_bytes(),
-            derived_xprv.secret_key().to_bytes()
+            expected_xprv.private_key().to_bytes(),
+            derived_xprv.private_key().to_bytes()
         );
         assert_eq!(expected_xprv.chain_code(), derived_xprv.chain_code());
         assert_eq!(expected_xprv.depth(), derived_xprv.depth());


### PR DESCRIPTION
Changes existing references to "secret key" (as used in the RustCrypto crates, notably `k256`) to "private key" exclusively, so as to better match the BIP32 spec's nomenclature.