### PR TITLE
Switch to `resolver = "2"`; MSRV 1.51

### DIFF
--- a/.github/workflows/anomaly.yml
+++ b/.github/workflows/anomaly.yml
@@ -25,7 +25,7 @@ jobs:
           - macos-latest
           - windows-latest
         toolchain:
-          - 1.47.0
+          - 1.51.0 # MSRV
           - stable
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/bip32.yml
+++ b/.github/workflows/bip32.yml
@@ -25,7 +25,7 @@ jobs:
           - macos-latest
           - windows-latest
         toolchain:
-          - 1.48.0 # MSRV
+          - 1.51.0 # MSRV
           - stable
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/canonical-path.yml
+++ b/.github/workflows/canonical-path.yml
@@ -25,7 +25,7 @@ jobs:
           - macos-latest
           - windows-latest
         toolchain:
-          - 1.47.0
+          - 1.51.0 # MSRV
           - stable
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/datadog.yml
+++ b/.github/workflows/datadog.yml
@@ -25,7 +25,7 @@ jobs:
           - macos-latest
           - windows-latest
         toolchain:
-          - 1.47.0
+          - 1.51.0 # MSRV
           - stable
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/harp.yml
+++ b/.github/workflows/harp.yml
@@ -25,7 +25,7 @@ jobs:
           - macos-latest
           - windows-latest
         toolchain:
-          - 1.47.0
+          - 1.51.0 # MSRV
           - stable
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/hkd32.yml
+++ b/.github/workflows/hkd32.yml
@@ -25,7 +25,7 @@ jobs:
           - macos-latest
           - windows-latest
         toolchain:
-          - 1.47.0
+          - 1.51.0 # MSRV
           - stable
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/iqhttp.yml
+++ b/.github/workflows/iqhttp.yml
@@ -25,7 +25,7 @@ jobs:
           - macos-latest
           - windows-latest
         toolchain:
-          - 1.47.0
+          - 1.51.0 # MSRV
           - stable
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/mintscan.yml
+++ b/.github/workflows/mintscan.yml
@@ -25,7 +25,7 @@ jobs:
           - macos-latest
           - windows-latest
         toolchain:
-          - 1.47.0
+          - 1.51.0 # MSRV
           - stable
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/secrecy.yml
+++ b/.github/workflows/secrecy.yml
@@ -25,7 +25,7 @@ jobs:
           - macos-latest
           - windows-latest
         toolchain:
-          - 1.47.0
+          - 1.51.0 # MSRV
           - stable
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/stdtx.yml
+++ b/.github/workflows/stdtx.yml
@@ -25,7 +25,7 @@ jobs:
           - macos-latest
           - windows-latest
         toolchain:
-          - 1.47.0
+          - 1.51.0 # MSRV
           - stable
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/subtle-encoding.yml
+++ b/.github/workflows/subtle-encoding.yml
@@ -25,7 +25,7 @@ jobs:
           - macos-latest
           - windows-latest
         toolchain:
-          - 1.47.0
+          - 1.51.0 # MSRV
           - stable
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/tai64.yml
+++ b/.github/workflows/tai64.yml
@@ -25,7 +25,7 @@ jobs:
           - macos-latest
           - windows-latest
         toolchain:
-          - 1.47.0
+          - 1.51.0 # MSRV
           - stable
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.48.0 # Bump if needed
+          toolchain: 1.51.0 # MSRV
           components: clippy
           override: true
           profile: minimal
@@ -47,7 +47,7 @@ jobs:
         env:
           CARGO_INCREMENTAL: 0
         with:
-          version: 0.11.0
+          version: 0.11.0 # switch to `latest` when we bump `k256` to v0.9
           args: --all -- --test-threads 1
       - uses: codecov/codecov-action@v1
       - uses: actions/upload-artifact@v1

--- a/.github/workflows/zeroize.yml
+++ b/.github/workflows/zeroize.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.47.0 # MSRV
+          - 1.51.0 # MSRV
           - stable
         target:
           - armv7a-none-eabi
@@ -46,7 +46,7 @@ jobs:
           - macos-latest
           - windows-latest
         toolchain:
