### PR TITLE
Remove `anomaly` and `zeroize`

### DIFF
--- a/anomaly/README.md
+++ b/anomaly/README.md
@@ -1,9 +1,0 @@
-# 🚨 DEPRECATED! 🚨
-
-`anomaly` is retired and will receive no further updates.
-
-We recommend transitioning to one or more of the following alternatives:
-
-- [`anyhow`](https://github.com/dtolnay/anyhow)
-- [`eyre`](https://github.com/yaahc/eyre)
-- [`thiserror`](https://github.com/dtolnay/thiserror)

--- a/zeroize/README.md
+++ b/zeroize/README.md
@@ -1,5 +1,0 @@
-# 🚨 MOVED! 🚨
-
-The `zeroize` crate repo has moved to a new location:
-
-https://github.com/RustCrypto/utils/tree/master/zeroize


### PR DESCRIPTION
- `anomaly` has been deprecated
- `zeroize` has been moved

This removes some short-lived notices about these two crates