### PR TITLE
bip32: `ChildNumber` and `DerivationPath` improvements

### DIFF
--- a/bip32/Cargo.toml
+++ b/bip32/Cargo.toml
@@ -35,7 +35,7 @@ features = ["arithmetic", "ecdsa", "zeroize"]
 hex-literal = "0.3"
 
 [features]
-default = ["secp256k1"]
+default = ["secp256k1", "std"]
 secp256k1 = ["k256"]
 std = []
 

--- a/bip32/src/child_number.rs
+++ b/bip32/src/child_number.rs
@@ -1,7 +1,10 @@
 //! Child numbers
 
 use crate::{Error, Result};
-use core::str::FromStr;
+use core::{
+    fmt::{self, Display},
+    str::FromStr,
+};
 
 /// Index of a particular child key for a given (extended) private key.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
@@ -14,6 +17,19 @@ impl ChildNumber {
     /// Hardened child keys use indices 2^31 through 2^32-1.
     pub const HARDENED_FLAG: u32 = 1 << 31;
 
+    /// Create new [`ChildNumber`] with the given index and hardened flag.
+    ///
+    /// Returns an error if it is equal to or greater than [`Self::HARDENED_FLAG`].
+    pub fn new(index: u32, hardened: bool) -> Result<Self> {
+        if index >= Self::HARDENED_FLAG {
+            Err(Error::ChildNumber)
+        } else if hardened {
+            Ok(Self(index | Self::HARDENED_FLAG))
+        } else {
+            Ok(Self(index))
+        }
+    }
+
     /// Parse a child number from the byte encoding.
     pub fn from_bytes(bytes: [u8; Self::BYTE_SIZE]) -> Self {
         u32::from_be_bytes(bytes).into()
@@ -24,9 +40,27 @@ impl ChildNumber {
         self.0.to_be_bytes()
     }
 
+    /// Get the index number for this [`ChildNumber`], i.e. with
+    /// [`Self::HARDENED_FLAG`] cleared.
+    pub fn index(self) -> u32 {
+        self.0 & !Self::HARDENED_FLAG
+    }
+
     /// Is this child number within the hardened range?
     pub fn is_hardened(&self) -> bool {
         self.0 & Self::HARDENED_FLAG != 0
+    }
+}
+
+impl Display for ChildNumber {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.index())?;
+
+        if self.is_hardened() {
+            f.write_str("\'")?;
+        }
+
+        Ok(())
     }
 }
 
