### PR TITLE
bip32: rename `XPrv::derive_child_from_seed` to `::derive_from_path`

### DIFF
--- a/bip32/src/extended_key/private_key.rs
+++ b/bip32/src/extended_key/private_key.rs
@@ -54,7 +54,7 @@ where
     /// Derive a child key from the given [`DerivationPath`].
     #[cfg(feature = "alloc")]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-    pub fn derive_child_from_seed<S>(seed: S, path: &DerivationPath) -> Result<Self>
+    pub fn derive_from_path<S>(seed: S, path: &DerivationPath) -> Result<Self>
     where
         S: AsRef<[u8]>,
     {

--- a/bip32/src/lib.rs
+++ b/bip32/src/lib.rs
@@ -55,11 +55,11 @@
 //!
 //! // Derive the root `XPrv` from the `seed` value
 //! let root_xprv = XPrv::new(&seed)?;
-//! assert_eq!(root_xprv, XPrv::derive_child_from_seed(&seed, &"m".parse()?)?);
+//! assert_eq!(root_xprv, XPrv::derive_from_path(&seed, &"m".parse()?)?);
 //!
 //! // Derive a child `XPrv` using the provided BIP32 derivation path
 //! let child_path = "m/0/2147483647'/1/2147483646'";
-//! let child_xprv = XPrv::derive_child_from_seed(&seed, &child_path.parse()?)?;
+//! let child_xprv = XPrv::derive_from_path(&seed, &child_path.parse()?)?;
 //!
 //! // Get the `XPub` associated with `child_xprv`.
 //! let child_xpub = child_xprv.public_key();

--- a/bip32/src/private_key.rs
+++ b/bip32/src/private_key.rs
@@ -120,7 +120,7 @@ mod tests {
         );
 
         let path = "m/0/2147483647'/1/2147483646'/2";
-        let xprv = XPrv::derive_child_from_seed(&seed, &path.parse().unwrap()).unwrap();
+        let xprv = XPrv::derive_from_path(&seed, &path.parse().unwrap()).unwrap();
 
         assert_eq!(
             xprv,

--- a/bip32/src/public_key.rs
+++ b/bip32/src/public_key.rs
@@ -114,7 +114,7 @@ mod tests {
     #[test]
     fn secp256k1_ffi_xprv_derivation() {
         let path = "m/0/2147483647'/1/2147483646'/2";
-        let xprv = XPrv::derive_child_from_seed(&SEED, &path.parse().unwrap()).unwrap();
+        let xprv = XPrv::derive_from_path(&SEED, &path.parse().unwrap()).unwrap();
 
         assert_eq!(
             xprv.public_key(),
@@ -125,7 +125,7 @@ mod tests {
     #[test]
     fn secp256k1_ffi_xpub_derivation() {
         let path = "m/0/2147483647'/1/2147483646'";
-        let xprv = XPrv::derive_child_from_seed(&SEED, &path.parse().unwrap()).unwrap();
+        let xprv = XPrv::derive_from_path(&SEED, &path.parse().unwrap()).unwrap();
         let xpub = xprv.public_key().derive_child(2.into()).unwrap();
 
         assert_eq!(

--- a/bip32/tests/bip32_vectors.rs
+++ b/bip32/tests/bip32_vectors.rs
@@ -15,7 +15,7 @@ use hex_literal::hex;
 ///
 /// Panics if anything goes wrong.
 fn derive_xprv(seed: &[u8], path: &str) -> XPrv {
-    XPrv::derive_child_from_seed(&seed, &path.parse().unwrap()).unwrap()
+    XPrv::derive_from_path(&seed, &path.parse().unwrap()).unwrap()
 }
 
 /// BIP32 Test Vector 1


### PR DESCRIPTION
The previous name was both long and somewhat confusing as `XPrv::new` also accepts a seed (and generates the root key).

The notable thing about `derive_from_path` is that it accepts a `DerivationPath` as an argument, so the name has been changed to both be shorter and reflect that it derives using a path.