### PR TITLE
Add tests for `#[derive(Zeroize)]` on `enum`s

### DIFF
--- a/zeroize/tests/zeroize_derive.rs
+++ b/zeroize/tests/zeroize_derive.rs
@@ -4,30 +4,30 @@
 mod custom_derive_tests {
     use zeroize::Zeroize;
 
-    #[derive(Zeroize)]
-    #[zeroize(drop)]
-    struct ZeroizableTupleStruct([u8; 3]);
-
     #[test]
     fn derive_tuple_struct_test() {
-        let mut value = ZeroizableTupleStruct([1, 2, 3]);
+        #[derive(Zeroize)]
+        #[zeroize(drop)]
+        struct Z([u8; 3]);
+
+        let mut value = Z([1, 2, 3]);
         value.zeroize();
         assert_eq!(&value.0, &[0, 0, 0])
     }
 
-    #[derive(Zeroize)]
-    #[zeroize(drop)]
-    struct ZeroizableStruct {
-        string: String,
-        vec: Vec<u8>,
-        bytearray: [u8; 3],
-        number: usize,
-        boolean: bool,
-    }
-
     #[test]
     fn derive_struct_test() {
-        let mut value = ZeroizableStruct {
+        #[derive(Zeroize)]
+        #[zeroize(drop)]
+        struct Z {
+            string: String,
+            vec: Vec<u8>,
+            bytearray: [u8; 3],
+            number: usize,
+            boolean: bool,
+        }
+
+        let mut value = Z {
             string: String::from("Hello, world!"),
             vec: vec![1, 2, 3],
             bytearray: [4, 5, 6],
@@ -44,10 +44,45 @@ mod custom_derive_tests {
         assert!(!value.boolean);
     }
 
-    /// Test that the custom macro actually derived `Drop` for `ZeroizableStruct`
     #[test]
-    fn derive_drop() {
-        assert!(std::mem::needs_drop::<ZeroizableStruct>());
+    fn derive_enum_test() {
+        #[derive(Zeroize)]
+        #[zeroize(drop)]
+        enum Z {
+            #[allow(dead_code)]
+            Variant1,
+            Variant2(usize),
+        }
+
+        let mut value = Z::Variant2(26);
+
+        value.zeroize();
+
+        assert!(matches!(value, Z::Variant2(0)));
+    }
+
+    /// Test that the custom macro actually derived `Drop` for `Z`
+    #[test]
+    fn derive_struct_drop() {
+        #[derive(Zeroize)]
+        #[zeroize(drop)]
+        struct Z([u8; 3]);
+
+        assert!(std::mem::needs_drop::<Z>());
+    }
+
+    /// Test that the custom macro actually derived `Drop` for `Z`
+    #[test]
+    fn derive_enum_drop() {
+        #[allow(dead_code)]
+        #[derive(Zeroize)]
+        #[zeroize(drop)]
+        enum Z {
+            Variant1,
+            Variant2(usize),
+        }
+
+        assert!(std::mem::needs_drop::<Z>());
     }
 
     /// Test that `Drop` is not derived in the following case by defining a
@@ -57,6 +92,16 @@ mod custom_derive_tests {
     struct ZeroizeNoDropStruct([u8; 3]);
 
     impl Drop for ZeroizeNoDropStruct {
+        fn drop(&mut self) {}
+    }
+
+    #[allow(dead_code)]
+    #[derive(Zeroize)]
+    enum ZeroizeNoDropEnum {
+        Variant([u8; 3]),
+    }
+
+    impl Drop for ZeroizeNoDropEnum {
         fn drop(&mut self) {}
     }
 }


### PR DESCRIPTION
Add additional tests to prevent #876 from happening again. I also moved the `struct`s inside the test functions to improve the code.

This will conflict with #900, I will handle the rebase ofc.