### PR TITLE
bip32: support for serializing `ExtendedKey` as Base58Check

### DIFF
--- a/bip32/src/extended_private_key.rs
+++ b/bip32/src/extended_private_key.rs
@@ -174,10 +174,10 @@ where
     type Error = Error;
 
     fn try_from(extended_key: ExtendedKey) -> Result<ExtendedPrivateKey<K>> {
-        if extended_key.prefix.is_private() {
+        if extended_key.prefix.is_private() && extended_key.key_bytes[0] == 0 {
             Ok(Self {
                 chain_code: extended_key.chain_code,
-                private_key: PrivateKey::from_bytes(&extended_key.key_bytes)?,
+                private_key: PrivateKey::from_bytes(extended_key.key_bytes[1..].try_into()?)?,
                 depth: extended_key.depth,
             })
         } else {

--- a/bip32/src/prefix.rs
+++ b/bip32/src/prefix.rs
@@ -93,7 +93,7 @@ impl Prefix {
         let mut buffer = [0u8; ExtendedKey::MAX_BASE58_SIZE];
         bs58::encode(&bytes).with_check().into(buffer.as_mut())?;
 
-        let s = str::from_utf8(&buffer[..4]).map_err(|_| Error::Decode)?;
+        let s = str::from_utf8(&buffer[..4]).map_err(|_| Error::Base58)?;
         Self::validate_str(s)?;
         Ok(Self::from_parts_unchecked(s, version))
     }
@@ -113,9 +113,14 @@ impl Prefix {
         &self.chars[1..] == b"prv"
     }
 
-    /// Get the version number.
+    /// Get the [`Version`] number.
     pub fn version(&self) -> Version {
         self.version
+    }
+
+    /// Serialize the [`Version`] number as big-endian bytes.
+    pub fn to_bytes(&self) -> [u8; Self::LENGTH] {
+        self.version.to_be_bytes()
     }
 
     /// Validate that the given prefix string is well-formed.

--- a/bip32/tests/bip32_vectors.rs
+++ b/bip32/tests/bip32_vectors.rs
@@ -4,7 +4,7 @@
 //!
 //! Note: Test vector 1 is omitted (for now) because the seed is smaller than
 //! what we currently support.
-// TODO(tarcieri): test `xpub`s
+// TODO(tarcieri): test `xpub`s, add test vector 1, consolidate test vectors
 
 use bip32::{Seed, XPrv};
 use hex_literal::hex;


### PR DESCRIPTION
Adds encoding support with the following impls:

- `write_base58`: a `no_std`-friendly method that accepts a buffer
- `Display`: standard Rust trait; provides `ToString` impl