### PR TITLE
Bump `k256` to v0.9; `rand_core` to v0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,7 +102,7 @@ dependencies = [
  "bs58",
  "hex-literal",
  "hkd32",
- "hmac 0.11.0",
+ "hmac",
  "k256",
  "ripemd160",
  "secp256k1",
@@ -116,17 +116,6 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-
-[[package]]
-name = "bitvec"
-version = "0.18.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98fcd36dda4e17b7d7abc64cb549bf0201f4ab71e00700c798ca7e62ed3761fa"
-dependencies = [
- "funty",
- "radium",
- "wyz",
-]
 
 [[package]]
 name = "block-buffer"
@@ -205,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.4.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f6b64db6932c7e49332728e3a6bd82c6b7e16016607d20923b537c3bc4c0d5f"
+checksum = "44c32f031ea41b4291d695026c023b95d59db2d8a2c7640800ed56bc8f510f22"
 
 [[package]]
 name = "core-foundation"
@@ -235,10 +224,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.10.0"
+name = "crypto-bigint"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
+checksum = "281d926f72b42bf3ba840b88cd53e39f36be9f66e34c8df3fb336372b3753d41"
 dependencies = [
  "generic-array",
  "subtle",
@@ -290,9 +279,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.1.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f59c66c30bb7445c8320a5f9233e437e3572368099f25532a59054328899b4"
+checksum = "49f215f706081a44cb702c71c39a52c05da637822e9c1645a50b7202689e982d"
 dependencies = [
  "const-oid",
 ]
@@ -308,12 +297,13 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.10.2"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fbdb4ff710acb4db8ca29f93b897529ea6d6a45626d5183b47e012aa6ae7e4"
+checksum = "16c4363c082db1a39dc354b9693923252c333bd41c918a64639da87aec1a6288"
 dependencies = [
+ "der",
  "elliptic-curve",
- "hmac 0.10.1",
+ "hmac",
  "signature",
 ]
 
@@ -350,18 +340,16 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.8.5"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2db227e61a43a34915680bdda462ec0e212095518020a88a1f91acd16092c39"
+checksum = "59029dd05f60215bbe37eda4b32ba1a142abc8b01a938955b20b92ff0d713e8e"
 dependencies = [
- "bitvec",
- "digest",
+ "crypto-bigint",
  "ff",
- "funty",
  "generic-array",
  "group",
  "pkcs8",
- "rand_core 0.5.1",
+ "rand_core 0.6.2",
  "subtle",
  "zeroize 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -397,12 +385,11 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01646e077d4ebda82b73f1bca002ea1e91561a77df2431a9e79729bcc31950ef"
+checksum = "63eec06c61e487eecf0f7e6e6372e596a81922c28d33e645d6983ca6493a1af0"
 dependencies = [
- "bitvec",
- "rand_core 0.5.1",
+ "rand_core 0.6.2",
  "subtle",
 ]
 
@@ -577,12 +564,12 @@ checksum = "0e4075386626662786ddb0ec9081e7c7eeb1ba31951f447ca780ef9f5d568189"
 
 [[package]]
 name = "group"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc11f9f5fbf1943b48ae7c2bf6846e7d827a512d1be4f23af708f5ca5d01dde1"
+checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
 dependencies = [
  "ff",
- "rand_core 0.5.1",
+ "rand_core 0.6.2",
  "subtle",
 ]
 
@@ -663,23 +650,13 @@ name = "hkd32"
 version = "0.5.0"
 dependencies = [
  "hex-literal",
- "hmac 0.11.0",
+ "hmac",
  "once_cell",
  "pbkdf2",
- "rand_core 0.5.1",
+ "rand_core 0.6.2",
  "sha2",
  "subtle-encoding 0.5.1",
  "zeroize 1.3.0",
-]
-
-[[package]]
-name = "hmac"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
-dependencies = [
- "crypto-mac 0.10.0",
- "digest",
 ]
 
 [[package]]
@@ -688,7 +665,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
- "crypto-mac 0.11.0",
+ "crypto-mac",
  "digest",
 ]
 
@@ -891,9 +868,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.7.3"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4476a0808212a9e81ce802eb1a0cfc60e73aea296553bacc0fac7e1268bc572a"
+checksum = "981d961c83e235370a70e302f16ecbfd34df72a14c5c0973d937f5fa26248653"
 dependencies = [
  "cfg-if",
  "ecdsa",
@@ -1149,7 +1126,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d95f5254224e617595d2cc3cc73ff0a5eaf2637519e25f03388154e9378b6ffa"
 dependencies = [
- "crypto-mac 0.11.0",
+ "crypto-mac",
 ]
 
 [[package]]
@@ -1172,11 +1149,12 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
-version = "0.3.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4839a901843f3942576e65857f0ebf2e190ef7024d3c62a94099ba3f819ad1d"
+checksum = "09d156817ae0125e8aa5067710b0db24f0984830614f99875a70aa5e3b74db69"
 dependencies = [
  "der",
+ "spki",
 ]
 
 [[package]]
@@ -1288,12 +1266,6 @@ checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "radium"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
 
 [[package]]
 name = "rand"
@@ -1649,12 +1621,12 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
+checksum = "0f0242b8e50dd9accdd56170e94ca1ebd223b098eb9c83539a6e367d0f36ae68"
 dependencies = [
  "digest",
- "rand_core 0.5.1",
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -1692,6 +1664,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "spki"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "987637c5ae6b3121aba9d513f869bd2bff11c4cc086c22473befd6649c0bd521"
+dependencies = [
+ "der",
+]
+
+[[package]]
 name = "stdtx"
 version = "0.4.0"
 dependencies = [
@@ -1700,7 +1681,7 @@ dependencies = [
  "k256",
  "prost-amino",
  "prost-amino-derive",
- "rand_core 0.5.1",
+ "rand_core 0.6.2",
  "rust_decimal",
  "serde",
  "serde_json",
@@ -2160,12 +2141,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "wyz"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "zeroize"

--- a/bip32/Cargo.toml
+++ b/bip32/Cargo.toml
@@ -28,7 +28,7 @@ zeroize = { version = "1", default-features = false, path = "../zeroize" }
 secp256k1-ffi = { package = "secp256k1", version = "0.20", optional = true }
 
 [dependencies.k256]
-version = "0.7"
+version = "0.9"
 optional = true
 default-features = false
 features = ["arithmetic", "ecdsa", "zeroize"]

--- a/bip32/src/private_key.rs
+++ b/bip32/src/private_key.rs
@@ -42,10 +42,10 @@ impl PrivateKey for k256::SecretKey {
 
     fn derive_child(&self, left_half: PrivateKeyBytes) -> Result<Self> {
         let child_scalar = k256::NonZeroScalar::from_repr(left_half.into()).ok_or(Error::Crypto)?;
-        let derived_scalar = self.secret_scalar().as_ref() + child_scalar.as_ref();
+        let derived_scalar = self.to_secret_scalar().as_ref() + child_scalar.as_ref();
 
         k256::NonZeroScalar::new(derived_scalar)
-            .map(Self::new)
+            .map(Into::into)
             .ok_or(Error::Crypto)
     }
 

--- a/bip32/src/public_key.rs
+++ b/bip32/src/public_key.rs
@@ -53,7 +53,7 @@ impl PublicKey for k256::ecdsa::VerifyingKey {
     }
 
     fn to_bytes(&self) -> PublicKeyBytes {
-        self.to_bytes()
+        self.to_bytes().as_ref().try_into().expect("malformed key")
     }
 }
 

--- a/hkd32/Cargo.toml
+++ b/hkd32/Cargo.toml
@@ -22,7 +22,7 @@ maintenance = { status = "passively-maintained" }
 
 [dependencies]
 hmac = { version = "0.11", default-features = false }
-rand_core = { version = "0.5", default-features = false }
+rand_core = { version = "0.6", default-features = false }
 sha2 = { version = "0.9", default-features = false }
 zeroize = { version = "1", default-features = false, features = ["zeroize_derive"], path = "../zeroize" }
 
@@ -33,7 +33,7 @@ subtle-encoding = { version = "0.5", optional = true, default-features = false, 
 
 [dev-dependencies]
 hex-literal = "0.3"
-rand_core = { version = "0.5", features = ["std"] }
+rand_core = { version = "0.6", features = ["std"] }
 
 [features]
 default = ["alloc", "bech32"]

--- a/stdtx/Cargo.toml
+++ b/stdtx/Cargo.toml
@@ -15,9 +15,9 @@ edition     = "2018"
 circle-ci = { repository = "tendermint/kms" }
 
 [dependencies]
-ecdsa = { version = "0.10", features = ["std"] }
+ecdsa = { version = "0.12", features = ["std"] }
 eyre = "0.6"
-k256 = { version = "0.7", features = ["ecdsa", "sha256"] }
+k256 = { version = "0.9", features = ["ecdsa", "sha256"] }
 prost-amino = "0.6"
 prost-amino-derive = "0.6"
 rust_decimal = "1.13"
@@ -29,4 +29,4 @@ thiserror = "1"
 toml = "0.5"
 
 [dev-dependencies]
-rand_core = { version = "0.5", features = ["std"] }
+rand_core = { version = "0.6", features = ["std"] }


### PR DESCRIPTION
We were previously keeping these back to ensure compatibility with `tendermint-rs` for use with `bip32`, however one of the interesting features of `bip32` is that it's generic, which means we can still use it via simple newtype wrappers that provide the current implementation.

This commit bumps these dependencies so we can release with the latest versions.