### PR TITLE
bip32: doc improvements and usage example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,7 @@ dependencies = [
  "hkd32",
  "hmac",
  "k256",
+ "rand_core 0.6.2",
  "ripemd160",
  "secp256k1",
  "sha2",
@@ -123,8 +124,15 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
+ "block-padding",
  "generic-array",
 ]
+
+[[package]]
+name = "block-padding"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bs58"
@@ -876,7 +884,14 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "sha2",
+ "sha3",
 ]
+
+[[package]]
+name = "keccak"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "lazy_static"
@@ -1607,6 +1622,18 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha3"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
+dependencies = [
+ "block-buffer",
+ "digest",
+ "keccak",
  "opaque-debug",
 ]
 

--- a/bip32/Cargo.toml
+++ b/bip32/Cargo.toml
@@ -31,10 +31,11 @@ secp256k1-ffi = { package = "secp256k1", version = "0.20", optional = true }
 version = "0.9"
 optional = true
 default-features = false
-features = ["arithmetic", "ecdsa", "zeroize"]
+features = ["arithmetic", "ecdsa", "sha256", "keccak256", "zeroize"]
 
 [dev-dependencies]
 hex-literal = "0.3"
+rand_core = { version = "0.6", features = ["std"] }
 
 [features]
 default = ["bip39", "secp256k1", "std"]

--- a/bip32/README.md
+++ b/bip32/README.md
@@ -37,8 +37,8 @@ Copyright © 2020-2021 iqlusion
 **bip32.rs** is distributed under the terms of either the MIT license
 or the Apache License (Version 2.0), at your option.
 
-See [LICENSE] (Apache License, Version 2.0) file in the `iqlusioninc/crates`
-toplevel directory of this repository or [LICENSE-MIT] for details.
+See [LICENSE-APACHE] (Apache License, Version 2.0) and [LICENSE-MIT] for
+further details.
 
 ## Contribution
 
@@ -65,3 +65,5 @@ without any additional terms or conditions.
 [bip32]: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
 [libsecp256k1 C library]: https://github.com/bitcoin-core/secp256k1
 [`secp256k1` Rust crate]: https://github.com/rust-bitcoin/rust-secp256k1/
+[LICENSE-APACHE]: https://github.com/iqlusioninc/crates/blob/main/bip32/LICENSE-APACHE
+[LICENSE-MIT]: https://github.com/iqlusioninc/crates/blob/main/bip32/LICENSE-MIT

--- a/bip32/tests/bip32_vectors.rs
+++ b/bip32/tests/bip32_vectors.rs
@@ -6,7 +6,7 @@
 //! what we currently support.
 // TODO(tarcieri): consolidate test vectors
 
-#![cfg(feature = "secp256k1")]
+#![cfg(all(feature = "alloc", feature = "secp256k1"))]
 
 use bip32::{Prefix, XPrv};
 use hex_literal::hex;

--- a/bip32/tests/bip39_vectors.rs
+++ b/bip32/tests/bip39_vectors.rs
@@ -1,6 +1,6 @@
 //! BIP39 test vectors
 
-#![cfg(feature = "secp256k1")]
+#![cfg(all(feature = "bip39", feature = "secp256k1"))]
 
 use bip32::{Mnemonic, Seed, XPrv};
 use hex_literal::hex;


### PR DESCRIPTION
Fixes broken links, adds a limitations section to the rustdoc, and includes a full code example