### PR TITLE
bip32 v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bip32"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "bs58",
  "hex-literal",

--- a/bip32/CHANGELOG.md
+++ b/bip32/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2021-06-23)
+### Added
+- Non-hardened derivation support with `XPub::derive_child` ([#772])
+
+### Changed
+- Rename `XPrv::derive_child_from_seed` => `XPrv::derive_from_path` ([#773])
+
+[#772]: https://github.com/iqlusioninc/crates/pull/772
+[#773]: https://github.com/iqlusioninc/crates/pull/773
+
 ## 0.1.1 (2021-06-18)
 ### Added
 - Documentation improvements and usage example ([#764])

--- a/bip32/Cargo.toml
+++ b/bip32/Cargo.toml
@@ -5,11 +5,11 @@ BIP32 hierarchical key derivation implemented in a generic, no_std-friendly
 manner. Supports deriving keys using the pure Rust k256 crate or the
 C library-backed secp256k1 crate
 """
-version    = "0.1.1" # Also update html_root_url in lib.rs when bumping this
+version    = "0.2.0" # Also update html_root_url in lib.rs when bumping this
 authors    = ["Tony Arcieri <tony@iqlusion.io>"]
 license    = "Apache-2.0 OR MIT"
 homepage   = "https://github.com/iqlusioninc/crates/"
-repository = "https://github.com/iqlusioninc/crates/tree/develop/bip32"
+repository = "https://github.com/iqlusioninc/crates/tree/main/bip32"
 categories = ["cryptography", "no-std"]
 keywords   = ["crypto", "bip32", "bip39", "derivation", "mnemonic"]
 edition    = "2018"

--- a/bip32/src/lib.rs
+++ b/bip32/src/lib.rs
@@ -96,7 +96,7 @@
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc(html_root_url = "https://docs.rs/bip32/0.1.1")]
+#![doc(html_root_url = "https://docs.rs/bip32/0.2.0")]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 


### PR DESCRIPTION
### Added
- Non-hardened derivation support with `XPub::derive_child` ([#772])

### Changed
- Rename `XPrv::derive_child_from_seed` => `XPrv::derive_from_path` ([#773])

[#772]: https://github.com/iqlusioninc/crates/pull/772
[#773]: https://github.com/iqlusioninc/crates/pull/773