### PR TITLE
Zeroizing::clone_from now zeroizes the destination before cloning

### DIFF
--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -458,7 +458,7 @@ impl<Z: Zeroize + Clone> Clone for Zeroizing<Z> {
 
     fn clone_from(&mut self, source: &Self) {
         self.0.zeroize();
-        self.0.clone_from(source.0);
+        self.0.clone_from(&source.0);
     }
 }
 

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -437,7 +437,7 @@ pub trait TryZeroize {
 
 /// `Zeroizing` is a a wrapper for any `Z: Zeroize` type which implements a
 /// `Drop` handler which zeroizes dropped values.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct Zeroizing<Z: Zeroize>(Z);
 
 impl<Z> Zeroizing<Z>
@@ -448,6 +448,17 @@ where
     /// zeroized when it's dropped.
     pub fn new(value: Z) -> Self {
         value.into()
+    }
+}
+
+impl<Z: Zeroize + Clone> Clone for Zeroizing<Z> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+
+    fn clone_from(&mut self, source: &Self) {
+        self.0.zeroize();
+        self.0.clone_from(source.0);
     }
 }
 


### PR DESCRIPTION
This PR adds a custom `Clone` implementation that zeroizes before cloning via `clone_from`. For most types, this will have no effect, since by default `clone_from` is defined as `*self = other.clone()`, which invokes the zeroizing destructor before the assignment. However, many allocating types like `String` and `Vec` specialize `clone_from` so that it reuses allocated storage in place. This MR will ensure that such specializations still zeroize the old data before reusing that storage.