### PR TITLE
hkd32: remove `derive_subkey` and domain separator constant

### DIFF
--- a/bip32/src/extended_private_key.rs
+++ b/bip32/src/extended_private_key.rs
@@ -9,13 +9,19 @@ use core::{
     fmt::{self, Debug},
     str::FromStr,
 };
-use hkd32::mnemonic::{Seed, BIP39_DOMAIN_SEPARATOR};
+use hkd32::mnemonic::Seed;
 use hmac::{Hmac, Mac, NewMac};
 use sha2::Sha512;
 use subtle::{Choice, ConstantTimeEq};
 
 /// Derivation depth.
 pub type Depth = u8;
+
+/// Derivation domain separator for BIP39 keys.
+#[cfg_attr(docsrs, doc(cfg(feature = "bip39")))]
+const BIP39_DOMAIN_SEPARATOR: [u8; 12] = [
+    0x42, 0x69, 0x74, 0x63, 0x6f, 0x69, 0x6e, 0x20, 0x73, 0x65, 0x65, 0x64,
+];
 
 /// Extended private keys derived using BIP32.
 #[derive(Clone)]

--- a/hkd32/src/mnemonic.rs
+++ b/hkd32/src/mnemonic.rs
@@ -15,4 +15,4 @@ pub(crate) mod seed;
 pub use self::{language::Language, phrase::Phrase};
 
 #[cfg(feature = "bip39")]
-pub use self::seed::{Seed, BIP39_DOMAIN_SEPARATOR};
+pub use self::seed::Seed;

--- a/hkd32/src/mnemonic/seed.rs
+++ b/hkd32/src/mnemonic/seed.rs
@@ -1,15 +1,6 @@
 //! BIP39 seed values
 
-use crate::{KeyMaterial, Path, KEY_SIZE};
-use hmac::{Hmac, Mac, NewMac};
-use sha2::Sha512;
 use zeroize::Zeroize;
-
-/// Base derivation secret for BIP39 keys.
-#[cfg_attr(docsrs, doc(cfg(feature = "bip39")))]
-pub const BIP39_DOMAIN_SEPARATOR: [u8; 12] = [
-    0x42, 0x69, 0x74, 0x63, 0x6f, 0x69, 0x6e, 0x20, 0x73, 0x65, 0x65, 0x64,
-];
 
 /// BIP39 seeds.
 #[cfg_attr(docsrs, doc(cfg(feature = "bip39")))]
@@ -27,18 +18,6 @@ impl Seed {
     /// Get the inner secret byte slice
     pub fn as_bytes(&self) -> &[u8; Seed::SIZE] {
         &self.0
-    }
-
-    /// Derive a BIP32 subkey from this seed
-    pub fn derive_subkey(self, path: impl AsRef<Path>) -> KeyMaterial {
-        let mut hmac = Hmac::<Sha512>::new_from_slice(&BIP39_DOMAIN_SEPARATOR)
-            .expect("HMAC key size incorrect");
-        hmac.update(&self.0);
-
-        // Use the chain code of the derived key as the root key
-        let root_key = KeyMaterial::from_bytes(&hmac.finalize().into_bytes()[KEY_SIZE..]).unwrap();
-
-        root_key.derive_subkey(path)
     }
 }
 


### PR DESCRIPTION
The `hkd32` crate previously provided a minimal implementation of BIP32, but not one that's particularly useful.

The recommended replacement is to use the `bip32` crate (which otherwise only uses `hkd32` to implement BIP39)