### PR TITLE
bip32: make "alloc" an optional feature (heapless support)

### DIFF
--- a/.github/workflows/bip32.yml
+++ b/.github/workflows/bip32.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "bip32/**"
+      - "hkd32/**"
       - "Cargo.*"
   push:
     branches: main
@@ -17,6 +18,30 @@ env:
   RUSTFLAGS: "-Dwarnings"
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.51.0 # MSRV
+          - stable
+        target:
+          - armv7a-none-eabi
+          - thumbv7em-none-eabi
+          - wasm32-unknown-unknown
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
+          override: true
+          profile: minimal
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features secp256k1
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,secp256k1
+
   test:
     strategy:
       matrix:
@@ -38,15 +63,3 @@ jobs:
       - run: cargo test --release --no-default-features
       - run: cargo test --release
       - run: cargo test --release --all-features
-
-  wasm:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: wasm32-unknown-unknown
-          override: true
-          profile: minimal
-      - run: cargo build --release --target wasm32-unknown-unknown --all-features

--- a/.github/workflows/hkd32.yml
+++ b/.github/workflows/hkd32.yml
@@ -17,6 +17,30 @@ env:
   RUSTFLAGS: "-Dwarnings"
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.51.0 # MSRV
+          - stable
+        target:
+          - armv7a-none-eabi
+          - thumbv7em-none-eabi
+          - wasm32-unknown-unknown
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
+          override: true
+          profile: minimal
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features bech32
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features alloc,bech32
+
   test:
     strategy:
       matrix:
@@ -37,15 +61,3 @@ jobs:
           profile: minimal
       - run: cargo test --release
       - run: cargo test --release --all-features
-
-  wasm:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: wasm32-unknown-unknown
-          override: true
-          profile: minimal
-      - run: cargo build --target wasm32-unknown-unknown

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -661,6 +661,7 @@ checksum = "5af1f635ef1bc545d78392b136bfe1c9809e029023c84a3638a864a10b8819c8"
 name = "hkd32"
 version = "0.5.0"
 dependencies = [
+ "hex-literal",
  "hmac 0.11.0",
  "once_cell",
  "pbkdf2",

--- a/bip32/Cargo.toml
+++ b/bip32/Cargo.toml
@@ -13,16 +13,15 @@ keywords    = ["crypto", "bip32", "bip39", "derivation", "mnemonic"]
 
 [dependencies]
 bs58 = { version = "0.4", default-features = false, features = ["check"] }
-hmac = "0.11"
-ripemd160 = "0.9"
-sha2 = "0.9"
-subtle = "2"
+hmac = { version = "0.11", default-features = false }
+ripemd160 = { version = "0.9", default-features = false }
+sha2 = { version = "0.9", default-features = false }
+subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false, path = "../zeroize" }
 
 [dependencies.hkd32]
 version = "0.5"
 default-features = false
-features = ["bip39", "mnemonic"]
 path = "../hkd32"
 
 [dependencies.k256]
@@ -35,9 +34,11 @@ features = ["arithmetic", "ecdsa", "zeroize"]
 hex-literal = "0.3"
 
 [features]
-default = ["secp256k1", "std"]
+default = ["bip39", "secp256k1", "std"]
+alloc = ["zeroize/alloc"]
+bip39 = ["hkd32/bip39", "std"]
 secp256k1 = ["k256"]