@@ -46,17 +80,47 @@ impl FromStr for ChildNumber {
     type Err = Error;
 
     fn from_str(child: &str) -> Result<ChildNumber> {
-        let (child, mask) = match child.strip_suffix('\'') {
-            Some(c) => (c, Self::HARDENED_FLAG),
-            None => (child, 0),
+        let (child, hardened) = match child.strip_suffix('\'') {
+            Some(c) => (c, true),
+            None => (child, false),
         };
 
-        let index = child.parse::<u32>().map_err(|_| Error::Decode)?;
+        let index = child.parse().map_err(|_| Error::ChildNumber)?;
+        ChildNumber::new(index, hardened)
+    }
+}
 
-        if index & Self::HARDENED_FLAG == 0 {
-            Ok(ChildNumber(index | mask))
-        } else {
-            Err(Error::Decode)
-        }
+#[cfg(test)]
+mod tests {
+    use super::ChildNumber;
+    use crate::Error;
+
+    #[test]
+    fn parse_non_hardened() {
+        let n = "42".parse::<ChildNumber>().unwrap();
+        assert_eq!(n, ChildNumber::new(42, false).unwrap());
+        assert_eq!(n.index(), 42);
+        assert!(!n.is_hardened());
+    }
+
+    #[test]
+    fn parse_hardened() {
+        let n = "42'".parse::<ChildNumber>().unwrap();
+        assert_eq!(n, ChildNumber::new(42, true).unwrap());
+        assert_eq!(n.index(), 42);
+        assert!(n.is_hardened());
+    }
+
+    #[test]
+    fn parse_rejects_invalid() {
+        assert_eq!("42!".parse::<ChildNumber>(), Err(Error::ChildNumber));
+    }
+
+    #[test]
+    fn index_overflow() {
+        // Invalid index
+        let index = ChildNumber::HARDENED_FLAG;
+        assert_eq!(ChildNumber::new(index, false), Err(Error::ChildNumber));
+        assert_eq!(ChildNumber::new(index, true), Err(Error::ChildNumber));
     }
 }

--- a/bip32/src/derivation_path.rs
+++ b/bip32/src/derivation_path.rs
@@ -1,13 +1,79 @@
 //! Derivation paths
 
 use crate::{ChildNumber, Error, Result};
-use alloc::vec::Vec;
-use core::str::FromStr;
+use alloc::vec::{self, Vec};
+use core::{
+    fmt::{self, Display},
+    str::FromStr,
+};
+
+/// Prefix for all derivation paths.
+const PREFIX: &str = "m";
 
 /// Derivation paths within a hierarchical keyspace.
-#[derive(Clone, PartialEq, Eq, Debug, Default)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct DerivationPath {
     path: Vec<ChildNumber>,
+}
+
+impl DerivationPath {
+    /// Iterate over the [`ChildNumber`] values in this derivation path.
+    pub fn iter(&self) -> impl Iterator<Item = ChildNumber> + '_ {
+        self.path.iter().cloned()
+    }
+
+    /// Is this derivation path empty? (i.e. the root)
+    pub fn is_empty(&self) -> bool {
+        self.path.is_empty()
+    }
+
+    /// Get the count of [`ChildNumber`] values in this derivation path.
+    pub fn len(&self) -> usize {
+        self.path.len()
+    }
+
+    /// Get the parent [`DerivationPath`] for the current one.
+    ///
+    /// Returns `None` if this is already the root path.
+    pub fn parent(&self) -> Option<Self> {
+        self.path.len().checked_sub(1).map(|n| {
+            let mut parent = self.clone();
+            parent.path.truncate(n);
+            parent
+        })
+    }
+
+    /// Push a [`ChildNumber`] onto an existing derivation path.
+    pub fn push(&mut self, child_number: ChildNumber) {
+        self.path.push(child_number)
+    }
+}
+
+impl AsRef<[ChildNumber]> for DerivationPath {
+    fn as_ref(&self) -> &[ChildNumber] {
+        &self.path
+    }
+}
+
+impl Display for DerivationPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(PREFIX)?;
+
+        for child_number in self.iter() {
+            write!(f, "/{}", child_number)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl Extend<ChildNumber> for DerivationPath {
+    fn extend<T>(&mut self, iter: T)
+    where
+        T: IntoIterator<Item = ChildNumber>,
+    {
+        self.path.extend(iter);
+    }
 }
 
 impl FromStr for DerivationPath {
@@ -16,18 +82,91 @@ impl FromStr for DerivationPath {
     fn from_str(path: &str) -> Result<DerivationPath> {
         let mut path = path.split('/');
 
-        if path.next() != Some("m") {
+        if path.next() != Some(PREFIX) {
             return Err(Error::Decode);
         }
 
         Ok(DerivationPath {
-            path: path.map(str::parse).collect::<Result<Vec<_>>>()?,
+            path: path.map(str::parse).collect::<Result<_>>()?,
         })
     }
 }
 
-impl AsRef<[ChildNumber]> for DerivationPath {
-    fn as_ref(&self) -> &[ChildNumber] {
-        &self.path
+impl IntoIterator for DerivationPath {
+    type Item = ChildNumber;
+    type IntoIter = vec::IntoIter<ChildNumber>;
+
+    fn into_iter(self) -> vec::IntoIter<ChildNumber> {
+        self.path.into_iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DerivationPath;
+    use alloc::string::ToString;
+
+    /// BIP32 test vectors
+    // TODO(tarcieri): consolidate test vectors
+    #[test]
+    fn round_trip() {
+        let path_m = "m";
+        assert_eq!(
+            path_m.parse::<DerivationPath>().unwrap().to_string(),
+            path_m
+        );
+
+        let path_m_0 = "m/0";
+        assert_eq!(
+            path_m_0.parse::<DerivationPath>().unwrap().to_string(),
+            path_m_0
+        );
+
+        let path_m_0_2147483647h = "m/0/2147483647'";
+        assert_eq!(
+            path_m_0_2147483647h
+                .parse::<DerivationPath>()
+                .unwrap()
+                .to_string(),
+            path_m_0_2147483647h
+        );
+
+        let path_m_0_2147483647h_1 = "m/0/2147483647'/1";
+        assert_eq!(
+            path_m_0_2147483647h_1
+                .parse::<DerivationPath>()
+                .unwrap()
+                .to_string(),
+            path_m_0_2147483647h_1
+        );
+
+        let path_m_0_2147483647h_1_2147483646h = "m/0/2147483647'/1/2147483646'";
+        assert_eq!(
+            path_m_0_2147483647h_1_2147483646h
+                .parse::<DerivationPath>()
+                .unwrap()
+                .to_string(),
+            path_m_0_2147483647h_1_2147483646h
+        );
+
+        let path_m_0_2147483647h_1_2147483646h_2 = "m/0/2147483647'/1/2147483646'/2";
+        assert_eq!(
+            path_m_0_2147483647h_1_2147483646h_2
+                .parse::<DerivationPath>()
+                .unwrap()
+                .to_string(),
+            path_m_0_2147483647h_1_2147483646h_2
+        );
+    }
+
+    #[test]
+    fn parent() {
+        let path_m_0_2147483647h = "m/0/2147483647'".parse::<DerivationPath>().unwrap();
+        let path_m_0 = path_m_0_2147483647h.parent().unwrap();
+        assert_eq!("m/0", path_m_0.to_string());
+
+        let path_m = path_m_0.parent().unwrap();
+        assert_eq!("m", path_m.to_string());
+        assert_eq!(path_m.parent(), None);
     }
 }

--- a/bip32/src/error.rs
+++ b/bip32/src/error.rs
@@ -7,9 +7,13 @@ pub type Result<T> = core::result::Result<T, Error>;
 
 /// Error type.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum Error {
     /// Base58 errors.
     Base58,
+
+    /// Child number-related errors.
+    ChildNumber,
 
     /// Cryptographic errors.
     Crypto,
@@ -25,6 +29,7 @@ impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::Base58 => f.write_str("base58 error"),
+            Error::ChildNumber => f.write_str("invalid child number"),
             Error::Crypto => f.write_str("cryptographic error"),
             Error::Decode => f.write_str("decoding error"),
             Error::Depth => f.write_str("maximum derivation depth exceeded"),

--- a/bip32/src/prefix.rs
+++ b/bip32/src/prefix.rs
@@ -3,7 +3,8 @@
 use crate::{Error, ExtendedKey, Result, Version};
 use core::{
     convert::{TryFrom, TryInto},
-    fmt, str,
+    fmt::{self, Debug, Display},
+    str,
 };
 
 /// Constant panicking assertion.
@@ -151,6 +152,21 @@ impl AsRef<str> for Prefix {
     }
 }
 
+impl Debug for Prefix {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Prefix")
+            .field("chars", &self.as_str())
+            .field("version", &DebugVersion(self.version))
+            .finish()
+    }
+}
+
+impl Display for Prefix {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 impl From<Prefix> for Version {
     fn from(prefix: Prefix) -> Version {
         prefix.version()
@@ -179,26 +195,11 @@ impl TryFrom<&[u8]> for Prefix {
     }
 }
 
-impl fmt::Debug for Prefix {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Prefix")
-            .field("chars", &self.as_str())
-            .field("version", &DebugVersion(self.version))
-            .finish()
-    }
-}
-
-impl fmt::Display for Prefix {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
-
 /// Debugging formatting helper for [`Version`] with a `Debug` impl that
 /// outputs hexadecimal instead of base 10.
 struct DebugVersion(Version);
 
-impl fmt::Debug for DebugVersion {
+impl Debug for DebugVersion {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:#010x}", self.0)
     }


### PR DESCRIPTION
- Adds `Display` impls to both
- Adds additional constructor methods for `ChildNumber`
- Adds `Extend` and `IntoIterator` impls for `DerivationPath`