### PR TITLE
Use const generics to implement Zeroize for Arrays

### DIFF
--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -258,27 +258,14 @@ impl_zeroize_with_default!(u8, u16, u32, u64, u128, usize);
 impl_zeroize_with_default!(f32, f64, char, bool);
 
 /// Implement `Zeroize` on arrays of types that impl `Zeroize`
-macro_rules! impl_zeroize_for_array {
-    ($($size:expr),+) => {
-        $(
-            impl<Z> Zeroize for [Z; $size]
-            where
-                Z: Zeroize
-            {
-                fn zeroize(&mut self) {
-                    self.iter_mut().zeroize();
-                }
-            }
-        )+
-     };
+impl<Z, const N: usize> Zeroize for [Z; N]
+where
+    Z: Zeroize,
+{
+    fn zeroize(&mut self) {
+        self.iter_mut().zeroize();
+    }
 }
-
-// TODO(tarcieri): const generics
-impl_zeroize_for_array!(
-    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
-    27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
-    51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64
-);
 
 impl<'a, Z> Zeroize for IterMut<'a, Z>
 where
@@ -546,9 +533,9 @@ mod tests {
 
     #[test]
     fn zeroize_byte_arrays() {
-        let mut arr = [42u8; 64];
+        let mut arr = [42u8; 137];
         arr.zeroize();
-        assert_eq!(arr.as_ref(), [0u8; 64].as_ref());
+        assert_eq!(arr.as_ref(), [0u8; 137].as_ref());
     }
 
     #[cfg(feature = "alloc")]


### PR DESCRIPTION
IIUC after https://github.com/iqlusioninc/crates/pull/755 the MSRV of Zeroize is 1.51, which is the version that rust stabilized  the "minimum const generics" feature (https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1510-2021-03-25).

So I think there's no more reason to use a macro and restrict ourselves to arrays with length up to 64.