### PR TITLE
Implement Zeroize for `[MaybeUninit<Z>]`

### DIFF
--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -559,6 +559,14 @@ mod tests {
         assert_eq!(arr.as_ref(), [0u8; 64].as_ref());
     }
 
+    #[test]
+    fn zeroize_maybeuninit_byte_arrays() {
+        let mut arr = [MaybeUninit::new(42u64); 64];
+        arr.zeroize();
+        let arr_init: [u64; 64] = unsafe { core::mem::transmute(arr) };
+        assert_eq!(arr_init, [0u64; 64]);
+    }
+
     #[cfg(feature = "alloc")]
     #[test]
     fn zeroize_vec() {


### PR DESCRIPTION
Implementing Zeroize for `[MaybeUninit<Z>]` is very helpful IMHO, because it allows to zeroize any custom heap allocated objects by just constructing a slice of `MaybeUninit`(as some of the buffer might not be initialized) and calling `zeroize()` on it.

I also changed the Vec implementation to zero out the full capacity and not just the uninitialized part, because I don't see any difference between the initialized and the unintialized, if the data in the buffer is secret then we should make sure we zero out all of the buffer.

The downside is that if the Vec contains a primitive(say `Vec<u8>`) then we'll zero the used space twice, so I can see arguments against it (currently the only time I can think this will matter is in Vecs with another indirection, like `Vec<Box<Z>>` or `Vec<&Z>`, and then is there a point in zeroing out those pointers?)

So if people disagree on the 2nd commit I can drop it and leave only the first commit.

