### PR TITLE
signatory v0.24.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1538,7 +1538,7 @@ dependencies = [
 
 [[package]]
 name = "signatory"
-version = "0.23.2"
+version = "0.24.0"
 dependencies = [
  "ecdsa",
  "ed25519-dalek",

--- a/signatory/CHANGELOG.md
+++ b/signatory/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.24.0 (2022-01-05)
+### Changed
+- Rust 2021 edition upgrade ([#889])
+- Bump `k256` dependency to v0.10 ([#938])
+
+[#889]: https://github.com/iqlusioninc/crates/pull/889
+[#938]: https://github.com/iqlusioninc/crates/pull/938
+
 ## 0.23.2 (2021-08-02)
 ### Added
 - `ed25519::VerifyingKey::to_bytes` ([#834])

--- a/signatory/Cargo.toml
+++ b/signatory/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "signatory"
 description  = "Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support"
-version      = "0.23.2" # Also update html_root_url in lib.rs when bumping this
+version      = "0.24.0" # Also update html_root_url in lib.rs when bumping this
 license      = "Apache-2.0 OR MIT"
 authors      = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage     = "https://github.com/iqlusioninc/crates"

--- a/signatory/src/lib.rs
+++ b/signatory/src/lib.rs
@@ -16,7 +16,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
-    html_root_url = "https://docs.rs/signatory/0.23.2",
+    html_root_url = "https://docs.rs/signatory/0.24.0",
     html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/crates/main/signatory/img/signatory-rustacean.png"
 )]
 #![forbid(unsafe_code, clippy::unwrap_used)]


### PR DESCRIPTION
### Changed
- Rust 2021 edition upgrade ([#889])
- Bump `k256` dependency to v0.10 ([#938])

[#889]: https://github.com/iqlusioninc/crates/pull/889
[#938]: https://github.com/iqlusioninc/crates/pull/938