### PR TITLE
bip32: make `Error` into an enum

### DIFF
--- a/bip32/Cargo.toml
+++ b/bip32/Cargo.toml
@@ -35,6 +35,7 @@ hex-literal = "0.3"
 [features]
 default = ["secp256k1"]
 secp256k1 = ["k256"]
+std = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/bip32/src/child_number.rs
+++ b/bip32/src/child_number.rs
@@ -43,12 +43,12 @@ impl FromStr for ChildNumber {
             None => (child, 0),
         };
 
-        let index = child.parse::<u32>().map_err(|_| Error)?;
+        let index = child.parse::<u32>().map_err(|_| Error::Decode)?;
 
         if index & HARDENED_FLAG == 0 {
             Ok(ChildNumber(index | mask))
         } else {
-            Err(Error)
+            Err(Error::Decode)
         }
     }
 }

--- a/bip32/src/derivation_path.rs
+++ b/bip32/src/derivation_path.rs
@@ -17,7 +17,7 @@ impl FromStr for DerivationPath {
         let mut path = path.split('/');
 
         if path.next() != Some("m") {
-            return Err(Error);
+            return Err(Error::Decode);
         }
 
         Ok(DerivationPath {

--- a/bip32/src/error.rs
+++ b/bip32/src/error.rs
@@ -1,31 +1,62 @@
-/// Error type.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct Error;
+//! Error type.
+
+use core::fmt::{self, Display};
 
 /// Result type.
 pub type Result<T> = core::result::Result<T, Error>;
 
+/// Error type.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Error {
+    /// Base58 errors.
+    Base58,
+
+    /// Cryptographic errors.
+    Crypto,
+
+    /// Decoding errors (not related to Base58).
+    Decode,
+
+    /// Maximum derivation depth exceeded.
+    Depth,
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Base58 => f.write_str("base58 error"),
+            Error::Crypto => f.write_str("cryptographic error"),
+            Error::Decode => f.write_str("decoding error"),
+            Error::Depth => f.write_str("maximum derivation depth exceeded"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl std::error::Error for Error {}
+
 impl From<bs58::decode::Error> for Error {
     fn from(_: bs58::decode::Error) -> Error {
-        Error
+        Error::Base58
     }
 }
 
 impl From<bs58::encode::Error> for Error {
     fn from(_: bs58::encode::Error) -> Error {
-        Error
+        Error::Base58
     }
 }
 
 impl From<core::array::TryFromSliceError> for Error {
     fn from(_: core::array::TryFromSliceError) -> Error {
-        Error
+        Error::Decode
     }
 }
 
 impl From<hmac::crypto_mac::InvalidKeyLength> for Error {
     fn from(_: hmac::crypto_mac::InvalidKeyLength) -> Error {
-        Error
+        Error::Crypto
     }
 }
 
@@ -33,7 +64,7 @@ impl From<hmac::crypto_mac::InvalidKeyLength> for Error {
 #[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
 impl From<k256::elliptic_curve::Error> for Error {
     fn from(_: k256::elliptic_curve::Error) -> Error {
-        Error
+        Error::Crypto
     }
 }
 
@@ -41,6 +72,6 @@ impl From<k256::elliptic_curve::Error> for Error {
 #[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
 impl From<k256::ecdsa::Error> for Error {
     fn from(_: k256::ecdsa::Error) -> Error {
-        Error
+        Error::Crypto
     }
 }

--- a/bip32/src/extended_key.rs
+++ b/bip32/src/extended_key.rs
@@ -45,10 +45,10 @@ impl FromStr for ExtendedKey {
         let decoded_len = bs58::decode(base58).with_check(None).into(&mut bytes)?;
 
         if decoded_len != Self::BYTE_SIZE {
-            return Err(Error);
+            return Err(Error::Decode);
         }
 
-        let prefix = base58.get(..4).ok_or(Error).and_then(|chars| {
+        let prefix = base58.get(..4).ok_or(Error::Decode).and_then(|chars| {
             Prefix::validate_str(chars)?;
             let version = Version::from_be_bytes(bytes[..4].try_into()?);
             Ok(Prefix::from_parts_unchecked(chars, version))

--- a/bip32/src/extended_private_key.rs
+++ b/bip32/src/extended_private_key.rs
@@ -68,7 +68,8 @@ where
 
     /// Derive a child key for a particular [`ChildNumber`].
     pub fn derive_child(&self, child: ChildNumber) -> Result<Self> {
-        let mut hmac: Hmac<Sha512> = Hmac::new_from_slice(&self.chain_code).map_err(|_| Error)?;
+        let mut hmac =
+            Hmac::<Sha512>::new_from_slice(&self.chain_code).map_err(|_| Error::Crypto)?;
 
         if child.is_hardened() {
             hmac.update(&[0]);
@@ -85,7 +86,7 @@ where
         Ok(ExtendedPrivateKey {
             private_key: self.private_key.derive_child(secret_key.try_into()?)?,
             chain_code: chain_code.try_into()?,
-            depth: self.depth.checked_add(1).ok_or(Error)?,
+            depth: self.depth.checked_add(1).ok_or(Error::Depth)?,
         })
     }
 
@@ -140,7 +141,7 @@ where
                 depth: extended_key.depth,
             })
         } else {
-            Err(Error)
+            Err(Error::Crypto)
         }
     }
 }

--- a/bip32/src/lib.rs
+++ b/bip32/src/lib.rs
@@ -11,6 +11,9 @@
 
 extern crate alloc;
 
+#[cfg(feature = "std")]
+extern crate std;
+
 mod child_number;
 mod derivation_path;
 mod error;

--- a/bip32/src/prefix.rs
+++ b/bip32/src/prefix.rs
@@ -93,7 +93,7 @@ impl Prefix {
         let mut buffer = [0u8; ExtendedKey::MAX_BASE58_SIZE];
         bs58::encode(&bytes).with_check().into(buffer.as_mut())?;
 
-        let s = str::from_utf8(&buffer[..4]).map_err(|_| Error)?;
+        let s = str::from_utf8(&buffer[..4]).map_err(|_| Error::Decode)?;
         Self::validate_str(s)?;
         Ok(Self::from_parts_unchecked(s, version))
     }
@@ -122,7 +122,7 @@ impl Prefix {
     // TODO(tarcieri): validate the string ends with `prv` or `pub`?
     pub(crate) const fn validate_str(s: &str) -> Result<&str> {
         if s.as_bytes().len() != Self::LENGTH {
-            return Err(Error);
+            return Err(Error::Decode);
         }
 
         let mut i = 0;
@@ -131,7 +131,7 @@ impl Prefix {
             if matches!(s.as_bytes()[i], b'a'..=b'z' | b'A'..=b'Z') {
                 i += 1;
             } else {
-                return Err(Error);
+                return Err(Error::Decode);
             }
         }
 

--- a/bip32/src/private_key.rs
+++ b/bip32/src/private_key.rs
@@ -2,6 +2,9 @@
 
 use crate::{Result, KEY_SIZE};
 
+#[cfg(feature = "secp256k1")]
+use crate::Error;
+
 /// Bytes which represent a private key.
 type KeyBytes = [u8; KEY_SIZE];
 
@@ -42,7 +45,7 @@ impl PrivateKey for k256::SecretKey {
 
         k256::NonZeroScalar::new(derived_scalar)
             .map(Self::new)
-            .ok_or(crate::Error)
+            .ok_or(Error::Crypto)
     }
 
     fn public_key(&self) -> Self::PublicKey {


### PR DESCRIPTION
Retrofits the `Error` type to be an enum that can distinguish between various different cases like decoding errors and cryptographic errors.