### PR TITLE
secrecy v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1535,7 +1535,7 @@ dependencies = [
 
 [[package]]
 name = "secrecy"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bytes 1.0.1",
  "serde",

--- a/secrecy/CHANGELOG.md
+++ b/secrecy/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.0 (2021-07-18)
+
+NOTE: This release includes an MSRV bump to Rust 1.51. Please use `secrecy = "0.7.0"`
+if you would like to support older Rust versions.
+
+### Added
+- impl `From<T>` for `Secret` ([#482])
+
+### Changed
+- Bump `bytes` to v1.0 ([#592])
+- Switch to `resolver = "2"`; MSRV 1.51 ([#755])
+
+[#482]: https://github.com/iqlusioninc/crates/pull/482
+[#592]: https://github.com/iqlusioninc/crates/pull/592
+[#755]: https://github.com/iqlusioninc/crates/pull/755
+
 ## 0.7.0 (2020-07-08)
 ### Added
 - Re-export zeroize ([#466])

--- a/secrecy/Cargo.toml
+++ b/secrecy/Cargo.toml
@@ -6,7 +6,7 @@ they aren't accidentally copied, logged, or otherwise exposed
 (as much as possible), and also ensure secrets are securely wiped
 from memory when dropped.
 """
-version     = "0.7.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.8.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0 OR MIT"
 edition     = "2018"
@@ -17,9 +17,11 @@ categories  = ["cryptography", "memory-management", "no-std", "os"]
 keywords    = ["clear", "memory", "secret", "secure", "wipe"]
 
 [dependencies]
+zeroize = { version = "1.4", path = "../zeroize", default-features = false }
+
+# optional dependencies
+bytes = { version = "1", optional = true }
 serde = { version = "1", optional = true }
-zeroize = { version = "1.1", path = "../zeroize", default-features = false }
-bytes = { version = "1.0", optional = true }
 
 [features]
 default = ["alloc"]

--- a/secrecy/src/lib.rs
+++ b/secrecy/src/lib.rs
@@ -72,7 +72,7 @@
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc(html_root_url = "https://docs.rs/secrecy/0.7.1")]
+#![doc(html_root_url = "https://docs.rs/secrecy/0.8.0")]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 


### PR DESCRIPTION
*NOTE: This release includes an MSRV bump to Rust 1.51. Please use `secrecy = "0.7.0"` if you would like to support older Rust versions.*

### Added
- impl `From<T>` for `Secret` ([#482])

### Changed
- Bump `bytes` to v1.0 ([#592])
- Switch to `resolver = "2"`; MSRV 1.51 ([#755])

[#482]: https://github.com/iqlusioninc/crates/pull/482
[#592]: https://github.com/iqlusioninc/crates/pull/592
[#755]: https://github.com/iqlusioninc/crates/pull/755