### PR TITLE
bip32: bump `k256` crate dependency to v0.9.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,9 +876,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "981d961c83e235370a70e302f16ecbfd34df72a14c5c0973d937f5fa26248653"
+checksum = "d2e31b17f680ce217565feadee9e9fd21f309ceb3983ca5ab566b50203982d78"
 dependencies = [
  "cfg-if",
  "ecdsa",

--- a/bip32/Cargo.toml
+++ b/bip32/Cargo.toml
@@ -28,7 +28,7 @@ zeroize = { version = "1", default-features = false, path = "../zeroize" }
 secp256k1-ffi = { package = "secp256k1", version = "0.20", optional = true }
 
 [dependencies.k256]
-version = "0.9"
+version = "0.9.3"
 optional = true
 default-features = false
 features = ["arithmetic", "ecdsa", "sha256", "keccak256", "zeroize"]

--- a/bip32/src/private_key.rs
+++ b/bip32/src/private_key.rs
@@ -74,7 +74,7 @@ impl PrivateKey for k256::ecdsa::SigningKey {
     }
 
     fn public_key(&self) -> Self::PublicKey {
-        self.verify_key()
+        self.verifying_key()
     }
 }
 


### PR DESCRIPTION
This release deprecates `verify_key` in favor of `verifying_key`