### PR TITLE
mintscan v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "mintscan"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "iqhttp",
  "serde",

--- a/mintscan/CHANGELOG.md
+++ b/mintscan/CHANGELOG.md
@@ -4,5 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2021-10-27)
+### Changed
+- Bump `tendermint` crate from 0.20.0 to 0.21.0 ([#820])
+- Rust 2021 edition upgrade; MSRV 1.56+ ([#889])
+
+[#820]: https://github.com/iqlusioninc/crates/pull/820
+[#889]: https://github.com/iqlusioninc/crates/pull/889
+
 ## 0.1.0 (2021-05-10)
 - Initial release

--- a/mintscan/Cargo.toml
+++ b/mintscan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mintscan"
-version = "0.1.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 API client for the Mintscan Cosmos explorer by Cosmostation
 """

--- a/mintscan/README.md
+++ b/mintscan/README.md
@@ -12,7 +12,7 @@ API client for the [Mintscan] Cosmos explorer by [Cosmostation].
 
 ## Minimum Supported Rust Version
 
-- Rust **1.51**
+- Rust **1.56**
 
 ## License
 
@@ -38,7 +38,7 @@ without any additional terms or conditions.
 [docs-link]: https://docs.rs/mintscan/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [license-link]: https://github.com/iqlusioninc/crates/blob/main/LICENSE
-[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
 [build-image]: https://github.com/iqlusioninc/crates/actions/workflows/mintscan.yml/badge.svg
 [build-link]: https://github.com/iqlusioninc/crates/actions/workflows/mintscan.yml
 

--- a/mintscan/src/lib.rs
+++ b/mintscan/src/lib.rs
@@ -3,7 +3,7 @@
 //! [Mintscan]: https://www.mintscan.io/
 //! [Cosmostation]: https://www.cosmostation.io/
 
-#![doc(html_root_url = "https://docs.rs/mintscan/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/mintscan/0.2.0")]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 


### PR DESCRIPTION
### Changed
- Bump `tendermint` crate from 0.20.0 to 0.21.0 ([#820])
- Rust 2021 edition upgrade; MSRV 1.56+ ([#889])

[#820]: https://github.com/iqlusioninc/crates/pull/820
[#889]: https://github.com/iqlusioninc/crates/pull/889