### PR TITLE
bip32: extract `ExtendedKeyAttrs` type

### DIFF
--- a/bip32/src/extended_key/attrs.rs
+++ b/bip32/src/extended_key/attrs.rs
@@ -1,0 +1,20 @@
+//! Extended key attributes.
+
+use crate::{ChainCode, ChildNumber, Depth, KeyFingerprint};
+
+/// Extended key attributes: fields common to extended keys including depth,
+/// fingerprints, child numbers, and chain codes.
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct ExtendedKeyAttrs {
+    /// Depth in the key derivation hierarchy.
+    pub depth: Depth,
+
+    /// Parent fingerprint.
+    pub parent_fingerprint: KeyFingerprint,
+
+    /// Child number.
+    pub child_number: ChildNumber,
+
+    /// Chain code.
+    pub chain_code: ChainCode,
+}

--- a/bip32/src/lib.rs
+++ b/bip32/src/lib.rs
@@ -26,7 +26,10 @@ pub use crate::{
     child_number::ChildNumber,
     derivation_path::DerivationPath,
     error::{Error, Result},
-    extended_key::{private_key::ExtendedPrivateKey, public_key::ExtendedPublicKey, ExtendedKey},
+    extended_key::{
+        attrs::ExtendedKeyAttrs, private_key::ExtendedPrivateKey, public_key::ExtendedPublicKey,
+        ExtendedKey,
+    },
     prefix::Prefix,
     private_key::{PrivateKey, PrivateKeyBytes},
     public_key::{PublicKey, PublicKeyBytes},

--- a/bip32/src/prefix.rs
+++ b/bip32/src/prefix.rs
@@ -66,7 +66,8 @@ impl Prefix {
     /// up to the caller to ensure that the version number matches the prefix.
     ///
     /// Panics if `s` is not 4 chars long, or any of the chars lie outside of
-    /// the supported range (lower case alphabetic characters `a..=z`).
+    /// the supported range: lower case (`a..=z`) or upper case (`A..=Z`)
+    /// letters.
     pub const fn from_parts_unchecked(s: &str, version: Version) -> Self {
         // TODO(tarcieri): return `Result` when const panic is stable
         const_assert!(Self::validate_str(s).is_ok(), "invalid prefix");


### PR DESCRIPTION
Extracts a type for carrying around attributes/metadata related to extended keys, which includes:

- depth
- parent fingerprint
- child number
- chain code