### PR TITLE
Cargo.lock: update `hyper` dep

### DIFF
--- a/datadog/Cargo.toml
+++ b/datadog/Cargo.toml
@@ -8,7 +8,7 @@ categories  = ["api-bindings"]
 
 [dependencies]
 hostname = "0.3"
-hyper = { version = "0.14", features = ["full"] }
+hyper = { version = "0.14.10", features = ["full"] }
 hyper-tls = "0.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
hardcoding `hyper` to v0.14.10 in `datadog` crate to fix version glob in [deps.rs badge](https://github.com/iqlusioninc/crates/pull/808).