### PR TITLE
bip32: reduce secp256k1 keys mod n

### DIFF
--- a/bip32/src/extended_private_key.rs
+++ b/bip32/src/extended_private_key.rs
@@ -60,7 +60,7 @@ where
         let (secret_key, chain_code) = result.split_at(KEY_SIZE);
 
         Ok(ExtendedPrivateKey {
-            private_key: PrivateKey::from_bytes(secret_key.try_into()?)?,
+            private_key: PrivateKey::from_bytes(secret_key.try_into()?).ok_or(Error)?,
             chain_code: chain_code.try_into()?,
             depth: 0,
         })
@@ -136,7 +136,7 @@ where
         if extended_key.version.is_private() {
             Ok(Self {
                 chain_code: extended_key.chain_code,
-                private_key: PrivateKey::from_bytes(&extended_key.key_bytes)?,
+                private_key: PrivateKey::from_bytes(&extended_key.key_bytes).ok_or(Error)?,
                 depth: extended_key.depth,
             })
         } else {


### PR DESCRIPTION
The BIP32 spec is somewhat ambiguous as to how modular reductions of keys are to be handled, and does not appear to stipulate any special handling of a key of all zeroes.

Based on the following remarks in the spec:

> Split I into two 32-byte sequences, IL and IR.
> The returned child key ki is parse256(IL) + kpar (mod n).

...it is assumed that all scalars are derived via a "narrow" modular reduction (i.e. 256-bit input), and that there is no special handling of the case of all zeroes.

This commit implements this approach in the `PrivateKey::from_bytes` method, reducing secp256k1 scalars.

For simplicity's sake, at least for now this same behavior is applied to parsed `xprv` keys, which are allowed to overflow the curve's order and are reduced by this API (as opposed to being rejected), but perhaps that should be revisited.

The `elliptic_curve::SecretKey` type rejects a key of all zeroes, however, and this is still reflected in the new `PublicKey::from_bytes` API, which returns `None` if it so happens to derive a key of all zeroes.