### PR TITLE
zeroize v1.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
  "secp256k1",
  "sha2",
  "subtle",
- "zeroize 1.3.0",
+ "zeroize 1.4.0",
 ]
 
 [[package]]
@@ -246,7 +246,7 @@ dependencies = [
  "generic-array",
  "rand_core 0.6.3",
  "subtle",
- "zeroize 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.3.0",
 ]
 
 [[package]]
@@ -278,7 +278,7 @@ dependencies = [
  "digest",
  "rand_core 0.5.1",
  "subtle",
- "zeroize 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.3.0",
 ]
 
 [[package]]
@@ -345,7 +345,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "sha2",
- "zeroize 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.3.0",
 ]
 
 [[package]]
@@ -367,7 +367,7 @@ dependencies = [
  "pkcs8",
  "rand_core 0.6.3",
  "subtle",
- "zeroize 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.3.0",
 ]
 
 [[package]]
@@ -668,7 +668,7 @@ dependencies = [
  "rand_core 0.6.3",
  "sha2",
  "subtle-encoding 0.5.1",
- "zeroize 1.3.0",
+ "zeroize 1.4.0",
 ]
 
 [[package]]
@@ -1186,7 +1186,7 @@ dependencies = [
  "base64ct",
  "der",
  "spki",
- "zeroize 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.3.0",
 ]
 
 [[package]]
@@ -1539,7 +1539,7 @@ version = "0.7.0"
 dependencies = [
  "bytes 1.0.1",
  "serde",
- "zeroize 1.3.0",
+ "zeroize 1.4.0",
 ]
 
 [[package]]
@@ -1674,7 +1674,7 @@ dependencies = [
  "rand_core 0.6.3",
  "signature",
  "tempfile",
- "zeroize 1.3.0",
+ "zeroize 1.4.0",
 ]
 
 [[package]]
@@ -1760,7 +1760,7 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 name = "subtle-encoding"
 version = "0.5.1"
 dependencies = [
- "zeroize 1.3.0",
+ "zeroize 1.4.0",
 ]
 
 [[package]]
@@ -1769,7 +1769,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dcb1ed7b8330c5eed5441052651dd7a12c75e2ed88f2ec024ae1fa3a5e59945"
 dependencies = [
- "zeroize 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.3.0",
 ]
 
 [[package]]
@@ -1802,7 +1802,7 @@ dependencies = [
  "chrono",
  "quickcheck",
  "serde",
- "zeroize 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.3.0",
 ]
 
 [[package]]
@@ -1848,7 +1848,7 @@ dependencies = [
  "thiserror",
  "toml",
  "url",
- "zeroize 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.3.0",
 ]
 
 [[package]]
@@ -2203,17 +2203,17 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "zeroize"
 version = "1.3.0"
-dependencies = [
- "zeroize_derive 1.1.0",
-]
-
-[[package]]
-name = "zeroize"
-version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
 dependencies = [
  "zeroize_derive 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.4.0"
+dependencies = [
+ "zeroize_derive 1.1.0",
 ]
 
 [[package]]

--- a/zeroize/CHANGELOG.md
+++ b/zeroize/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.4.0 (2021-07-18)
+
+NOTE: This release includes an MSRV bump to Rust 1.51. Please use `zeroize = "1.3.0"`
+if you would like to support older Rust versions.
+
+### Added
+- Use const generics to impl `Zeroize` for `[Z; N]`; MSRV 1.51 ([#794])
+- `Zeroizing::clone_from` now zeroizes the destination before cloning ([#801])
+
+[#794]: https://github.com/iqlusioninc/crates/pull/794
+[#801]: https://github.com/iqlusioninc/crates/pull/801
+
 ## 1.3.0 (2021-04-19)
 ### Added
 - impl `Zeroize` for `Box<[Z]>` ([#615])

--- a/zeroize/Cargo.toml
+++ b/zeroize/Cargo.toml
@@ -7,7 +7,7 @@ operation will not be 'optimized away' by the compiler.
 Uses a portable pure Rust implementation that works everywhere,
 even WASM!
 """
-version     = "1.3.0" # Also update html_root_url in lib.rs when bumping this
+version     = "1.4.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0 OR MIT"
 edition     = "2018"

--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -208,7 +208,7 @@
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc(html_root_url = "https://docs.rs/zeroize/1.3.0")]
+#![doc(html_root_url = "https://docs.rs/zeroize/1.4.0")]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
*NOTE: This release includes an MSRV bump to Rust 1.51. Please use `zeroize = "1.3.0"` if you would like to support older Rust versions.*

### Added
- Use const generics to impl `Zeroize` for `[Z; N]`; MSRV 1.51 ([#794])
- `Zeroizing::clone_from` now zeroizes the destination before cloning ([#801])

[#794]: https://github.com/iqlusioninc/crates/pull/794
[#801]: https://github.com/iqlusioninc/crates/pull/801