### PR TITLE
bip32 v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bip32"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bs58",
  "hex-literal",

--- a/bip32/CHANGELOG.md
+++ b/bip32/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.2.0 (2021-06-23)
 ### Added
+- `From` conversions to `k256::ecdsa::*Key` ([#777])
+
+[#777]: https://github.com/iqlusioninc/crates/pull/777
+
+## 0.2.0 (2021-06-23) [YANKED]
+### Added
 - Non-hardened derivation support with `XPub::derive_child` ([#772])
 
 ### Changed

--- a/bip32/Cargo.toml
+++ b/bip32/Cargo.toml
@@ -5,7 +5,7 @@ BIP32 hierarchical key derivation implemented in a generic, no_std-friendly
 manner. Supports deriving keys using the pure Rust k256 crate or the
 C library-backed secp256k1 crate
 """
-version    = "0.2.0" # Also update html_root_url in lib.rs when bumping this
+version    = "0.2.1" # Also update html_root_url in lib.rs when bumping this
 authors    = ["Tony Arcieri <tony@iqlusion.io>"]
 license    = "Apache-2.0 OR MIT"
 homepage   = "https://github.com/iqlusioninc/crates/"

--- a/bip32/src/lib.rs
+++ b/bip32/src/lib.rs
@@ -95,7 +95,7 @@
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc(html_root_url = "https://docs.rs/bip32/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/bip32/0.2.1")]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 


### PR DESCRIPTION
### Added
- `From` conversions to `k256::ecdsa::*Key` ([#777])

[#777]: https://github.com/iqlusioninc/crates/pull/777