### PR TITLE
hkd32 v0.6.0-pre

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,7 +660,7 @@ checksum = "5af1f635ef1bc545d78392b136bfe1c9809e029023c84a3638a864a10b8819c8"
 
 [[package]]
 name = "hkd32"
-version = "0.5.0"
+version = "0.6.0-pre"
 dependencies = [
  "hex-literal",
  "hmac 0.11.0",

--- a/bip32/Cargo.toml
+++ b/bip32/Cargo.toml
@@ -17,7 +17,7 @@ readme     = "README.md"
 
 [dependencies]
 bs58 = { version = "0.4", default-features = false, features = ["check"] }
-hkd32 = { version = "0.5", default-features = false, path = "../hkd32" }
+hkd32 = { version = "0.6.0-pre", default-features = false, path = "../hkd32" }
 hmac = { version = "0.11", default-features = false }
 ripemd160 = { version = "0.9", default-features = false }
 sha2 = { version = "0.9", default-features = false }

--- a/hkd32/Cargo.toml
+++ b/hkd32/Cargo.toml
@@ -7,7 +7,7 @@ repeated applications of the Hash-based Message Authentication Code
 (HMAC) construction. Optionally supports storing root derivation
 passwords as a 24-word mnemonic phrase (i.e. BIP39).
 """
-version    = "0.5.0" # Also update html_root_url in lib.rs when bumping this
+version    = "0.6.0-pre" # Also update html_root_url in lib.rs when bumping this
 authors    = ["Tony Arcieri <tony@iqlusion.io>"]
 license    = "Apache-2.0 OR MIT"
 homepage   = "https://github.com/iqlusioninc/crates/"


### PR DESCRIPTION
This release is compatible with the current `tendermint` crate, and does not include #759.

We'll merge that after this prerelease.