### PR TITLE
bip32: add `(Extended)PublicKey::derive_child`

### DIFF
--- a/.github/workflows/bip32.yml
+++ b/.github/workflows/bip32.yml
@@ -61,5 +61,7 @@ jobs:
           override: true
           profile: minimal
       - run: cargo test --release --no-default-features
+      - run: cargo test --release --no-default-features --features secp256k1,bip39
+      - run: cargo test --release --no-default-features --features secp256k1-ffi,bip39
       - run: cargo test --release
       - run: cargo test --release --all-features

--- a/bip32/src/lib.rs
+++ b/bip32/src/lib.rs
@@ -155,3 +155,6 @@ pub type KeyFingerprint = [u8; 4];
 
 /// BIP32 "versions": integer representation of the key prefix.
 pub type Version = u32;
+
+/// HMAC with SHA-512
+type HmacSha512 = hmac::Hmac<sha2::Sha512>;

--- a/bip32/tests/bip32_vectors.rs
+++ b/bip32/tests/bip32_vectors.rs
@@ -90,6 +90,11 @@ fn test_vector_1() {
         key_m_0h_1_2h_2_1000000000.public_key().to_string(Prefix::XPUB),
         "xpub6H1LXWLaKsWFhvm6RVpEL9P4KfRZSW7abD2ttkWP3SSQvnyA8FSVqNTEcYFgJS2UaFcxupHiYkro49S8yGasTvXEYBVPamhGW6cFJodrTHy"
     );
+
+    // Test non-hardened derivation from an xpub
+    let xpub = key_m_0h_1_2h_2.public_key();
+    let xpub_child = xpub.derive_child(1000000000.into()).unwrap();
+    assert_eq!(key_m_0h_1_2h_2_1000000000.public_key(), xpub_child);
 }
 
 /// BIP32 Test Vector 2
@@ -167,6 +172,11 @@ fn test_vector_2() {
         key_m_0_2147483647h_1_2147483646h_2.public_key().to_string(Prefix::XPUB),
         "xpub6FnCn6nSzZAw5Tw7cgR9bi15UV96gLZhjDstkXXxvCLsUXBGXPdSnLFbdpq8p9HmGsApME5hQTZ3emM2rnY5agb9rXpVGyy3bdW6EEgAtqt"
     );
+
+    // Test non-hardened derivation from an xpub
+    let xpub = key_m_0_2147483647h_1_2147483646h.public_key();
+    let xpub_child = xpub.derive_child(2.into()).unwrap();
+    assert_eq!(key_m_0_2147483647h_1_2147483646h_2.public_key(), xpub_child);
 }
 
 /// BIP32 Test Vector 3


### PR DESCRIPTION
Adds a `derive_child` method to the `PublicKey` trait which can be used for computing a child xpub from a parent xpub (i.e. non-hardened derivation support)

Additionally adds a corresponding `ExtendedPublicKey::derive_child` method which wraps up this derivation.