### PR TITLE
Resolve a build issue with bip32 when there are competing versions of generic-array in the dependency tree.

### DIFF
--- a/bip32/src/public_key.rs
+++ b/bip32/src/public_key.rs
@@ -68,7 +68,10 @@ impl PublicKey for k256::ecdsa::VerifyingKey {
     }
 
     fn to_bytes(&self) -> PublicKeyBytes {
-        self.to_bytes().as_ref().try_into().expect("malformed key")
+        self.to_bytes()
+            .as_slice()
+            .try_into()
+            .expect("malformed key")
     }
 
     fn derive_child(&self, other: PrivateKeyBytes) -> Result<Self> {


### PR DESCRIPTION
As explained in #858, using GenericArray::as_slice is more deterministic for the compiler when it is working against conflicting versions of generic-array; at least, that is the theory behind why `as_ref` without any type annotations is causing complier confusion, given the wider set of `AsRef` impls on `GenericArray` in 0.14 vs. 0.12.

I think regardless of my personal build issue, this update to `as_slice` is safe and could be argued as a better fit.