### PR TITLE
bip32 v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "392c772b012d685a640cdad68a5a21f4a45e696f85a2c2c907aab2fe49a91e19"
 
 [[package]]
 name = "bip32"
-version = "0.3.0-pre"
+version = "0.3.0"
 dependencies = [
  "bs58",
  "hex-literal",

--- a/bip32/CHANGELOG.md
+++ b/bip32/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2022-01-05)
+### Changed
+- Rust 2021 edition upgrade ([#889])
+- Decouple from `hkd32` ([#907])
+- Bump `k256` dependency to v0.10 ([#938])
+- Bump `secp256k1` (FFI) dependency to v0.21 ([#942])
+
+[#889]: https://github.com/iqlusioninc/crates/pull/889
+[#907]: https://github.com/iqlusioninc/crates/pull/907
+[#938]: https://github.com/iqlusioninc/crates/pull/938
+[#942]: https://github.com/iqlusioninc/crates/pull/942
+
 ## 0.2.2 (2021-09-07)
 ### Changed
 - Avoid `AsRef` ambiguity with `generic-array` ([#859])

--- a/bip32/Cargo.toml
+++ b/bip32/Cargo.toml
@@ -5,7 +5,7 @@ BIP32 hierarchical key derivation implemented in a generic, no_std-friendly
 manner. Supports deriving keys using the pure Rust k256 crate or the
 C library-backed secp256k1 crate
 """
-version = "0.3.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.3.0" # Also update html_root_url in lib.rs when bumping this
 authors = ["Tony Arcieri <tony@iqlusion.io>"]
 license = "Apache-2.0 OR MIT"
 homepage = "https://github.com/iqlusioninc/crates/"

--- a/bip32/src/lib.rs
+++ b/bip32/src/lib.rs
@@ -1,12 +1,10 @@
-//! Pure Rust implementation of
-//! [BIP-0032: Hierarchical Deterministic Wallets][bip32].
-//!
-//! # About
-//! BIP32 is an algorithm for generating a hierarchy of elliptic curve keys,
-//! a.k.a. "wallets", from a single seed value. A related algorithm also
-//! implemented by this crate, BIP39, provides a way to derive the seed value
-//! from a set of 24-words from a preset list, a.k.a. a "mnemonic".
-//!
+#![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc(html_root_url = "https://docs.rs/bip32/0.3.0")]
+#![doc = include_str!("../README.md")]
+#![forbid(unsafe_code, clippy::unwrap_used)]
+#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+
 //! ## Backends
 //! This crate provides a generic implementation of BIP32 which can be used
 //! with any backing provider which implements the [`PrivateKey`] and
@@ -92,12 +90,6 @@
 //! [bip32]: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
 //! [libsecp256k1 C library]: https://github.com/bitcoin-core/secp256k1
 //! [`secp256k1` Rust crate]: https://github.com/rust-bitcoin/rust-secp256k1/
-
-#![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc(html_root_url = "https://docs.rs/bip32/0.2.2")]
-#![forbid(unsafe_code, clippy::unwrap_used)]
-#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;


### PR DESCRIPTION
### Changed
- Rust 2021 edition upgrade ([#889])
- Decouple from `hkd32` ([#907])
- Bump `k256` dependency to v0.10 ([#938])
- Bump `secp256k1` (FFI) dependency to v0.21 ([#942])

[#889]: https://github.com/iqlusioninc/crates/pull/889
[#907]: https://github.com/iqlusioninc/crates/pull/907
[#938]: https://github.com/iqlusioninc/crates/pull/938
[#942]: https://github.com/iqlusioninc/crates/pull/942