-std = []
+std = ["alloc"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/bip32/src/derivation_path.rs
+++ b/bip32/src/derivation_path.rs
@@ -11,6 +11,7 @@ use core::{
 const PREFIX: &str = "m";
 
 /// Derivation paths within a hierarchical keyspace.
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct DerivationPath {
     path: Vec<ChildNumber>,

--- a/bip32/src/extended_key.rs
+++ b/bip32/src/extended_key.rs
@@ -112,7 +112,7 @@ impl Drop for ExtendedKey {
 }
 
 // TODO(tarcieri): consolidate test vectors
-#[cfg(test)]
+#[cfg(all(test, feature = "alloc"))]
 mod tests {
     use super::ExtendedKey;
     use alloc::string::ToString;

--- a/bip32/src/extended_key/public_key.rs
+++ b/bip32/src/extended_key/public_key.rs
@@ -4,11 +4,13 @@ use crate::{
     Error, ExtendedKey, ExtendedKeyAttrs, ExtendedPrivateKey, KeyFingerprint, Prefix, PrivateKey,
     PublicKey, PublicKeyBytes, Result,
 };
-use alloc::string::{String, ToString};
 use core::{
     convert::{TryFrom, TryInto},
     str::FromStr,
 };
+
+#[cfg(feature = "alloc")]
+use alloc::string::{String, ToString};
 
 /// Extended public secp256k1 ECDSA verification key.
 #[cfg(feature = "secp256k1")]
@@ -64,6 +66,8 @@ where
     }
 
     /// Serialize this key as a `String`.
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn to_string(&self, prefix: Prefix) -> String {
         self.to_extended_key(prefix).to_string()
     }

--- a/bip32/src/lib.rs
+++ b/bip32/src/lib.rs
@@ -9,22 +9,24 @@
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 #[cfg(feature = "std")]
 extern crate std;
 
 mod child_number;
-mod derivation_path;
 mod error;
 mod extended_key;
 mod prefix;
 mod private_key;
 mod public_key;
 
+#[cfg(feature = "alloc")]
+mod derivation_path;
+
 pub use crate::{
     child_number::ChildNumber,
-    derivation_path::DerivationPath,
     error::{Error, Result},
     extended_key::{
         attrs::ExtendedKeyAttrs, private_key::ExtendedPrivateKey, public_key::ExtendedPublicKey,
@@ -34,10 +36,14 @@ pub use crate::{
     private_key::{PrivateKey, PrivateKeyBytes},
     public_key::{PublicKey, PublicKeyBytes},
 };
-pub use hkd32::{
-    mnemonic::{Language, Phrase as Mnemonic, Seed},
-    KEY_SIZE,
-};
+pub use hkd32::KEY_SIZE;
+
+#[cfg(feature = "alloc")]
+pub use crate::derivation_path::DerivationPath;
+
+#[cfg(feature = "bip39")]
+#[cfg_attr(docsrs, doc(cfg(feature = "bip39")))]
+pub use hkd32::mnemonic::{Language, Phrase as Mnemonic, Seed};
 
 #[cfg(feature = "secp256k1")]
 #[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]

--- a/bip32/tests/bip32_vectors.rs
+++ b/bip32/tests/bip32_vectors.rs
@@ -15,7 +15,7 @@ use hex_literal::hex;
 ///
 /// Panics if anything goes wrong.
 fn derive_xprv(seed: &Seed, path: &str) -> XPrv {
-    XPrv::derive_child_from_path(&seed, &path.parse().unwrap()).unwrap()
+    XPrv::derive_child_from_seed(&seed, &path.parse().unwrap()).unwrap()
 }
 
 /// BIP32 test vector 2

--- a/hkd32/Cargo.toml
+++ b/hkd32/Cargo.toml
@@ -7,37 +7,40 @@ repeated applications of the Hash-based Message Authentication Code
 (HMAC) construction. Optionally supports storing root derivation
 passwords as a 24-word mnemonic phrase (i.e. BIP39).
 """
-version     = "0.5.0" # Also update html_root_url in lib.rs when bumping this
-authors     = ["Tony Arcieri <tony@iqlusion.io>"]
-license     = "Apache-2.0"
-edition     = "2018"
-homepage    = "https://github.com/iqlusioninc/crates/"
-repository  = "https://github.com/iqlusioninc/crates/tree/main/hkd32"
-readme      = "README.md"
-categories  = ["cryptography", "no-std"]
-keywords    = ["crypto", "bip32", "bip39", "derivation", "mnemonic"]
+version    = "0.5.0" # Also update html_root_url in lib.rs when bumping this
+authors    = ["Tony Arcieri <tony@iqlusion.io>"]
+license    = "Apache-2.0 OR MIT"
+homepage   = "https://github.com/iqlusioninc/crates/"
+repository = "https://github.com/iqlusioninc/crates/tree/main/hkd32"
+edition    = "2018"
+readme     = "README.md"
+categories = ["cryptography", "no-std"]
+keywords   = ["crypto", "bip32", "bip39", "derivation", "mnemonic"]
 
 [badges]
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
 hmac = { version = "0.11", default-features = false }
-once_cell = { version = "1", optional = true }
-pbkdf2 = { version = "0.8", optional = true, default-features = false }
 rand_core = { version = "0.5", default-features = false }
 sha2 = { version = "0.9", default-features = false }
-subtle-encoding = { version = "0.5", optional = true, path = "../subtle-encoding" }
 zeroize = { version = "1", default-features = false, features = ["zeroize_derive"], path = "../zeroize" }
 
+# optional dependencies
+once_cell = { version = "1", optional = true }
+pbkdf2 = { version = "0.8", optional = true, default-features = false }
+subtle-encoding = { version = "0.5", optional = true, default-features = false, path = "../subtle-encoding" }
+
 [dev-dependencies]
+hex-literal = "0.3"
 rand_core = { version = "0.5", features = ["std"] }
 
 [features]
 default = ["alloc", "bech32"]
 alloc = ["zeroize/alloc"]
 bech32 = ["alloc", "subtle-encoding/bech32-preview"]
-mnemonic = ["alloc", "rand_core/std", "once_cell"]
 bip39 = ["mnemonic", "pbkdf2"]
+mnemonic = ["alloc", "once_cell"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/hkd32/tests/bip39_vectors.rs
+++ b/hkd32/tests/bip39_vectors.rs
@@ -4,29 +4,26 @@
 
 use core::convert::TryInto;
 use hkd32::mnemonic;
-use subtle_encoding::hex;
 
-fn test_mnemonic(entropy_hex: &str, expected_phrase: &str) {
-    let entropy_bytes = hex::decode(entropy_hex).unwrap();
+fn test_mnemonic(entropy_bytes: &[u8], expected_phrase: &str) {
     let mnemonic = mnemonic::Phrase::from_entropy(
-        entropy_bytes.as_slice().try_into().unwrap(),
+        entropy_bytes.try_into().unwrap(),
         mnemonic::Language::English,
     );
     assert_eq!(mnemonic.phrase(), expected_phrase);
 }
 
-fn test_seed(phrase: &str, password: &str, expected_seed_hex: &str) {
+fn test_seed(phrase: &str, password: &str, expected_seed_bytes: &[u8]) {
     let mnemonic = mnemonic::Phrase::new(phrase, mnemonic::Language::English).unwrap();
     let seed = mnemonic.to_seed(password);
     let actual_seed_bytes: &[u8] = seed.as_bytes();
-    let expected_seed_bytes = hex::decode(expected_seed_hex).unwrap();
 
     assert!(
-        actual_seed_bytes.eq(expected_seed_bytes.as_slice()),
+        actual_seed_bytes.eq(expected_seed_bytes),
         "Wrong seed for '{}'\nexp: {:?}\nact: {:?}\n",
         phrase,
-        expected_seed_hex,
-        String::from_utf8(hex::encode(actual_seed_bytes)).unwrap()
+        expected_seed_bytes,
+        actual_seed_bytes
     );
 }
 
@@ -36,7 +33,7 @@ macro_rules! tests {
             #[test]
             fn test_all() {
                 $(
-                    super::test_mnemonic($entropy_hex, $phrase);
+                    super::test_mnemonic(&hex_literal::hex!($entropy_hex), $phrase);
                 )*
             }
         }
@@ -45,7 +42,7 @@ macro_rules! tests {
             #[test]
             fn test_all() {
                 $(
-                    super::test_seed($phrase, "TREZOR", $seed_hex);
+                    super::test_seed($phrase, "TREZOR", &hex_literal::hex!($seed_hex));
                 )*
             }
         }


### PR DESCRIPTION
The only thing that presently requires `alloc` is `DerivationPath`.

This commit makes `DerivationPath` optional, and feature-gated under a newly added `alloc` feature.

Additionally, this commit tests `no_std` builds of both `bip32` and `hkd32`, including builds on WASM.