-          - 1.47.0 # MSRV
+          - 1.51.0 # MSRV
           - stable
     runs-on: ${{ matrix.platform }}
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "anomaly",
     "bip32",
@@ -15,9 +16,3 @@ members = [
     "zeroize",
     "zeroize/derive"
 ]
-
-# Enable integer overflow checks in release builds
-# WARNING: DO NOT REMOVE THIS! We rely on this for panic-on-overflow semantics
-# in the event of integer arithmetic bugs.
-[profile.release]
-overflow-checks = true

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ without any additional terms or conditions.
 
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/crates/blob/main/LICENSE
-[msrv-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
+[msrv-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
 
 [//]: # (crates)
 

--- a/anomaly/README.md
+++ b/anomaly/README.md
@@ -52,7 +52,7 @@ from real-world libraries and applications, most notably [Abscissa].
 
 ## Minimum Supported Rust Version
 
-Rust **1.47** or newer.
+Rust **1.51** or newer.
 
 In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
 for this crate's SemVer guarantees), however when we do it will be accompanied by
@@ -81,7 +81,7 @@ without any additional terms or conditions.
 [docs-image]: https://docs.rs/anomaly/badge.svg
 [docs-link]: https://docs.rs/anomaly/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
 [build-image]: https://github.com/iqlusioninc/crates/actions/workflows/anomaly.yml/badge.svg

--- a/bip32/README.md
+++ b/bip32/README.md
@@ -15,7 +15,7 @@ BIP32 hierarchical key derivation.
 
 ## Minimum Supported Rust Version
 
-Rust **1.48** or newer.
+Rust **1.51** or newer.
 
 In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
 for this crate's SemVer guarantees), however when we do it will be accompanied by
@@ -45,7 +45,7 @@ without any additional terms or conditions.
 [docs-link]: https://docs.rs/bip32/
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/crates/blob/main/LICENSE
-[rustc-image]: https://img.shields.io/badge/rustc-1.48+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
 [build-image]: https://github.com/iqlusioninc/crates/actions/workflows/bip32.yml/badge.svg

--- a/canonical-path/README.md
+++ b/canonical-path/README.md
@@ -17,7 +17,7 @@ are canonical, or at least, were canonical at the time they were created.
 
 ## Minimum Supported Rust Version
 
-Rust **1.47** or newer.
+Rust **1.51** or newer.
 
 In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
 for this crate's SemVer guarantees), however when we do it will be accompanied by
@@ -53,6 +53,6 @@ without any additional terms or conditions.
 [docs-link]: https://docs.rs/canonical-path/
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/crates/blob/main/LICENSE
-[rustc-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
 [build-image]: https://github.com/iqlusioninc/crates/actions/workflows/canonical-path.yml/badge.svg
 [build-link]: https://github.com/iqlusioninc/crates/actions/workflows/canonical-path.yml

--- a/datadog/README.md
+++ b/datadog/README.md
@@ -13,7 +13,7 @@ Client library for the [Datadog] service.
 
 ## Minimum Supported Rust Version
 
-Rust **1.47** or newer.
+Rust **1.51** or newer.
 
 In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
 for this crate's SemVer guarantees), however when we do it will be accompanied by
@@ -47,7 +47,7 @@ without any additional terms or conditions.
 [docs-link]: https://docs.rs/datadog/
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/crates/blob/main/LICENSE
-[rustc-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
 [build-image]: https://github.com/iqlusioninc/crates/actions/workflows/datadog.yml/badge.svg

--- a/harp/README.md
+++ b/harp/README.md
@@ -21,7 +21,7 @@ such as Intel SGX or `#![no_std]` environments.
 
 ## Minimum Supported Rust Version
 
-Rust **1.47** or newer.
+Rust **1.51** or newer.
 
 In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
 for this crate's SemVer guarantees), however when we do it will be accompanied by
@@ -57,7 +57,7 @@ without any additional terms or conditions.
 [docs-link]: https://docs.rs/harp/
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/crates/blob/main/LICENSE
-[rustc-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
 [build-image]: https://github.com/iqlusioninc/crates/actions/workflows/harp.yml/badge.svg

--- a/hkd32/README.md
+++ b/hkd32/README.md
@@ -22,7 +22,7 @@ an initial 32-bytes of input key material.
 
 ## Minimum Supported Rust Version
 
-- Rust **1.47**
+- Rust **1.51**
 
 ## License
 
@@ -51,7 +51,7 @@ without any additional terms or conditions.
 [docs-link]: https://docs.rs/hkd32/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [license-link]: https://github.com/iqlusioninc/crates/blob/main/LICENSE
-[rustc-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
 [build-image]: https://github.com/iqlusioninc/crates/actions/workflows/hkd32.yml/badge.svg
 [build-link]: https://github.com/iqlusioninc/crates/actions/workflows/hkd32.yml
 

--- a/iqhttp/README.md
+++ b/iqhttp/README.md
@@ -13,7 +13,7 @@ built-in SSL/TLS support based on [`rustls`].
 
 ## Minimum Supported Rust Version
 
-- Rust **1.47**
+- Rust **1.51**
 
 ## License
 
@@ -39,7 +39,7 @@ without any additional terms or conditions.
 [docs-link]: https://docs.rs/iqhttp/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [license-link]: https://github.com/iqlusioninc/crates/blob/main/LICENSE
-[rustc-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
 [build-image]: https://github.com/iqlusioninc/crates/actions/workflows/iqhttp.yml/badge.svg
 [build-link]: https://github.com/iqlusioninc/crates/actions/workflows/iqhttp.yml
 

--- a/mintscan/README.md
+++ b/mintscan/README.md
@@ -12,7 +12,7 @@ API client for the [Mintscan] Cosmos explorer by [Cosmostation].
 
 ## Minimum Supported Rust Version
 
-- Rust **1.47**
+- Rust **1.51**
 
 ## License
 
@@ -38,7 +38,7 @@ without any additional terms or conditions.
 [docs-link]: https://docs.rs/mintscan/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [license-link]: https://github.com/iqlusioninc/crates/blob/main/LICENSE
-[rustc-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
 [build-image]: https://github.com/iqlusioninc/crates/actions/workflows/mintscan.yml/badge.svg
 [build-link]: https://github.com/iqlusioninc/crates/actions/workflows/mintscan.yml
 

--- a/secrecy/README.md
+++ b/secrecy/README.md
@@ -24,7 +24,7 @@ from memory when dropped.
 
 ## Minimum Supported Rust Version
 
-Rust **1.47** or newer.
+Rust **1.51** or newer.
 
 In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
 for this crate's SemVer guarantees), however when we do it will be accompanied by
@@ -66,7 +66,7 @@ without any additional terms or conditions.
 [docs-image]: https://docs.rs/secrecy/badge.svg
 [docs-link]: https://docs.rs/secrecy/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
 [build-image]: https://github.com/iqlusioninc/crates/actions/workflows/secrecy.yml/badge.svg

--- a/stdtx/README.md
+++ b/stdtx/README.md
@@ -26,7 +26,7 @@ uses the [StdTx] format without requiring upstream modifications.
 
 ## Minimum Supported Rust Version
 
-Rust **1.47** or newer.
+Rust **1.51** or newer.
 
 In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
 for this crate's SemVer guarantees), however when we do it will be accompanied by
@@ -60,7 +60,7 @@ limitations under the License.
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/crates/blob/main/LICENSE
-[msrv-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
+[msrv-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
 
 [//]: # (general links)
 

--- a/stdtx/src/amino/msg.rs
+++ b/stdtx/src/amino/msg.rs
@@ -12,7 +12,7 @@ use super::{schema::ValueType, Schema, TypeName};
 use crate::{Address, Decimal, Error};
 use eyre::{Result, WrapErr};
 use prost_amino::encode_length_delimiter as encode_leb128; // Little-endian Base 128
-use std::{collections::BTreeMap, iter::FromIterator};
+use std::collections::BTreeMap;
 use subtle_encoding::hex;
 
 /// Tags are indexes which identify message fields
@@ -153,7 +153,7 @@ impl Msg {
 
         json.insert(
             "value".to_owned(),
-            serde_json::Map::from_iter(values.into_iter()).into(),
+            values.into_iter().collect::<serde_json::Map<_, _>>().into(),
         );
 
         serde_json::Value::Object(json)

--- a/subtle-encoding/README.md
+++ b/subtle-encoding/README.md
@@ -21,7 +21,7 @@ Useful for encoding/decoding secret values such as cryptographic keys.
 
 ## Minimum Supported Rust Version
 
-Rust **1.47** or newer.
+Rust **1.51** or newer.
 
 In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
 for this crate's SemVer guarantees), however when we do it will be accompanied by
@@ -55,7 +55,7 @@ toplevel directory of this repository or [LICENSE-MIT] for details.
 [docs-image]: https://docs.rs/subtle-encoding/badge.svg
 [docs-link]: https://docs.rs/subtle-encoding/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
 [build-image]: https://github.com/iqlusioninc/crates/actions/workflows/subtle-encoding.yml/badge.svg

--- a/tai64/README.md
+++ b/tai64/README.md
@@ -17,7 +17,7 @@ Supports converting to/from Rust's built-in [SystemTime] type and optionally to
 
 ## Minimum Supported Rust Version
 
-Rust **1.47** or newer.
+Rust **1.51** or newer.
 
 In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
 for this crate's SemVer guarantees), however when we do it will be accompanied by
@@ -51,7 +51,7 @@ without any additional terms or conditions.
 [docs-link]: https://docs.rs/tai64/
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/crates/blob/main/LICENSE
-[rustc-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
 [build-image]: https://github.com/iqlusioninc/crates/actions/workflows/tai64.yml/badge.svg

--- a/tai64/src/lib.rs
+++ b/tai64/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![no_std]
 #![doc(html_root_url = "https://docs.rs/tai64/3.1.0")]
+#![allow(clippy::upper_case_acronyms)]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 

--- a/zeroize/README.md
+++ b/zeroize/README.md
@@ -36,7 +36,7 @@ thereof, implemented in pure Rust with no usage of FFI or assembly.
 
 ## Minimum Supported Rust Version
 
-Rust **1.47** or newer.
+Rust **1.51** or newer.
 
 In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
 for this crate's SemVer guarantees), however when we do it will be accompanied by
@@ -63,7 +63,7 @@ without any additional terms or conditions.
 [docs-image]: https://docs.rs/zeroize/badge.svg
 [docs-link]: https://docs.rs/zeroize/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
 [build-image]: https://github.com/iqlusioninc/crates/actions/workflows/zeroize.yml/badge.svg
 [build-link]: https://github.com/iqlusioninc/crates/actions/workflows/zeroize.yml
 

--- a/zeroize/derive/README.md
+++ b/zeroize/derive/README.md
@@ -13,7 +13,7 @@ See [zeroize] crate for documentation.
 
 ## Minimum Supported Rust Version
 
-Rust **1.47** or newer.
+Rust **1.51** or newer.
 
 In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
 for this crate's SemVer guarantees), however when we do it will be accompanied by
@@ -38,7 +38,7 @@ without any additional terms or conditions.
 [crate-image]: https://img.shields.io/crates/v/zeroize_derive.svg
 [crate-link]: https://crates.io/crates/zeroize_derive
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
 [build-image]: https://github.com/iqlusioninc/crates/workflows/Rust/badge.svg?branch=main&event=push
 [build-link]: https://github.com/iqlusioninc/crates/actions
 

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -22,7 +22,7 @@
 //!
 //! ## Minimum Supported Rust Version
 //!
-//! Requires Rust **1.47** or newer.
+//! Requires Rust **1.51** or newer.
 //!
 //! In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
 //! for this crate's SemVer guarantees), however when we do it will be accompanied


### PR DESCRIPTION
This resolver prevents build and dev dependencies from being mixed into the actual crate dependencies, which makes it easier to develop/test crates which work on `no_std` platforms.

More info: https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html#cargos-new-feature-resolver