### PR TITLE
bip32: secp256k1-ffi feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,7 @@ dependencies = [
  "hmac 0.11.0",
  "k256",
  "ripemd160",
+ "secp256k1",
  "sha2",
  "subtle",
  "zeroize 1.3.0",
@@ -1508,6 +1509,24 @@ checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee5070fdc6f26ca5be6dcfc3d07c76fdb974a63a8b246b459854274145f5a258"
+dependencies = [
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67e4b6455ee49f5901c8985b88f98fb0a0e1d90a6661f5a03f4888bd987dad29"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/bip32/Cargo.toml
+++ b/bip32/Cargo.toml
@@ -1,28 +1,31 @@
 [package]
 name = "bip32"
-description = "BIP32 hierarchical key derivation"
-version     = "0.0.0" # Also update html_root_url in lib.rs when bumping this
-authors     = ["Tony Arcieri <tony@iqlusion.io>"]
-license     = "Apache-2.0 OR MIT"
-edition     = "2018"
-homepage    = "https://github.com/iqlusioninc/crates/"
-repository  = "https://github.com/iqlusioninc/crates/tree/develop/bip32"
-readme      = "README.md"
-categories  = ["cryptography", "no-std"]
-keywords    = ["crypto", "bip32", "bip39", "derivation", "mnemonic"]
+description = """
+BIP32 hierarchical key derivation implemented in a generic, no_std-friendly
+manner. Supports deriving keys using the pure Rust k256 crate or the
+C library-backed secp256k1 crate
+"""
+version    = "0.0.0" # Also update html_root_url in lib.rs when bumping this
+authors    = ["Tony Arcieri <tony@iqlusion.io>"]
+license    = "Apache-2.0 OR MIT"
+homepage   = "https://github.com/iqlusioninc/crates/"
+repository = "https://github.com/iqlusioninc/crates/tree/develop/bip32"
+categories = ["cryptography", "no-std"]
+keywords   = ["crypto", "bip32", "bip39", "derivation", "mnemonic"]
+edition    = "2018"
+readme     = "README.md"
 
 [dependencies]
 bs58 = { version = "0.4", default-features = false, features = ["check"] }
+hkd32 = { version = "0.5", default-features = false, path = "../hkd32" }
 hmac = { version = "0.11", default-features = false }
 ripemd160 = { version = "0.9", default-features = false }
 sha2 = { version = "0.9", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false, path = "../zeroize" }
 
-[dependencies.hkd32]
-version = "0.5"
-default-features = false
-path = "../hkd32"
+# optional dependencies
+secp256k1-ffi = { package = "secp256k1", version = "0.20", optional = true }
 
 [dependencies.k256]
 version = "0.7"

--- a/bip32/README.md
+++ b/bip32/README.md
@@ -7,11 +7,20 @@
 [![Safety Dance][safety-image]][safety-link]
 [![Build Status][build-image]][build-link]
 
-BIP32 hierarchical key derivation.
+BIP32 hierarchical key derivation implemented in a generic, `no_std`-friendly
+manner. Supports deriving keys using the pure Rust `k256` crate or the
+C library-backed `secp256k1` crate.
 
 ![Diagram](https://raw.githubusercontent.com/bitcoin/bips/4bc05ff903cb47eb18ce58a9836de1ac13ecf1b7/bip-0032/derivation.png)
 
 [Documentation][docs-link]
+
+## About
+
+BIP32 is an algorithm for generating a hierarchy of elliptic curve keys,
+a.k.a. "wallets", from a single seed value. A related algorithm also
+implemented by this crate, BIP39, provides a way to derive the seed value
+from a set of 24-words from a preset list, a.k.a. a "mnemonic".
 
 ## Minimum Supported Rust Version
 
@@ -50,3 +59,9 @@ without any additional terms or conditions.
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
 [build-image]: https://github.com/iqlusioninc/crates/actions/workflows/bip32.yml/badge.svg
 [build-link]: https://github.com/iqlusioninc/crates/actions/workflows/bip32.yml
+
+[//]: # (links)
+
+[bip32]: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
+[libsecp256k1 C library]: https://github.com/bitcoin-core/secp256k1
+[`secp256k1` Rust crate]: https://github.com/rust-bitcoin/rust-secp256k1/

--- a/bip32/src/error.rs
+++ b/bip32/src/error.rs
@@ -23,6 +23,9 @@ pub enum Error {
 
     /// Maximum derivation depth exceeded.
     Depth,
+
+    /// Seed length invalid.
+    SeedLength,
 }
 
 impl Display for Error {
@@ -33,6 +36,7 @@ impl Display for Error {
             Error::Crypto => f.write_str("cryptographic error"),
             Error::Decode => f.write_str("decoding error"),
             Error::Depth => f.write_str("maximum derivation depth exceeded"),
+            Error::SeedLength => f.write_str("seed length invalid"),
         }
     }
 }
@@ -77,6 +81,14 @@ impl From<k256::elliptic_curve::Error> for Error {
 #[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
 impl From<k256::ecdsa::Error> for Error {
     fn from(_: k256::ecdsa::Error) -> Error {
+        Error::Crypto
+    }
+}
+
+#[cfg(feature = "secp256k1-ffi")]
+#[cfg_attr(docsrs, doc(cfg(feature = "secp256k1-ffi")))]
+impl From<secp256k1_ffi::Error> for Error {
+    fn from(_: secp256k1_ffi::Error) -> Error {
         Error::Crypto
     }
 }

--- a/bip32/src/lib.rs
+++ b/bip32/src/lib.rs
@@ -1,7 +1,26 @@
 //! Pure Rust implementation of
 //! [BIP-0032: Hierarchical Deterministic Wallets][bip32].
 //!
+//! # About
+//! BIP32 is an algorithm for generating a hierarchy of elliptic curve keys,
+//! a.k.a. "wallets", from a single seed value. A related algorithm also
+//! implemented by this crate, BIP39, provides a way to derive the seed value
+//! from a set of 24-words from a preset list, a.k.a. a "mnemonic".
+//!
+//! # Backends
+//! This crate provides a generic implementation of BIP32 which can be used
+//! with any backing provider which implements the [`PrivateKey`] and
+//! [`PublicKey`] traits. The following providers are built into this crate,
+//! under the following crate features:
+//!
+//! - `secp256k1` (enabled by default): support for the pure Rust [`k256`]
+//!   crate, with [`XPrv`] and [`XPub`] type aliases.
+//! - `secp256k1-ffi`: support for Bitcoin Core's [libsecp256k1 C library],
+//!   as wrapped by the [`secp256k1` Rust crate].
+//!
 //! [bip32]: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
+//! [libsecp256k1 C library]: https://github.com/bitcoin-core/secp256k1
+//! [`secp256k1` Rust crate]: https://github.com/rust-bitcoin/rust-secp256k1/
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/bip32/src/prefix.rs
+++ b/bip32/src/prefix.rs
@@ -106,22 +106,22 @@ impl Prefix {
     }
 
     /// Is this a public key?
-    pub fn is_public(&self) -> bool {
+    pub fn is_public(self) -> bool {
         &self.chars[1..] == b"pub"
     }
 
     /// Is this a private key?
-    pub fn is_private(&self) -> bool {
+    pub fn is_private(self) -> bool {
         &self.chars[1..] == b"prv"
     }
 
     /// Get the [`Version`] number.
-    pub fn version(&self) -> Version {
+    pub fn version(self) -> Version {
         self.version
     }
 
     /// Serialize the [`Version`] number as big-endian bytes.
-    pub fn to_bytes(&self) -> [u8; Self::LENGTH] {
+    pub fn to_bytes(self) -> [u8; Self::LENGTH] {
         self.version.to_be_bytes()
     }
 

--- a/bip32/src/private_key.rs
+++ b/bip32/src/private_key.rs
@@ -9,7 +9,6 @@ use crate::Error;
 pub type PrivateKeyBytes = [u8; KEY_SIZE];
 
 /// Trait for key types which can be derived using BIP32.
-// TODO(tarcieri): add `ConstantTimeEq` bound
 pub trait PrivateKey: Sized {
     /// Public key type which corresponds to this private key.
     type PublicKey: PublicKey;
@@ -76,5 +75,55 @@ impl PrivateKey for k256::ecdsa::SigningKey {
 
     fn public_key(&self) -> Self::PublicKey {
         self.verify_key()
+    }
+}
+
+#[cfg(feature = "secp256k1-ffi")]
+#[cfg_attr(docsrs, doc(cfg(feature = "secp256k1-ffi")))]
+impl PrivateKey for secp256k1_ffi::SecretKey {
+    type PublicKey = secp256k1_ffi::PublicKey;
+
+    fn from_bytes(bytes: &PrivateKeyBytes) -> Result<Self> {
+        Ok(secp256k1_ffi::SecretKey::from_slice(bytes)?)
+    }
+
+    fn to_bytes(&self) -> PrivateKeyBytes {
+        *self.as_ref()
+    }
+
+    fn derive_child(&self, left_half: PrivateKeyBytes) -> Result<Self> {
+        let mut child = *self;
+        child.add_assign(&left_half)?;
+        Ok(child)
+    }
+
+    fn public_key(&self) -> Self::PublicKey {
+        use secp256k1_ffi::{Secp256k1, SignOnly};
+        let engine = Secp256k1::<SignOnly>::signing_only();
+        secp256k1_ffi::PublicKey::from_secret_key(&engine, self)
+    }
+}
+
+/// `secp256k1-ffi` smoke tests
+#[cfg(all(test, feature = "secp256k1-ffi"))]
+mod tests {
+    use hex_literal::hex;
+
+    type XPrv = crate::ExtendedPrivateKey<secp256k1_ffi::SecretKey>;
+
+    #[test]
+    fn secp256k1_ffi_derivation() {
+        let seed = hex!(
+            "fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a2
+             9f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542"
+        );
+
+        let path = "m/0/2147483647'/1/2147483646'/2";
+        let xprv = XPrv::derive_child_from_seed(&seed, &path.parse().unwrap()).unwrap();
+
+        assert_eq!(
+            xprv,
+            "xprvA2nrNbFZABcdryreWet9Ea4LvTJcGsqrMzxHx98MMrotbir7yrKCEXw7nadnHM8Dq38EGfSh6dqA9QWTyefMLEcBYJUuekgW4BYPJcr9E7j".parse().unwrap()
+        );
     }
 }

--- a/bip32/tests/bip32_vectors.rs
+++ b/bip32/tests/bip32_vectors.rs
@@ -1,31 +1,105 @@
-//! BIP32 test vectors.
+//! BIP32 Test Vectors.
 //!
 //! Sourced from: <https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#Test_Vectors>
 //!
 //! Note: Test vector 1 is omitted (for now) because the seed is smaller than
 //! what we currently support.
-// TODO(tarcieri): test `xpub`s, add test vector 1, consolidate test vectors
+// TODO(tarcieri): consolidate test vectors
 
 #![cfg(feature = "secp256k1")]
 
-use bip32::{Prefix, Seed, XPrv};
+use bip32::{Prefix, XPrv};
 use hex_literal::hex;
 
 /// Derive an [`XPrv`] for the given seed and derivation path.
 ///
 /// Panics if anything goes wrong.
-fn derive_xprv(seed: &Seed, path: &str) -> XPrv {
+fn derive_xprv(seed: &[u8], path: &str) -> XPrv {
     XPrv::derive_child_from_seed(&seed, &path.parse().unwrap()).unwrap()
 }
 
-/// BIP32 test vector 2
-/// <https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#test-vector-2>
+/// BIP32 Test Vector 1
+/// <https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#Test_vector_1>
+#[test]
+fn test_vector_1() {
+    let seed = hex!("000102030405060708090a0b0c0d0e0f");
+
+    // Chain m
+    let key_m = derive_xprv(&seed, "m");
+    assert_eq!(key_m, XPrv::new(&seed).unwrap());
+    assert_eq!(
+        &*key_m.to_string(Prefix::XPRV),
+        "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi"
+    );
+    assert_eq!(
+        key_m.public_key().to_string(Prefix::XPUB),
+        "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8"
+    );
+
+    // Chain m/0'
+    let key_m_0h = derive_xprv(&seed, "m/0'");
+    assert_eq!(
+        &*key_m_0h.to_string(Prefix::XPRV),
+        "xprv9uHRZZhk6KAJC1avXpDAp4MDc3sQKNxDiPvvkX8Br5ngLNv1TxvUxt4cV1rGL5hj6KCesnDYUhd7oWgT11eZG7XnxHrnYeSvkzY7d2bhkJ7"
+    );
+    assert_eq!(
+        key_m_0h.public_key().to_string(Prefix::XPUB),
+        "xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw"
+    );
+
+    // Chain m/0'/1
+    let key_m_0h_1 = derive_xprv(&seed, "m/0'/1");
+    assert_eq!(
+        &*key_m_0h_1.to_string(Prefix::XPRV),
+        "xprv9wTYmMFdV23N2TdNG573QoEsfRrWKQgWeibmLntzniatZvR9BmLnvSxqu53Kw1UmYPxLgboyZQaXwTCg8MSY3H2EU4pWcQDnRnrVA1xe8fs"
+    );
+    assert_eq!(
+        key_m_0h_1.public_key().to_string(Prefix::XPUB),
+        "xpub6ASuArnXKPbfEwhqN6e3mwBcDTgzisQN1wXN9BJcM47sSikHjJf3UFHKkNAWbWMiGj7Wf5uMash7SyYq527Hqck2AxYysAA7xmALppuCkwQ"
+    );
+
+    // Chain m/0'/1/2'
+    let key_m_0h_1_2h = derive_xprv(&seed, "m/0'/1/2'");
+    assert_eq!(
+        &*key_m_0h_1_2h.to_string(Prefix::XPRV),
+        "xprv9z4pot5VBttmtdRTWfWQmoH1taj2axGVzFqSb8C9xaxKymcFzXBDptWmT7FwuEzG3ryjH4ktypQSAewRiNMjANTtpgP4mLTj34bhnZX7UiM"
+    );
+    assert_eq!(
+        key_m_0h_1_2h.public_key().to_string(Prefix::XPUB),
+        "xpub6D4BDPcP2GT577Vvch3R8wDkScZWzQzMMUm3PWbmWvVJrZwQY4VUNgqFJPMM3No2dFDFGTsxxpG5uJh7n7epu4trkrX7x7DogT5Uv6fcLW5"
+    );
+
+    // Chain m/0'/1/2'/2
+    let key_m_0h_1_2h_2 = derive_xprv(&seed, "m/0'/1/2'/2");
+    assert_eq!(
+        &*key_m_0h_1_2h_2.to_string(Prefix::XPRV),
+        "xprvA2JDeKCSNNZky6uBCviVfJSKyQ1mDYahRjijr5idH2WwLsEd4Hsb2Tyh8RfQMuPh7f7RtyzTtdrbdqqsunu5Mm3wDvUAKRHSC34sJ7in334"
+    );
+    assert_eq!(
+        key_m_0h_1_2h_2.public_key().to_string(Prefix::XPUB),
+        "xpub6FHa3pjLCk84BayeJxFW2SP4XRrFd1JYnxeLeU8EqN3vDfZmbqBqaGJAyiLjTAwm6ZLRQUMv1ZACTj37sR62cfN7fe5JnJ7dh8zL4fiyLHV"
+    );
+
+    // Chain m/0'/1/2'/2/1000000000
+    let key_m_0h_1_2h_2_1000000000 = derive_xprv(&seed, "m/0'/1/2'/2/1000000000");
+    assert_eq!(
+        &*key_m_0h_1_2h_2_1000000000.to_string(Prefix::XPRV),
+        "xprvA41z7zogVVwxVSgdKUHDy1SKmdb533PjDz7J6N6mV6uS3ze1ai8FHa8kmHScGpWmj4WggLyQjgPie1rFSruoUihUZREPSL39UNdE3BBDu76"
+    );
+    assert_eq!(
+        key_m_0h_1_2h_2_1000000000.public_key().to_string(Prefix::XPUB),
+        "xpub6H1LXWLaKsWFhvm6RVpEL9P4KfRZSW7abD2ttkWP3SSQvnyA8FSVqNTEcYFgJS2UaFcxupHiYkro49S8yGasTvXEYBVPamhGW6cFJodrTHy"
+    );
+}
+
+/// BIP32 Test Vector 2
+/// <https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#Test_vector_2>
 #[test]
 fn test_vector_2() {
-    let seed = Seed::new(hex!(
+    let seed = hex!(
         "fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a2
          9f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542"
-    ));
+    );
 
     // Chain m
     let key_m = derive_xprv(&seed, "m");
@@ -95,18 +169,18 @@ fn test_vector_2() {
     );
 }
 
-/// BIP32 test vector 3
-/// <https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#test-vector-3>
+/// BIP32 Test Vector 3
+/// <https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#Test_vector_3>
 ///
 /// These vectors test for the retention of leading zeros. See:
 /// - <https://github.com/bitpay/bitcore-lib/issues/47>
 /// - <https://github.com/iancoleman/bip39/issues/58>
 #[test]
 fn test_vector_3() {
-    let seed = Seed::new(hex!(
+    let seed = hex!(
         "4b381541583be4423346c643850da4b320e46a87ae3d2a4e6da11eba819cd4ac
          ba45d239319ac14f863b8d5ab5a0d0c64d2e8a1e7d1457df2e5a3c51c73235be"
-    ));
+    );
 
     // Chain m
     let key_m = derive_xprv(&seed, "m");
@@ -129,5 +203,49 @@ fn test_vector_3() {
     assert_eq!(
         key_m_0h.public_key().to_string(Prefix::XPUB),
         "xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y"
+    );
+}
+
+/// BIP32 Test Vector 4
+/// <https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#test-vector-4>
+///
+/// These vectors test for the retention of leading zeros. See:
+/// <https://github.com/btcsuite/btcutil/issues/172>
+#[test]
+fn test_vector_4() {
+    let seed = hex!("3ddd5602285899a946114506157c7997e5444528f3003f6134712147db19b678");
+
+    // Chain m
+    let key_m = derive_xprv(&seed, "m");
+    assert_eq!(key_m, XPrv::new(&seed).unwrap());
+    assert_eq!(
+        &*key_m.to_string(Prefix::XPRV),
+        "xprv9s21ZrQH143K48vGoLGRPxgo2JNkJ3J3fqkirQC2zVdk5Dgd5w14S7fRDyHH4dWNHUgkvsvNDCkvAwcSHNAQwhwgNMgZhLtQC63zxwhQmRv"
+    );
+    assert_eq!(
+        key_m.public_key().to_string(Prefix::XPUB),
+        "xpub661MyMwAqRbcGczjuMoRm6dXaLDEhW1u34gKenbeYqAix21mdUKJyuyu5F1rzYGVxyL6tmgBUAEPrEz92mBXjByMRiJdba9wpnN37RLLAXa"
+    );
+
+    // Chain m/0'
+    let key_m_0h = derive_xprv(&seed, "m/0'");
+    assert_eq!(
+        &*key_m_0h.to_string(Prefix::XPRV),
+        "xprv9vB7xEWwNp9kh1wQRfCCQMnZUEG21LpbR9NPCNN1dwhiZkjjeGRnaALmPXCX7SgjFTiCTT6bXes17boXtjq3xLpcDjzEuGLQBM5ohqkao9G"
+    );
+    assert_eq!(
+        key_m_0h.public_key().to_string(Prefix::XPUB),
+        "xpub69AUMk3qDBi3uW1sXgjCmVjJ2G6WQoYSnNHyzkmdCHEhSZ4tBok37xfFEqHd2AddP56Tqp4o56AePAgCjYdvpW2PU2jbUPFKsav5ut6Ch1m"
+    );
+
+    // Chain m/0'/1'
+    let key_m_0h_1h = derive_xprv(&seed, "m/0'/1'");
+    assert_eq!(
+        &*key_m_0h_1h.to_string(Prefix::XPRV),
+        "xprv9xJocDuwtYCMNAo3Zw76WENQeAS6WGXQ55RCy7tDJ8oALr4FWkuVoHJeHVAcAqiZLE7Je3vZJHxspZdFHfnBEjHqU5hG1Jaj32dVoS6XLT1"
+    );
+    assert_eq!(
+        key_m_0h_1h.public_key().to_string(Prefix::XPUB),
+        "xpub6BJA1jSqiukeaesWfxe6sNK9CCGaujFFSJLomWHprUL9DePQ4JDkM5d88n49sMGJxrhpjazuXYWdMf17C9T5XnxkopaeS7jGk1GyyVziaMt"
     );
 }

--- a/hkd32/src/mnemonic/phrase.rs
+++ b/hkd32/src/mnemonic/phrase.rs
@@ -74,6 +74,10 @@ impl Phrase {
     ///
     /// The phrase supplied will be checked for word length and validated
     /// according to the checksum specified in BIP0039.
+    ///
+    /// To use the default language, English, (the only one supported by this
+    /// library and also the only one standardized for BIP39) you can supply
+    /// `Default::default()` as the language.
     pub fn new<S>(phrase: S, language: Language) -> Result<Self, Error>
     where
         S: AsRef<str>,

--- a/hkd32/src/mnemonic/seed.rs
+++ b/hkd32/src/mnemonic/seed.rs
@@ -3,6 +3,7 @@
 use zeroize::Zeroize;
 
 /// BIP39 seeds.
+// TODO(tarcieri): support for 32-byte seeds
 #[cfg_attr(docsrs, doc(cfg(feature = "bip39")))]
 pub struct Seed(pub(crate) [u8; Seed::SIZE]);
 
@@ -21,8 +22,8 @@ impl Seed {
     }
 }
 
-impl AsRef<[u8; Seed::SIZE]> for Seed {
-    fn as_ref(&self) -> &[u8; Seed::SIZE] {
+impl AsRef<[u8]> for Seed {
+    fn as_ref(&self) -> &[u8] {
         self.as_bytes()
     }
 }


### PR DESCRIPTION
Adds support for deriving keys using the `secp256k1` crate, which wraps the Bitcoin Core libsecp256k1 C library.

Additionally, this commit fills out the remaining BIP32 test vectors, namely Test Vector 1 and Test Vector 4.