### PR TITLE
bip32: refactor `extended_key` module

### DIFF
--- a/bip32/src/extended_key.rs
+++ b/bip32/src/extended_key.rs
@@ -1,14 +1,19 @@
 //! Parser for extended key types (i.e. `xprv` and `xpub`)
 
-use crate::{
-    ChainCode, ChildNumber, Depth, Error, KeyFingerprint, Prefix, Result, Version, KEY_SIZE,
-};
 use core::{
     convert::TryInto,
     fmt::{self, Display},
     str::{self, FromStr},
 };
+
 use zeroize::Zeroize;
+
+use crate::{
+    ChainCode, ChildNumber, Depth, Error, KeyFingerprint, Prefix, Result, Version, KEY_SIZE,
+};
+
+pub mod private_key;
+pub mod public_key;
 
 /// Serialized extended key (e.g. `xprv` and `xpub`).
 pub struct ExtendedKey {

--- a/bip32/src/extended_key/private_key.rs
+++ b/bip32/src/extended_key/private_key.rs
@@ -22,7 +22,16 @@ const BIP39_DOMAIN_SEPARATOR: [u8; 12] = [
     0x42, 0x69, 0x74, 0x63, 0x6f, 0x69, 0x6e, 0x20, 0x73, 0x65, 0x65, 0x64,
 ];
 
+/// Extended private secp256k1 ECDSA signing key.
+#[cfg(feature = "secp256k1")]
+#[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
+pub type XPrv = ExtendedPrivateKey<k256::ecdsa::SigningKey>;
+
 /// Extended private keys derived using BIP32.
+///
+/// Generic around a [`PrivateKey`] type. When the `secp256k1` feature of this
+/// crate is enabled, the [`XPrv`] type provides a convenient alias for
+/// extended ECDSA/secp256k1 private keys.
 #[derive(Clone)]
 pub struct ExtendedPrivateKey<K: PrivateKey> {
     /// Derived private key

--- a/bip32/src/extended_key/public_key.rs
+++ b/bip32/src/extended_key/public_key.rs
@@ -10,7 +10,16 @@ use core::{
     str::FromStr,
 };
 
+/// Extended public secp256k1 ECDSA verification key.
+#[cfg(feature = "secp256k1")]
+#[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
+pub type XPub = ExtendedPublicKey<k256::ecdsa::VerifyingKey>;
+
 /// Extended public keys derived using BIP32.
+///
+/// Generic around a [`PublicKey`] type. When the `secp256k1` feature of this
+/// crate is enabled, the [`XPub`] type provides a convenient alias for
+/// extended ECDSA/secp256k1 public keys.
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct ExtendedPublicKey<K: PublicKey> {
     /// Derived public key

--- a/bip32/src/lib.rs
+++ b/bip32/src/lib.rs
@@ -18,19 +18,15 @@ mod child_number;
 mod derivation_path;
 mod error;
 mod extended_key;
-mod extended_private_key;
-mod extended_public_key;
 mod prefix;
 mod private_key;
 mod public_key;
 
-pub use self::{
+pub use crate::{
     child_number::ChildNumber,
     derivation_path::DerivationPath,
     error::{Error, Result},
-    extended_key::ExtendedKey,
-    extended_private_key::ExtendedPrivateKey,
-    extended_public_key::ExtendedPublicKey,
+    extended_key::{private_key::ExtendedPrivateKey, public_key::ExtendedPublicKey, ExtendedKey},
     prefix::Prefix,
     private_key::{PrivateKey, PrivateKeyBytes},
     public_key::{PublicKey, PublicKeyBytes},
@@ -42,7 +38,10 @@ pub use hkd32::{
 
 #[cfg(feature = "secp256k1")]
 #[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
-pub use k256 as secp256k1;
+pub use {
+    crate::extended_key::{private_key::XPrv, public_key::XPub},
+    k256 as secp256k1,
+};
 
 /// Chain code: extension for both private and public keys which provides an
 /// additional 256-bits of entropy.
@@ -56,13 +55,3 @@ pub type KeyFingerprint = [u8; 4];
 
 /// BIP32 "versions": integer representation of the key prefix.
 pub type Version = u32;
-
-/// Extended private secp256k1 ECDSA signing key.
-#[cfg(feature = "secp256k1")]
-#[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
-pub type XPrv = ExtendedPrivateKey<secp256k1::ecdsa::SigningKey>;
-
-/// Extended public secp256k1 ECDSA verification key.
-#[cfg(feature = "secp256k1")]
-#[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
-pub type XPub = ExtendedPublicKey<secp256k1::ecdsa::VerifyingKey>;

--- a/hkd32/src/mnemonic/phrase.rs
+++ b/hkd32/src/mnemonic/phrase.rs
@@ -133,7 +133,6 @@ impl Phrase {
     /// Note: that this does not follow the normal BIP39 derivation, which
     /// first applies PBKDF2 along with a secondary password. Use `to_seed`
     /// if you are interested in BIP39 compatibility.
-    /// Derive a BIP32 subkey from this seed
     pub fn derive_subkey(self, path: impl AsRef<Path>) -> KeyMaterial {
         KeyMaterial::from(self).derive_subkey(path)
     }


### PR DESCRIPTION
Moves `ExtendedPrivateKey`/`ExtendedPublicKey` under the `extended_key` module, keeping it private and re-exporting them at the toplevel.