### PR TITLE
signatory: docs.rs config

### DIFF
--- a/signatory/Cargo.toml
+++ b/signatory/Cargo.toml
@@ -27,3 +27,7 @@ tempfile = "3"
 default = ["std"]
 secp256k1 = ["ecdsa", "k256"]
 std = ["pkcs8/std", "rand_core/std", "signature/std"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/signatory/src/ecdsa.rs
+++ b/signatory/src/ecdsa.rs
@@ -1,6 +1,7 @@
 //! Elliptic Curve Digital Signature Algorithm (ECDSA) support.
 
 #[cfg(feature = "secp256k1")]
+#[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
 pub mod secp256k1;
 
 mod keyring;
@@ -9,4 +10,5 @@ pub use self::keyring::KeyRing;
 pub use ecdsa::{elliptic_curve, Signature};
 
 #[cfg(feature = "secp256k1")]
+#[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
 pub use k256::Secp256k1;

--- a/signatory/src/ecdsa/keyring.rs
+++ b/signatory/src/ecdsa/keyring.rs
@@ -13,6 +13,7 @@ use super::secp256k1;
 pub struct KeyRing {
     /// ECDSA/secp256k1 keys.
     #[cfg(feature = "secp256k1")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
     pub secp256k1: secp256k1::KeyRing,
 }
 

--- a/signatory/src/ecdsa/secp256k1.rs
+++ b/signatory/src/ecdsa/secp256k1.rs
@@ -67,6 +67,7 @@ impl FromPrivateKey for SigningKey {
 }
 
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl GeneratePkcs8 for SigningKey {
     /// Randomly generate a new PKCS#8 private key.
     fn generate_pkcs8() -> pkcs8::PrivateKeyDocument {

--- a/signatory/src/error.rs
+++ b/signatory/src/error.rs
@@ -14,6 +14,7 @@ pub enum Error {
 
     /// ECDSA errors.
     #[cfg(feature = "ecdsa")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
     Ecdsa,
 
     /// Key name is invalid.
@@ -21,14 +22,17 @@ pub enum Error {
 
     /// I/O errors
     #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     Io(std::io::Error),
 
     /// Expected a directory, found something else
     #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     NotADirectory,
 
     /// Permissions error, not required mode
     #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     Permissions,
 
     /// PKCS#8 errors
@@ -54,9 +58,11 @@ impl Display for Error {
 }
 
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for Error {}
 
 #[cfg(feature = "ecdsa")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
 impl From<ecdsa::Error> for Error {
     fn from(_: ecdsa::Error) -> Error {
         Error::Ecdsa
@@ -76,6 +82,7 @@ impl From<pkcs8::der::Error> for Error {
 }
 
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl From<std::io::Error> for Error {
     fn from(err: std::io::Error) -> Error {
         Error::Io(err)

--- a/signatory/src/key/ring.rs
+++ b/signatory/src/key/ring.rs
@@ -10,6 +10,7 @@ use crate::ecdsa;
 pub struct KeyRing {
     /// ECDSA key ring.
     #[cfg(feature = "ecdsa")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
     pub ecdsa: ecdsa::KeyRing,
 }
 

--- a/signatory/src/lib.rs
+++ b/signatory/src/lib.rs
@@ -1,6 +1,7 @@
 //! Signatory
 
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(html_root_url = "https://docs.rs/signatory/0.23.0-pre.1")]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
@@ -11,6 +12,7 @@ extern crate alloc;
 extern crate std;
 
 #[cfg(feature = "ecdsa")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
 pub mod ecdsa;
 
 mod algorithm;


### PR DESCRIPTION
Uses `doc_cfg` on https://docs.rs to annotate which crate features are required to use specific parts of the library.