### PR TITLE
bip32 v0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ checksum = "8a32fd6af2b5827bce66c29053ba0e7c42b9dcab01835835058558c10851a46b"
 
 [[package]]
 name = "bip32"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bs58",
  "hex-literal",

--- a/bip32/CHANGELOG.md
+++ b/bip32/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.0 (2021-06-23)
+## 0.2.2 (2021-09-07)
+### Changed
+- Avoid `AsRef` ambiguity with `generic-array` ([#859])
+
+[#859]: https://github.com/iqlusioninc/crates/pull/859
+
+## 0.2.1 (2021-06-23)
 ### Added
 - `From` conversions to `k256::ecdsa::*Key` ([#777])
 

--- a/bip32/Cargo.toml
+++ b/bip32/Cargo.toml
@@ -5,7 +5,7 @@ BIP32 hierarchical key derivation implemented in a generic, no_std-friendly
 manner. Supports deriving keys using the pure Rust k256 crate or the
 C library-backed secp256k1 crate
 """
-version    = "0.2.1" # Also update html_root_url in lib.rs when bumping this
+version    = "0.2.2" # Also update html_root_url in lib.rs when bumping this
 authors    = ["Tony Arcieri <tony@iqlusion.io>"]
 license    = "Apache-2.0 OR MIT"
 homepage   = "https://github.com/iqlusioninc/crates/"

--- a/bip32/src/lib.rs
+++ b/bip32/src/lib.rs
@@ -95,7 +95,7 @@
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc(html_root_url = "https://docs.rs/bip32/0.2.1")]
+#![doc(html_root_url = "https://docs.rs/bip32/0.2.2")]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 


### PR DESCRIPTION
### Changed
- Avoid `AsRef` ambiguity with `generic-array` ([#859])

[#859]: https://github.com/iqlusioninc/crates/pull/859