### PR TITLE
signatory: Ed25519 support

### DIFF
--- a/.github/workflows/signatory.yml
+++ b/.github/workflows/signatory.yml
@@ -37,6 +37,7 @@ jobs:
       - run: cargo test --release --no-default-features
       - run: cargo test --release
       - run: cargo test --release --features ecdsa
+      - run: cargo test --release --features ed25519
       - run: cargo test --release --features nistp256
       - run: cargo test --release --features secp256k1
       - run: cargo test --release --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25fab6889090c8133f3deb8f73ba3c65a7f456f66436fc012a1b1e272b1e103e"
+checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
  "generic-array",
  "subtle",
@@ -356,9 +356,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e5c176479da93a0983f0a6fdc3c1b8e7d5be0d7fe3fe05a99f15b96582b9a8"
+checksum = "069397e10739989e400628cbc0556a817a8a64119d7a2315767f4456e1332c23"
 dependencies = [
  "crypto-bigint",
  "ff",
@@ -1179,9 +1179,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d156817ae0125e8aa5067710b0db24f0984830614f99875a70aa5e3b74db69"
+checksum = "87bb2d5c68b7505a3a89eb2f3583a4d56303863005226c2ef99319930a262be4"
 dependencies = [
  "base64ct",
  "der",
@@ -1668,6 +1668,7 @@ name = "signatory"
 version = "0.23.0-pre.2"
 dependencies = [
  "ecdsa",
+ "ed25519-dalek",
  "k256",
  "p256",
  "pkcs8",
@@ -1902,9 +1903,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
+checksum = "4ac2e1d4bd0f75279cfd5a076e0d578bbf02c22b7c39e766c437dd49b3ec43e0"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1917,9 +1918,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
+checksum = "c2602b8af3767c285202012822834005f596c811042315fa7e9f5b12b2a43207"
 dependencies = [
  "autocfg",
  "bytes 1.0.1",

--- a/signatory/Cargo.toml
+++ b/signatory/Cargo.toml
@@ -13,13 +13,14 @@ edition     = "2018"
 autobenches = false
 
 [dependencies]
-pkcs8 = { version = "0.7", features = ["alloc", "pem"] }
+pkcs8 = { version = "0.7.2", features = ["alloc", "pem"] }
 rand_core = "0.6"
 signature = "1.3.1"
-zeroize = { version = "1", path = "../zeroize" }
+zeroize = { version = "1.4", path = "../zeroize" }
 
 # optional dependencies
-ecdsa = { version = "0.12", optional = true, features = ["pem", "pkcs8"] }
+ecdsa = { version = "0.12.3", optional = true, features = ["pem", "pkcs8"] }
+ed25519-dalek = { version = "1", optional = true, default-features = false, features = ["u64_backend"] }
 k256 = { version = "0.9", optional = true, features = ["ecdsa", "sha256", "keccak256"] }
 p256 = { version = "0.9", optional = true, features = ["ecdsa", "sha256"] }
 
@@ -28,6 +29,7 @@ tempfile = "3"
 
 [features]
 default = ["std"]
+ed25519 = ["ed25519-dalek"]
 nistp256 = ["ecdsa", "p256"]
 secp256k1 = ["ecdsa", "k256"]
 std = ["pkcs8/std", "rand_core/std", "signature/std"]

--- a/signatory/src/ecdsa.rs
+++ b/signatory/src/ecdsa.rs
@@ -13,6 +13,10 @@ mod keyring;
 pub use self::keyring::KeyRing;
 pub use ecdsa::{elliptic_curve, Signature};
 
+#[cfg(feature = "nistp256")]
+#[cfg_attr(docsrs, doc(cfg(feature = "nistp256")))]
+pub use {self::nistp256::NistP256Signer, p256::NistP256};
+
 #[cfg(feature = "secp256k1")]
 #[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
-pub use k256::Secp256k1;
+pub use {self::secp256k1::Secp256k1Signer, k256::Secp256k1};

--- a/signatory/src/ecdsa/keyring.rs
+++ b/signatory/src/ecdsa/keyring.rs
@@ -1,4 +1,4 @@
-//! ECDSA key ring.
+//! ECDSA keyring.
 
 use crate::{Error, KeyHandle, LoadPkcs8, Result};
 
@@ -11,7 +11,7 @@ use super::nistp256;
 #[cfg(feature = "secp256k1")]
 use super::secp256k1;
 
-/// ECDSA key ring.
+/// ECDSA keyring.
 #[derive(Debug, Default)]
 pub struct KeyRing {
     /// ECDSA/P-256 keys.

--- a/signatory/src/ecdsa/nistp256.rs
+++ b/signatory/src/ecdsa/nistp256.rs
@@ -1,4 +1,4 @@
-//! ECDSA/P-256 support.
+//! ECDSA/NIST P-256 support.
 
 pub use p256::ecdsa::{Signature, VerifyingKey};
 
@@ -7,9 +7,9 @@ use crate::{
     Error, KeyHandle, Map, Result,
 };
 use alloc::boxed::Box;
-use core::fmt;
-use ecdsa::signature::Signer;
+use core::{convert::TryFrom, fmt};
 use pkcs8::{FromPrivateKey, ToPrivateKey};
+use signature::Signer;
 
 /// ECDSA/P-256 key ring.
 #[derive(Debug, Default)]
@@ -18,7 +18,7 @@ pub struct KeyRing {
 }
 
 impl KeyRing {
-    /// Create new ECDSA/P-256 keystore.
+    /// Create new ECDSA/NIST P-256 keyring.
     pub fn new() -> Self {
         Self::default()
     }
@@ -49,7 +49,7 @@ impl LoadPkcs8 for KeyRing {
     }
 }
 
-/// Transaction signing key (ECDSA/P-256)
+/// ECDSA/NIST P-256 signing key.
 pub struct SigningKey {
     inner: Box<dyn NistP256Signer>,
 }
@@ -81,6 +81,14 @@ impl FromPrivateKey for SigningKey {
     }
 }
 
+impl TryFrom<&[u8]> for SigningKey {
+    type Error = Error;
+
+    fn try_from(bytes: &[u8]) -> Result<Self> {
+        Self::from_bytes(bytes)
+    }
+}
+
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl GeneratePkcs8 for SigningKey {
@@ -106,7 +114,7 @@ impl fmt::Debug for SigningKey {
     }
 }
 
-/// ECDSA/P-256 signer
+/// ECDSA/NIST P-256 signer.
 pub trait NistP256Signer: Signer<Signature> {
     /// Get the ECDSA verifying key for this signer
     fn verifying_key(&self) -> VerifyingKey;

--- a/signatory/src/ecdsa/secp256k1.rs
+++ b/signatory/src/ecdsa/secp256k1.rs
@@ -10,11 +10,11 @@ use crate::{
     Error, KeyHandle, Map, Result,
 };
 use alloc::boxed::Box;
-use core::fmt;
-use ecdsa::signature::Signer;
+use core::{convert::TryFrom, fmt};
 use pkcs8::{FromPrivateKey, ToPrivateKey};
+use signature::Signer;
 
-/// ECDSA/secp256k1 key ring.
+/// ECDSA/secp256k1 keyring.
 #[derive(Debug, Default)]
 pub struct KeyRing {
     keys: Map<VerifyingKey, SigningKey>,
@@ -52,7 +52,7 @@ impl LoadPkcs8 for KeyRing {
     }
 }
 
-/// Transaction signing key (ECDSA/secp256k1)
+/// ECDSA/secp256k1 signing key.
 pub struct SigningKey {
     inner: Box<dyn Secp256k1Signer>,
 }
@@ -81,6 +81,14 @@ impl FromPrivateKey for SigningKey {
     fn from_pkcs8_private_key_info(private_key: pkcs8::PrivateKeyInfo<'_>) -> pkcs8::Result<Self> {
         let signing_key = k256::ecdsa::SigningKey::from_pkcs8_private_key_info(private_key)?;
         Ok(Self::new(Box::new(signing_key)))
+    }
+}
+
+impl TryFrom<&[u8]> for SigningKey {
+    type Error = Error;
+
+    fn try_from(bytes: &[u8]) -> Result<Self> {
+        Self::from_bytes(bytes)
     }
 }
 

--- a/signatory/src/ed25519.rs
+++ b/signatory/src/ed25519.rs
@@ -1,0 +1,21 @@
+//! Ed25519 digital signature algorithm support.
+
+mod keyring;
+mod sign;
+mod verify;
+
+pub use self::{
+    keyring::KeyRing,
+    sign::{Ed25519Signer, SigningKey},
+    verify::VerifyingKey,
+};
+pub use ed25519_dalek::ed25519::Signature;
+
+/// Ed25519 Object Identifier (OID).
+pub const ALGORITHM_OID: pkcs8::ObjectIdentifier = pkcs8::ObjectIdentifier::new("1.3.101.112");
+
+/// Ed25519 Algorithm Identifier.
+pub const ALGORITHM_ID: pkcs8::AlgorithmIdentifier<'static> = pkcs8::AlgorithmIdentifier {
+    oid: ALGORITHM_OID,
+    parameters: None,
+};

--- a/signatory/src/ed25519/keyring.rs
+++ b/signatory/src/ed25519/keyring.rs
@@ -1,0 +1,43 @@
+//! Ed25519 keyring.
+
+use super::{SigningKey, VerifyingKey};
+use crate::{Error, KeyHandle, LoadPkcs8, Map, Result};
+use pkcs8::FromPrivateKey;
+
+/// Ed25519 keyring.
+#[derive(Debug, Default)]
+pub struct KeyRing {
+    keys: Map<VerifyingKey, SigningKey>,
+}
+
+impl KeyRing {
+    /// Create new Ed25519 keyring.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Get the [`SigningKey`] that corresponds to the provided [`VerifyingKey`]
+    /// (i.e. public key)
+    pub fn get(&self, verifying_key: &VerifyingKey) -> Option<&SigningKey> {
+        self.keys.get(verifying_key)
+    }
+
+    /// Iterate over the keys in the keyring.
+    pub fn iter(&self) -> impl Iterator<Item = &SigningKey> {
+        self.keys.values()
+    }
+}
+
+impl LoadPkcs8 for KeyRing {
+    fn load_pkcs8(&mut self, private_key: pkcs8::PrivateKeyInfo<'_>) -> Result<KeyHandle> {
+        let signing_key = SigningKey::from_pkcs8_private_key_info(private_key)?;
+        let verifying_key = signing_key.verifying_key();
+
+        if self.keys.contains_key(&verifying_key) {
+            return Err(Error::DuplicateKey);
+        }
+
+        self.keys.insert(verifying_key, signing_key);
+        Ok(KeyHandle::Ed25519(verifying_key))
+    }
+}

--- a/signatory/src/ed25519/sign.rs
+++ b/signatory/src/ed25519/sign.rs
@@ -1,0 +1,99 @@
+//! Ed25519 keys.
+
+use super::{Signature, VerifyingKey, ALGORITHM_ID, ALGORITHM_OID};
+use crate::{key::store::GeneratePkcs8, Error, Result};
+use alloc::boxed::Box;
+use core::{convert::TryFrom, fmt};
+use ed25519_dalek::SECRET_KEY_LENGTH;
+use pkcs8::FromPrivateKey;
+use rand_core::{OsRng, RngCore};
+use signature::Signer;
+use zeroize::Zeroizing;
+
+/// Ed25519 signing key.
+pub struct SigningKey {
+    inner: Box<dyn Ed25519Signer>,
+}
+
+impl SigningKey {
+    /// Initialize from a provided signer object.
+    ///
+    /// Use [`SigningKey::from_bytes`] to initialize from a raw private key.
+    pub fn new(signer: Box<dyn Ed25519Signer>) -> Self {
+        Self { inner: signer }
+    }
+
+    /// Initialize from a raw scalar value (big endian).
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
+        let secret = ed25519_dalek::SecretKey::from_bytes(&bytes).map_err(|_| Error::Parse)?;
+        let public = ed25519_dalek::PublicKey::from(&secret);
+        let keypair = ed25519_dalek::Keypair { secret, public };
+        Ok(Self::new(Box::new(keypair)))
+    }
+
+    /// Get the verifying key that corresponds to this signing key.
+    pub fn verifying_key(&self) -> VerifyingKey {
+        self.inner.verifying_key()
+    }
+}
+
+impl FromPrivateKey for SigningKey {
+    fn from_pkcs8_private_key_info(private_key: pkcs8::PrivateKeyInfo<'_>) -> pkcs8::Result<Self> {
+        private_key.algorithm.assert_algorithm_oid(ALGORITHM_OID)?;
+
+        if private_key.algorithm.parameters.is_some() {
+            return Err(pkcs8::Error::ParametersMalformed);
+        }
+
+        Self::from_bytes(private_key.private_key).map_err(|_| pkcs8::Error::KeyMalformed)
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl GeneratePkcs8 for SigningKey {
+    /// Randomly generate a new PKCS#8 private key.
+    fn generate_pkcs8() -> pkcs8::PrivateKeyDocument {
+        let mut private_key = Zeroizing::new([0u8; SECRET_KEY_LENGTH]);
+        OsRng.fill_bytes(&mut *private_key);
+        pkcs8::PrivateKeyInfo::new(ALGORITHM_ID, &*private_key).to_der()
+    }
+}
+
+impl Signer<Signature> for SigningKey {
+    fn try_sign(&self, msg: &[u8]) -> signature::Result<Signature> {
+        self.inner.try_sign(msg)
+    }
+}
+
+impl TryFrom<&[u8]> for SigningKey {
+    type Error = Error;
+
+    fn try_from(bytes: &[u8]) -> Result<Self> {
+        Self::from_bytes(bytes)
+    }
+}
+
+impl fmt::Debug for SigningKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SigningKey")
+            .field("verifying_key", &self.verifying_key())
+            .finish()
+    }
+}
+
+/// Ed25519 signer
+pub trait Ed25519Signer: Signer<Signature> {
+    /// Get the ECDSA verifying key for this signer
+    fn verifying_key(&self) -> VerifyingKey;
+}
+
+impl<T> Ed25519Signer for T
+where
+    T: Signer<Signature>,
+    VerifyingKey: for<'a> From<&'a T>,
+{
+    fn verifying_key(&self) -> VerifyingKey {
+        self.into()
+    }
+}

--- a/signatory/src/error.rs
+++ b/signatory/src/error.rs
@@ -33,6 +33,9 @@ pub enum Error {
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     NotADirectory,
 
+    /// Parse errors for raw/non-PKCS#8 keys.
+    Parse,
+
     /// Permissions error, not required mode
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
@@ -54,6 +57,7 @@ impl Display for Error {
             Self::Io(err) => write!(f, "{}", err),
             #[cfg(feature = "std")]
             Self::NotADirectory => f.write_str("not a directory"),
+            Self::Parse => f.write_str("parse error"),
             #[cfg(feature = "std")]
             Self::Permissions => f.write_str("invalid file permissions"),
             Self::Pkcs8(err) => write!(f, "{}", err),

--- a/signatory/src/key/handle.rs
+++ b/signatory/src/key/handle.rs
@@ -4,6 +4,9 @@
 #[allow(unused_imports)]
 use crate::ecdsa;
 
+#[cfg(feature = "ed25519")]
+use crate::ed25519;
+
 /// Handle to a particular key.
 ///
 /// Uniquely identifies a particular key in the keyring.
@@ -19,10 +22,15 @@ pub enum KeyHandle {
     #[cfg(feature = "secp256k1")]
     #[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
     EcdsaSecp256k1(ecdsa::secp256k1::VerifyingKey),
+
+    /// Ed25519.
+    #[cfg(feature = "ed25519")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
+    Ed25519(ed25519::VerifyingKey),
 }
 
 impl KeyHandle {
-    /// Get the ECDSA/P-256 verifying key, if this is an ECDSA/P-256 key
+    /// Get ECDSA/P-256 verifying key, if this is an ECDSA/P-256 key.
     #[cfg(feature = "nistp256")]
     #[cfg_attr(docsrs, doc(cfg(feature = "nistp256")))]
     pub fn ecdsa_nistp256(&self) -> Option<ecdsa::nistp256::VerifyingKey> {
@@ -33,12 +41,23 @@ impl KeyHandle {
         }
     }
 
-    /// Get the ECDSA/secp256k1 verifying key, if this is an ECDSA/secp256k1 key
+    /// Get ECDSA/secp256k1 verifying key, if this is an ECDSA/secp256k1 key.
     #[cfg(feature = "secp256k1")]
     #[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
     pub fn ecdsa_secp256k1(&self) -> Option<ecdsa::secp256k1::VerifyingKey> {
         match self {
             KeyHandle::EcdsaSecp256k1(pk) => Some(*pk),
+            #[allow(unreachable_patterns)]
+            _ => None,
+        }
+    }
+
+    /// Get Ed25519 verifying key, if this is an Ed25519 key.
+    #[cfg(feature = "ed25519")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
+    pub fn ed25519(&self) -> Option<ed25519::VerifyingKey> {
+        match self {
+            KeyHandle::Ed25519(pk) => Some(*pk),
             #[allow(unreachable_patterns)]
             _ => None,
         }

--- a/signatory/src/key/ring.rs
+++ b/signatory/src/key/ring.rs
@@ -5,6 +5,9 @@ use crate::{Error, KeyHandle, Result};
 #[cfg(feature = "ecdsa")]
 use crate::ecdsa;
 
+#[cfg(feature = "ed25519")]
+use crate::ed25519;
+
 /// Signature key ring which can contain signing keys for all supported algorithms.
 #[derive(Debug, Default)]
 pub struct KeyRing {
@@ -12,6 +15,11 @@ pub struct KeyRing {
     #[cfg(feature = "ecdsa")]
     #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
     pub ecdsa: ecdsa::KeyRing,
+
+    /// Ed25519 key ring.
+    #[cfg(feature = "ed25519")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
+    pub ed25519: ed25519::KeyRing,
 }
 
 impl KeyRing {
@@ -32,6 +40,8 @@ impl LoadPkcs8 for KeyRing {
         match private_key.algorithm.oid {
             #[cfg(feature = "ecdsa")]
             ecdsa::elliptic_curve::ALGORITHM_OID => self.ecdsa.load_pkcs8(private_key),
+            #[cfg(feature = "ed25519")]
+            ed25519::ALGORITHM_OID => self.ed25519.load_pkcs8(private_key),
             _ => Err(Error::AlgorithmInvalid),
         }
     }

--- a/signatory/src/lib.rs
+++ b/signatory/src/lib.rs
@@ -18,6 +18,10 @@ extern crate std;
 #[cfg_attr(docsrs, doc(cfg(feature = "ecdsa")))]
 pub mod ecdsa;
 
+#[cfg(feature = "ed25519")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
+pub mod ed25519;
+
 mod algorithm;
 mod error;
 mod key;


### PR DESCRIPTION
Adds support for Ed25519 signing, verification, and keyrings, using `ed25519-dalek` as the backing implementation.