### PR TITLE
mintscan v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "mintscan"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "iqhttp",
  "serde",

--- a/mintscan/CHANGELOG.md
+++ b/mintscan/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2021-10-29)
+### Changed
+- Bump `tendermint` crate from 0.22.0 to 0.23.0 ([#897])
+
+[#897]: https://github.com/iqlusioninc/crates/pull/897
+
 ## 0.2.0 (2021-10-27)
 ### Changed
 - Bump `tendermint` crate from 0.20.0 to 0.21.0 ([#820])

--- a/mintscan/Cargo.toml
+++ b/mintscan/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "mintscan"
-version = "0.2.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 API client for the Mintscan Cosmos explorer by Cosmostation
 """
 authors = ["Tony Arcieri <tony@iqlusion.io>", ]
-homepage   = "https://github.com/iqlusioninc/crates/"
+homepage = "https://github.com/iqlusioninc/crates/"
 repository = "https://github.com/iqlusioninc/crates/tree/main/mintscan"
-license    = "Apache-2.0 OR MIT"
+license = "Apache-2.0 OR MIT"
 categories = ["api-bindings", "cryptography::cryptocurrencies"]
-keywords   = ["api", "client", "cosmos", "explorer", "tendermint"]
-readme     = "README.md"
-edition     = "2021"
+keywords = ["api", "client", "cosmos", "explorer", "tendermint"]
+readme = "README.md"
+edition = "2021"
 rust-version = "1.56"
 
 [dependencies]

--- a/mintscan/src/lib.rs
+++ b/mintscan/src/lib.rs
@@ -3,7 +3,7 @@
 //! [Mintscan]: https://www.mintscan.io/
 //! [Cosmostation]: https://www.cosmostation.io/
 
-#![doc(html_root_url = "https://docs.rs/mintscan/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/mintscan/0.3.0")]
 #![forbid(unsafe_code, clippy::unwrap_used)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 


### PR DESCRIPTION
### Changed
- Bump `tendermint` crate from 0.22.0 to 0.23.0 ([#897])

[#897]: https://github.com/iqlusioninc/crates/pull/897