### PR TITLE
signatory: ECDSA/P-256 support

### DIFF
--- a/.github/workflows/signatory.yml
+++ b/.github/workflows/signatory.yml
@@ -37,5 +37,6 @@ jobs:
       - run: cargo test --release --no-default-features
       - run: cargo test --release
       - run: cargo test --release --features ecdsa
+      - run: cargo test --release --features nistp256
       - run: cargo test --release --features secp256k1
       - run: cargo test --release --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,6 +1115,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d053368e1bae4c8a672953397bd1bd7183dde1c72b0b7612a15719173148d186"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "sha2",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1658,6 +1669,7 @@ version = "0.23.0-pre.2"
 dependencies = [
  "ecdsa",
  "k256",
+ "p256",
  "pkcs8",
  "rand_core 0.6.3",
  "signature",

--- a/signatory/Cargo.toml
+++ b/signatory/Cargo.toml
@@ -13,18 +13,22 @@ edition     = "2018"
 autobenches = false
 
 [dependencies]
-k256 = { version = "0.9", optional = true, features = ["ecdsa", "sha256", "keccak256"] }
-ecdsa = { version = "0.12", optional = true, features = ["pem", "pkcs8"] }
 pkcs8 = { version = "0.7", features = ["alloc", "pem"] }
 rand_core = "0.6"
 signature = "1.3.1"
 zeroize = { version = "1", path = "../zeroize" }
+
+# optional dependencies
+ecdsa = { version = "0.12", optional = true, features = ["pem", "pkcs8"] }
+k256 = { version = "0.9", optional = true, features = ["ecdsa", "sha256", "keccak256"] }
+p256 = { version = "0.9", optional = true, features = ["ecdsa", "sha256"] }
 
 [dev-dependencies]
 tempfile = "3"
 
 [features]
 default = ["std"]
+nistp256 = ["ecdsa", "p256"]
 secp256k1 = ["ecdsa", "k256"]
 std = ["pkcs8/std", "rand_core/std", "signature/std"]
 

--- a/signatory/src/ecdsa.rs
+++ b/signatory/src/ecdsa.rs
@@ -1,5 +1,9 @@
 //! Elliptic Curve Digital Signature Algorithm (ECDSA) support.
 
+#[cfg(feature = "nistp256")]
+#[cfg_attr(docsrs, doc(cfg(feature = "nistp256")))]
+pub mod nistp256;
+
 #[cfg(feature = "secp256k1")]
 #[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
 pub mod secp256k1;

--- a/signatory/src/ecdsa/keyring.rs
+++ b/signatory/src/ecdsa/keyring.rs
@@ -5,12 +5,20 @@ use crate::{Error, KeyHandle, LoadPkcs8, Result};
 #[allow(unused_imports)]
 use ecdsa::elliptic_curve::AlgorithmParameters;
 
+#[cfg(feature = "nistp256")]
+use super::nistp256;
+
 #[cfg(feature = "secp256k1")]
 use super::secp256k1;
 
 /// ECDSA key ring.
 #[derive(Debug, Default)]
 pub struct KeyRing {
+    /// ECDSA/P-256 keys.
+    #[cfg(feature = "nistp256")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "nistp256")))]
+    pub nistp256: nistp256::KeyRing,
+
     /// ECDSA/secp256k1 keys.
     #[cfg(feature = "secp256k1")]
     #[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
@@ -24,6 +32,8 @@ impl LoadPkcs8 for KeyRing {
         }
 
         match private_key.algorithm.parameters_oid()? {
+            #[cfg(feature = "nistp256")]
+            p256::NistP256::OID => self.nistp256.load_pkcs8(private_key),
             #[cfg(feature = "secp256k1")]
             k256::Secp256k1::OID => self.secp256k1.load_pkcs8(private_key),
             _ => Err(Error::AlgorithmInvalid),

--- a/signatory/src/key/handle.rs
+++ b/signatory/src/key/handle.rs
@@ -1,22 +1,42 @@
 //! Handle to a particular key.
 
+#[cfg(feature = "ecdsa")]
+#[allow(unused_imports)]
+use crate::ecdsa;
+
 /// Handle to a particular key.
 ///
 /// Uniquely identifies a particular key in the keyring.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum KeyHandle {
-    /// ECDSA with secp256k1.
+    /// ECDSA/P-256.
+    #[cfg(feature = "nistp256")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "nistp256")))]
+    EcdsaNistP256(ecdsa::nistp256::VerifyingKey),
+
+    /// ECDSA/secp256k1.
     #[cfg(feature = "secp256k1")]
     #[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
-    EcdsaSecp256k1(k256::ecdsa::VerifyingKey),
+    EcdsaSecp256k1(ecdsa::secp256k1::VerifyingKey),
 }
 
 impl KeyHandle {
+    /// Get the ECDSA/P-256 verifying key, if this is an ECDSA/P-256 key
+    #[cfg(feature = "nistp256")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "nistp256")))]
+    pub fn ecdsa_nistp256(&self) -> Option<ecdsa::nistp256::VerifyingKey> {
+        match self {
+            KeyHandle::EcdsaNistP256(pk) => Some(*pk),
+            #[allow(unreachable_patterns)]
+            _ => None,
+        }
+    }
+
     /// Get the ECDSA/secp256k1 verifying key, if this is an ECDSA/secp256k1 key
     #[cfg(feature = "secp256k1")]
     #[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
-    pub fn ecdsa_secp256k1(&self) -> Option<k256::ecdsa::VerifyingKey> {
+    pub fn ecdsa_secp256k1(&self) -> Option<ecdsa::secp256k1::VerifyingKey> {
         match self {
             KeyHandle::EcdsaSecp256k1(pk) => Some(*pk),
             #[allow(unreachable_patterns)]


### PR DESCRIPTION
Adds a `nistp256` crate feature which provides feature-gated support for ECDSA signatures using NIST's P-256 elliptic curve.