### PR TITLE
zeroize: derive `Default` on `Zeroizing`

### DIFF
--- a/zeroize/src/lib.rs
+++ b/zeroize/src/lib.rs
@@ -424,7 +424,7 @@ pub trait TryZeroize {
 
 /// `Zeroizing` is a a wrapper for any `Z: Zeroize` type which implements a
 /// `Drop` handler which zeroizes dropped values.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Default, Eq, PartialEq)]
 pub struct Zeroizing<Z: Zeroize>(Z);
 
 impl<Z> Zeroizing<Z>


### PR DESCRIPTION
Simplifies initialization of a `Zeroizing` type to its default value.

Closes #849.