### PR TITLE
bip32: add PublicKey/ExtendedPublicKey and XPub alias

### DIFF
--- a/.github/workflows/bip32.yml
+++ b/.github/workflows/bip32.yml
@@ -35,8 +35,8 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           override: true
           profile: minimal
+      - run: cargo test --release --no-default-features
       - run: cargo test --release
-      - run: cargo test --release --features zeroize
       - run: cargo test --release --all-features
 
   wasm:
@@ -49,4 +49,4 @@ jobs:
           target: wasm32-unknown-unknown
           override: true
           profile: minimal
-      - run: cargo build --target wasm32-unknown-unknown
+      - run: cargo build --release --target wasm32-unknown-unknown --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,7 @@ dependencies = [
  "hkd32",
  "hmac 0.11.0",
  "k256",
+ "ripemd160",
  "sha2",
  "subtle",
  "zeroize 1.3.0",
@@ -1421,6 +1422,17 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "ripemd160"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eca4ecc81b7f313189bf73ce724400a07da2a6dac19588b03c8bd76a2dcc251"
+dependencies = [
+ "block-buffer",
+ "digest",
+ "opaque-debug",
 ]
 
 [[package]]

--- a/bip32/Cargo.toml
+++ b/bip32/Cargo.toml
@@ -14,9 +14,10 @@ keywords    = ["crypto", "bip32", "bip39", "derivation", "mnemonic"]
 [dependencies]
 bs58 = { version = "0.4", default-features = false, features = ["check"] }
 hmac = "0.11"
+ripemd160 = "0.9"
 sha2 = "0.9"
 subtle = "2"
-zeroize = { version = "1", optional = true, default-features = false, path = "../zeroize" }
+zeroize = { version = "1", default-features = false, path = "../zeroize" }
 
 [dependencies.hkd32]
 version = "0.5"

--- a/bip32/src/child_number.rs
+++ b/bip32/src/child_number.rs
@@ -3,22 +3,30 @@
 use crate::{Error, Result};
 use core::str::FromStr;
 
-/// Hardened child keys use indices 2^31 through 2^32-1.
-const HARDENED_FLAG: u32 = 1 << 31;
-
 /// Index of a particular child key for a given (extended) private key.
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
 pub struct ChildNumber(pub u32);
 
 impl ChildNumber {
-    /// Is this child number within the hardened range?
-    pub fn is_hardened(&self) -> bool {
-        self.0 & HARDENED_FLAG != 0
+    /// Size of a child number when encoded as bytes.
+    pub const BYTE_SIZE: usize = 4;
+
+    /// Hardened child keys use indices 2^31 through 2^32-1.
+    pub const HARDENED_FLAG: u32 = 1 << 31;
+
+    /// Parse a child number from the byte encoding.
+    pub fn from_bytes(bytes: [u8; Self::BYTE_SIZE]) -> Self {
+        u32::from_be_bytes(bytes).into()
     }
 
     /// Serialize this child number as bytes.
-    pub fn to_bytes(self) -> [u8; 4] {
+    pub fn to_bytes(self) -> [u8; Self::BYTE_SIZE] {
         self.0.to_be_bytes()
+    }
+
+    /// Is this child number within the hardened range?
+    pub fn is_hardened(&self) -> bool {
+        self.0 & Self::HARDENED_FLAG != 0
     }
 }
 
@@ -39,13 +47,13 @@ impl FromStr for ChildNumber {
 
     fn from_str(child: &str) -> Result<ChildNumber> {
         let (child, mask) = match child.strip_suffix('\'') {
-            Some(c) => (c, HARDENED_FLAG),
+            Some(c) => (c, Self::HARDENED_FLAG),
             None => (child, 0),
         };
 
         let index = child.parse::<u32>().map_err(|_| Error::Decode)?;
 
-        if index & HARDENED_FLAG == 0 {
+        if index & Self::HARDENED_FLAG == 0 {
             Ok(ChildNumber(index | mask))
         } else {
             Err(Error::Decode)

--- a/bip32/src/extended_public_key.rs
+++ b/bip32/src/extended_public_key.rs
@@ -1,0 +1,129 @@
+//! Extended public keys
+
+use crate::{
+    ChainCode, ChildNumber, Depth, Error, ExtendedKey, ExtendedPrivateKey, KeyFingerprint, Prefix,
+    PrivateKey, PublicKey, PublicKeyBytes, Result,
+};
+use alloc::string::{String, ToString};
+use core::{
+    convert::{TryFrom, TryInto},
+    str::FromStr,
+};
+
+/// Extended public keys derived using BIP32.
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct ExtendedPublicKey<K: PublicKey> {
+    /// Derived public key
+    public_key: K,
+
+    /// Derivation depth
+    depth: Depth,
+
+    /// Key fingerprint of this key's parent
+    parent_fingerprint: KeyFingerprint,
+
+    /// Child number.
+    child_number: ChildNumber,
+
+    /// Chain code
+    chain_code: ChainCode,
+}
+
+impl<K> ExtendedPublicKey<K>
+where
+    K: PublicKey,
+{
+    /// Serialize the derived public key as bytes.
+    pub fn public_key(&self) -> &K {
+        &self.public_key
+    }
+
+    /// Get the [`Depth`] of this extended private key.
+    pub fn depth(&self) -> Depth {
+        self.depth
+    }
+
+    /// Key fingerprint of this key's parent.
+    pub fn parent_fingerprint(&self) -> KeyFingerprint {
+        self.parent_fingerprint
+    }
+
+    /// Child number used to derive this key from its parent.
+    pub fn child_number(&self) -> ChildNumber {
+        self.child_number
+    }
+
+    /// Borrow the chain code for this extended private key.
+    pub fn chain_code(&self) -> &ChainCode {
+        &self.chain_code
+    }
+
+    /// Serialize the raw public key as a byte array (e.g. SEC1-encoded).
+    pub fn to_bytes(&self) -> PublicKeyBytes {
+        self.public_key.to_bytes()
+    }
+
+    /// Serialize this key as an [`ExtendedKey`].
+    pub fn to_extended_key(&self, prefix: Prefix) -> ExtendedKey {
+        ExtendedKey {
+            prefix,
+            depth: self.depth,
+            parent_fingerprint: self.parent_fingerprint,
+            child_number: self.child_number,
+            chain_code: self.chain_code,
+            key_bytes: self.to_bytes(),
+        }
+    }
+
+    /// Serialize this key as a `String`.
+    pub fn to_string(&self, prefix: Prefix) -> String {
+        self.to_extended_key(prefix).to_string()
+    }
+}
+
+impl<K> From<&ExtendedPrivateKey<K>> for ExtendedPublicKey<K::PublicKey>
+where
+    K: PrivateKey,
+{
+    fn from(xprv: &ExtendedPrivateKey<K>) -> ExtendedPublicKey<K::PublicKey> {
+        ExtendedPublicKey {
+            public_key: xprv.private_key().public_key(),
+            depth: xprv.depth(),
+            parent_fingerprint: xprv.parent_fingerprint(),
+            child_number: xprv.child_number(),
+            chain_code: *xprv.chain_code(),
+        }
+    }
+}
+
+impl<K> FromStr for ExtendedPublicKey<K>
+where
+    K: PublicKey,
+{
+    type Err = Error;
+
+    fn from_str(xpub: &str) -> Result<Self> {
+        ExtendedKey::from_str(xpub)?.try_into()
+    }
+}
+
+impl<K> TryFrom<ExtendedKey> for ExtendedPublicKey<K>
+where
+    K: PublicKey,
+{
+    type Error = Error;
+
+    fn try_from(extended_key: ExtendedKey) -> Result<ExtendedPublicKey<K>> {
+        if extended_key.prefix.is_public() {
+            Ok(Self {
+                public_key: PublicKey::from_bytes(extended_key.key_bytes)?,
+                depth: extended_key.depth,
+                parent_fingerprint: extended_key.parent_fingerprint,
+                child_number: extended_key.child_number,
+                chain_code: extended_key.chain_code,
+            })
+        } else {
+            Err(Error::Crypto)
+        }
+    }
+}

--- a/bip32/src/lib.rs
+++ b/bip32/src/lib.rs
@@ -19,16 +19,21 @@ mod derivation_path;
 mod error;
 mod extended_key;
 mod extended_private_key;
+mod extended_public_key;
 mod prefix;
 mod private_key;
+mod public_key;
 
 pub use self::{
     child_number::ChildNumber,
     derivation_path::DerivationPath,
     error::{Error, Result},
     extended_key::ExtendedKey,
-    extended_private_key::{Depth, ExtendedPrivateKey},
+    extended_private_key::ExtendedPrivateKey,
+    extended_public_key::ExtendedPublicKey,
     prefix::Prefix,
+    private_key::{PrivateKey, PrivateKeyBytes},
+    public_key::{PublicKey, PublicKeyBytes},
 };
 pub use hkd32::{
     mnemonic::{Language, Phrase as Mnemonic, Seed},
@@ -43,10 +48,21 @@ pub use k256 as secp256k1;
 /// additional 256-bits of entropy.
 pub type ChainCode = [u8; KEY_SIZE];
 
+/// Derivation depth.
+pub type Depth = u8;
+
+/// BIP32 key fingerprints.
+pub type KeyFingerprint = [u8; 4];
+
+/// BIP32 "versions": integer representation of the key prefix.
+pub type Version = u32;
+
 /// Extended private secp256k1 ECDSA signing key.
 #[cfg(feature = "secp256k1")]
 #[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
 pub type XPrv = ExtendedPrivateKey<secp256k1::ecdsa::SigningKey>;
 
-/// BIP32 "versions": integer representation of the key prefix.
-pub type Version = u32;
+/// Extended public secp256k1 ECDSA verification key.
+#[cfg(feature = "secp256k1")]
+#[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
+pub type XPub = ExtendedPublicKey<secp256k1::ecdsa::VerifyingKey>;

--- a/bip32/src/private_key.rs
+++ b/bip32/src/private_key.rs
@@ -1,48 +1,49 @@
 //! Trait for deriving child keys on a given type.
 
-use crate::{Result, KEY_SIZE};
+use crate::{PublicKey, Result, KEY_SIZE};
 
 #[cfg(feature = "secp256k1")]
 use crate::Error;
 
 /// Bytes which represent a private key.
-type KeyBytes = [u8; KEY_SIZE];
+pub type PrivateKeyBytes = [u8; KEY_SIZE];
 
 /// Trait for key types which can be derived using BIP32.
 // TODO(tarcieri): add `ConstantTimeEq` bound
 pub trait PrivateKey: Sized {
-    /// Serialized public key type.
-    type PublicKey: AsRef<[u8]> + Sized;
+    /// Public key type which corresponds to this private key.
+    type PublicKey: PublicKey;
 
     /// Initialize this key from bytes.
-    fn from_bytes(bytes: &KeyBytes) -> Result<Self>;
+    fn from_bytes(bytes: &PrivateKeyBytes) -> Result<Self>;
 
     /// Serialize this key as bytes.
-    fn to_bytes(&self) -> KeyBytes;
+    fn to_bytes(&self) -> PrivateKeyBytes;
 
-    /// Derive a child key from this key and a provided [`ChainCode`].
-    fn derive_child(&self, derivation_key: &KeyBytes) -> Result<Self>;
+    /// Derive a child key from a parent key and the left-half of the output
+    /// of HMAC-SHA512 (where `left_half` is referred to as "I sub L" in BIP32)
+    fn derive_child(&self, left_half: PrivateKeyBytes) -> Result<Self>;
 
-    /// Serialize the public key for this [`SecretKey`].
+    /// Get the [`PublicKey`] that corresponds to this private key.
     fn public_key(&self) -> Self::PublicKey;
 }
 
 #[cfg(feature = "secp256k1")]
 #[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
 impl PrivateKey for k256::SecretKey {
-    type PublicKey = k256::CompressedPoint;
+    type PublicKey = k256::PublicKey;
 
-    fn from_bytes(bytes: &KeyBytes) -> Result<Self> {
+    fn from_bytes(bytes: &PrivateKeyBytes) -> Result<Self> {
         Ok(k256::SecretKey::from_bytes(bytes)?)
     }
 
-    fn to_bytes(&self) -> KeyBytes {
+    fn to_bytes(&self) -> PrivateKeyBytes {
         k256::SecretKey::to_bytes(self).into()
     }
 
-    fn derive_child(&self, derivation_key: &KeyBytes) -> Result<Self> {
-        let child_scalar = k256::Scalar::from_bytes_reduced(derivation_key.into());
-        let derived_scalar = self.secret_scalar().as_ref() + child_scalar;
+    fn derive_child(&self, left_half: PrivateKeyBytes) -> Result<Self> {
+        let child_scalar = k256::NonZeroScalar::from_repr(left_half.into()).ok_or(Error::Crypto)?;
+        let derived_scalar = self.secret_scalar().as_ref() + child_scalar.as_ref();
 
         k256::NonZeroScalar::new(derived_scalar)
             .map(Self::new)
@@ -50,37 +51,30 @@ impl PrivateKey for k256::SecretKey {
     }
 
     fn public_key(&self) -> Self::PublicKey {
-        use core::convert::TryInto;
-        use k256::elliptic_curve::sec1::ToEncodedPoint;
-
-        self.public_key()
-            .to_encoded_point(true)
-            .as_ref()
-            .try_into()
-            .expect("malformed public key")
+        k256::SecretKey::public_key(self)
     }
 }
 
 #[cfg(feature = "secp256k1")]
 #[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
 impl PrivateKey for k256::ecdsa::SigningKey {
-    type PublicKey = [u8; 33];
+    type PublicKey = k256::ecdsa::VerifyingKey;
 
-    fn from_bytes(bytes: &KeyBytes) -> Result<Self> {
+    fn from_bytes(bytes: &PrivateKeyBytes) -> Result<Self> {
         Ok(k256::ecdsa::SigningKey::from_bytes(bytes)?)
     }
 
-    fn to_bytes(&self) -> KeyBytes {
+    fn to_bytes(&self) -> PrivateKeyBytes {
         k256::ecdsa::SigningKey::to_bytes(self).into()
     }
 
-    fn derive_child(&self, derivation_key: &KeyBytes) -> Result<Self> {
+    fn derive_child(&self, left_half: PrivateKeyBytes) -> Result<Self> {
         k256::SecretKey::from(self)
-            .derive_child(derivation_key)
+            .derive_child(left_half)
             .map(Into::into)
     }
 
     fn public_key(&self) -> Self::PublicKey {
-        PrivateKey::public_key(&k256::SecretKey::from(self))
+        self.verify_key()
     }
 }

--- a/bip32/src/public_key.rs
+++ b/bip32/src/public_key.rs
@@ -1,0 +1,58 @@
+//! Trait for deriving child keys on a given type.
+
+use crate::{KeyFingerprint, Result, KEY_SIZE};
+use core::convert::TryInto;
+use ripemd160::Ripemd160;
+use sha2::{Digest, Sha256};
+
+#[cfg(feature = "secp256k1")]
+use k256::elliptic_curve::sec1::ToEncodedPoint;
+
+/// Bytes which represent a public key.
+///
+/// Includes an extra byte for an SEC1 tag.
+pub type PublicKeyBytes = [u8; KEY_SIZE + 1];
+
+/// Trait for key types which can be derived using BIP32.
+pub trait PublicKey: Sized {
+    /// Initialize this key from bytes.
+    fn from_bytes(bytes: PublicKeyBytes) -> Result<Self>;
+
+    /// Serialize this key as bytes.
+    fn to_bytes(&self) -> PublicKeyBytes;
+
+    /// Compute a 4-byte key fingerprint for this public key.
+    ///
+    /// Default implementation uses `RIPEMD160(SHA256(public_key))`.
+    fn fingerprint(&self) -> KeyFingerprint {
+        let digest = Ripemd160::digest(&Sha256::digest(&self.to_bytes()));
+        digest[..4].try_into().expect("digest truncated")
+    }
+}
+
+#[cfg(feature = "secp256k1")]
+#[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
+impl PublicKey for k256::PublicKey {
+    fn from_bytes(bytes: PublicKeyBytes) -> Result<Self> {
+        Ok(k256::PublicKey::from_sec1_bytes(&bytes)?)
+    }
+
+    fn to_bytes(&self) -> PublicKeyBytes {
+        self.to_encoded_point(true)
+            .as_bytes()
+            .try_into()
+            .expect("malformed public key")
+    }
+}
+
+#[cfg(feature = "secp256k1")]
+#[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
+impl PublicKey for k256::ecdsa::VerifyingKey {
+    fn from_bytes(bytes: PublicKeyBytes) -> Result<Self> {
+        Ok(k256::ecdsa::VerifyingKey::from_sec1_bytes(&bytes)?)
+    }
+
+    fn to_bytes(&self) -> PublicKeyBytes {
+        self.to_bytes()
+    }
+}

--- a/bip32/tests/bip32_vectors.rs
+++ b/bip32/tests/bip32_vectors.rs
@@ -6,7 +6,9 @@
 //! what we currently support.
 // TODO(tarcieri): test `xpub`s, add test vector 1, consolidate test vectors
 
-use bip32::{Seed, XPrv};
+#![cfg(feature = "secp256k1")]
+
+use bip32::{Prefix, Seed, XPrv};
 use hex_literal::hex;
 
 /// Derive an [`XPrv`] for the given seed and derivation path.
@@ -25,36 +27,71 @@ fn test_vector_2() {
          9f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542"
     ));
 
+    // Chain m
     let key_m = derive_xprv(&seed, "m");
     assert_eq!(key_m, XPrv::new(&seed).unwrap());
     assert_eq!(
-        key_m,
-        "xprv9s21ZrQH143K31xYSDQpPDxsXRTUcvj2iNHm5NUtrGiGG5e2DtALGdso3pGz6ssrdK4PFmM8NSpSBHNqPqm55Qn3LqFtT2emdEXVYsCzC2U".parse().unwrap()
+        &*key_m.to_string(Prefix::XPRV),
+        "xprv9s21ZrQH143K31xYSDQpPDxsXRTUcvj2iNHm5NUtrGiGG5e2DtALGdso3pGz6ssrdK4PFmM8NSpSBHNqPqm55Qn3LqFtT2emdEXVYsCzC2U"
+    );
+    assert_eq!(
+        key_m.public_key().to_string(Prefix::XPUB),
+        "xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB"
     );
 
+    // Chain m/0
+    let key_m_0 = derive_xprv(&seed, "m/0");
     assert_eq!(
-        derive_xprv(&seed, "m/0"),
-        "xprv9vHkqa6EV4sPZHYqZznhT2NPtPCjKuDKGY38FBWLvgaDx45zo9WQRUT3dKYnjwih2yJD9mkrocEZXo1ex8G81dwSM1fwqWpWkeS3v86pgKt".parse().unwrap()
+        &*key_m_0.to_string(Prefix::XPRV),
+        "xprv9vHkqa6EV4sPZHYqZznhT2NPtPCjKuDKGY38FBWLvgaDx45zo9WQRUT3dKYnjwih2yJD9mkrocEZXo1ex8G81dwSM1fwqWpWkeS3v86pgKt"
+    );
+    assert_eq!(
+        key_m_0.public_key().to_string(Prefix::XPUB),
+        "xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH"
     );
 
+    // Chain m/0/2147483647'
+    let key_m_0_2147483647h = derive_xprv(&seed, "m/0/2147483647'");
     assert_eq!(
-        derive_xprv(&seed, "m/0/2147483647'"),
-        "xprv9wSp6B7kry3Vj9m1zSnLvN3xH8RdsPP1Mh7fAaR7aRLcQMKTR2vidYEeEg2mUCTAwCd6vnxVrcjfy2kRgVsFawNzmjuHc2YmYRmagcEPdU9".parse().unwrap()
+        &*key_m_0_2147483647h.to_string(Prefix::XPRV),
+        "xprv9wSp6B7kry3Vj9m1zSnLvN3xH8RdsPP1Mh7fAaR7aRLcQMKTR2vidYEeEg2mUCTAwCd6vnxVrcjfy2kRgVsFawNzmjuHc2YmYRmagcEPdU9"
+    );
+    assert_eq!(
+        key_m_0_2147483647h.public_key().to_string(Prefix::XPUB),
+        "xpub6ASAVgeehLbnwdqV6UKMHVzgqAG8Gr6riv3Fxxpj8ksbH9ebxaEyBLZ85ySDhKiLDBrQSARLq1uNRts8RuJiHjaDMBU4Zn9h8LZNnBC5y4a"
     );
 
+    // Chain m/0/2147483647'/1
+    let key_m_0_2147483647h_1 = derive_xprv(&seed, "m/0/2147483647'/1");
     assert_eq!(
-        derive_xprv(&seed, "m/0/2147483647'/1"),
-        "xprv9zFnWC6h2cLgpmSA46vutJzBcfJ8yaJGg8cX1e5StJh45BBciYTRXSd25UEPVuesF9yog62tGAQtHjXajPPdbRCHuWS6T8XA2ECKADdw4Ef".parse().unwrap()
+        &*key_m_0_2147483647h_1.to_string(Prefix::XPRV),
+        "xprv9zFnWC6h2cLgpmSA46vutJzBcfJ8yaJGg8cX1e5StJh45BBciYTRXSd25UEPVuesF9yog62tGAQtHjXajPPdbRCHuWS6T8XA2ECKADdw4Ef"
+    );
+    assert_eq!(
+        key_m_0_2147483647h_1.public_key().to_string(Prefix::XPUB),
+        "xpub6DF8uhdarytz3FWdA8TvFSvvAh8dP3283MY7p2V4SeE2wyWmG5mg5EwVvmdMVCQcoNJxGoWaU9DCWh89LojfZ537wTfunKau47EL2dhHKon"
     );
 
+    // Chain m/0/2147483647'/1/2147483646'
+    let key_m_0_2147483647h_1_2147483646h = derive_xprv(&seed, "m/0/2147483647'/1/2147483646'");
     assert_eq!(
-        derive_xprv(&seed, "m/0/2147483647'/1/2147483646'"),
-        "xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc".parse().unwrap()
+        &*key_m_0_2147483647h_1_2147483646h.to_string(Prefix::XPRV),
+        "xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc"
+    );
+    assert_eq!(
+        key_m_0_2147483647h_1_2147483646h.public_key().to_string(Prefix::XPUB),
+        "xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL"
     );
 
+    // Chain m/0/2147483647'/1/2147483646'/2
+    let key_m_0_2147483647h_1_2147483646h_2 = derive_xprv(&seed, "m/0/2147483647'/1/2147483646'/2");
     assert_eq!(
-        derive_xprv(&seed, "m/0/2147483647'/1/2147483646'/2"),
-        "xprvA2nrNbFZABcdryreWet9Ea4LvTJcGsqrMzxHx98MMrotbir7yrKCEXw7nadnHM8Dq38EGfSh6dqA9QWTyefMLEcBYJUuekgW4BYPJcr9E7j".parse().unwrap()
+        &*key_m_0_2147483647h_1_2147483646h_2.to_string(Prefix::XPRV),
+        "xprvA2nrNbFZABcdryreWet9Ea4LvTJcGsqrMzxHx98MMrotbir7yrKCEXw7nadnHM8Dq38EGfSh6dqA9QWTyefMLEcBYJUuekgW4BYPJcr9E7j"
+    );
+    assert_eq!(
+        key_m_0_2147483647h_1_2147483646h_2.public_key().to_string(Prefix::XPUB),
+        "xpub6FnCn6nSzZAw5Tw7cgR9bi15UV96gLZhjDstkXXxvCLsUXBGXPdSnLFbdpq8p9HmGsApME5hQTZ3emM2rnY5agb9rXpVGyy3bdW6EEgAtqt"
     );
 }
 
@@ -71,15 +108,26 @@ fn test_vector_3() {
          ba45d239319ac14f863b8d5ab5a0d0c64d2e8a1e7d1457df2e5a3c51c73235be"
     ));
 
+    // Chain m
     let key_m = derive_xprv(&seed, "m");
     assert_eq!(key_m, XPrv::new(&seed).unwrap());
     assert_eq!(
-        key_m,
-        "xprv9s21ZrQH143K25QhxbucbDDuQ4naNntJRi4KUfWT7xo4EKsHt2QJDu7KXp1A3u7Bi1j8ph3EGsZ9Xvz9dGuVrtHHs7pXeTzjuxBrCmmhgC6".parse().unwrap()
+        &*key_m.to_string(Prefix::XPRV),
+        "xprv9s21ZrQH143K25QhxbucbDDuQ4naNntJRi4KUfWT7xo4EKsHt2QJDu7KXp1A3u7Bi1j8ph3EGsZ9Xvz9dGuVrtHHs7pXeTzjuxBrCmmhgC6"
+    );
+    assert_eq!(
+        key_m.public_key().to_string(Prefix::XPUB),
+        "xpub661MyMwAqRbcEZVB4dScxMAdx6d4nFc9nvyvH3v4gJL378CSRZiYmhRoP7mBy6gSPSCYk6SzXPTf3ND1cZAceL7SfJ1Z3GC8vBgp2epUt13"
     );
 
+    // Chain m/0'
+    let key_m_0h = derive_xprv(&seed, "m/0'");
     assert_eq!(
-        derive_xprv(&seed, "m/0'"),
-        "xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L".parse().unwrap()
+        &*key_m_0h.to_string(Prefix::XPRV),
+        "xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L"
+    );
+    assert_eq!(
+        key_m_0h.public_key().to_string(Prefix::XPUB),
+        "xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y"
     );
 }

--- a/bip32/tests/bip39_vectors.rs
+++ b/bip32/tests/bip39_vectors.rs
@@ -91,15 +91,8 @@ fn test_seed() {
 fn test_xprv() {
     for vector in TEST_VECTORS {
         let seed = Seed::new(vector.seed);
-        let expected_xprv: XPrv = vector.xprv.parse().unwrap();
+        let expected_xprv = vector.xprv.parse::<XPrv>().unwrap();
         let derived_xprv = XPrv::new(&seed).unwrap();
-
-        // TODO(tarcieri): `Eq` impl for `ExtendedPrivateKey`? (using `subtle` behind the scenes)
-        assert_eq!(
-            expected_xprv.private_key().to_bytes(),
-            derived_xprv.private_key().to_bytes()
-        );
-        assert_eq!(expected_xprv.chain_code(), derived_xprv.chain_code());
-        assert_eq!(expected_xprv.depth(), derived_xprv.depth());
+        assert_eq!(expected_xprv, derived_xprv);
     }
 }


### PR DESCRIPTION
Adds a `PublicKey` trait and uses it as the bound for the associated `PrivateKey::PublicKey` type.

Adds `ExtendedPublicKey`, the extended key analogue of `ExtendedPrivateKey`, and support for serializing/deserializing them to/from `ExtendedKey`, as well as computing it from an `ExtendedPrivateKey`.

When the `secp256k1` feature is enabled, adds an `XPub` alias for an `ExtendedPublicKey` whose `K: PublicKey` is a `k256::ecdsa::VerifyingKey`.

Finally, augments the test vectors in `tests/bip32_vectors.rs` to include `xpub...` strings, and ensures keys are derived and serialized correctly.