### PR TITLE
stdtx v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1601,7 +1601,7 @@ dependencies = [
 
 [[package]]
 name = "stdtx"
-version = "0.6.0-pre"
+version = "0.6.0"
 dependencies = [
  "ecdsa",
  "eyre",

--- a/stdtx/CHANGELOG.md
+++ b/stdtx/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2022-01-06)
+### Changed
+- Rust 2021 edition upgrade ([#889])
+- Bump `k256` dependency to v0.10 ([#938])
+
+[#889]: https://github.com/iqlusioninc/crates/pull/889
+[#938]: https://github.com/iqlusioninc/crates/pull/938
+
 ## 0.5.0 (2021-06-23)
 ### Changed
 - MSRV 1.51+ ([#755])

--- a/stdtx/Cargo.toml
+++ b/stdtx/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "stdtx"
 description = "Extensible schema-driven Cosmos StdTx builder and Amino serializer"
-version     = "0.6.0-pre" # Also update html_root_url in lib.rs when bumping this
+version     = "0.6.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0"
 homepage    = "https://github.com/iqlusioninc/crates/"

--- a/stdtx/src/lib.rs
+++ b/stdtx/src/lib.rs
@@ -115,7 +115,7 @@
 //! [`yubihsm`]: https://docs.rs/yubihsm
 //! [`stdtx::Builder`]: https://docs.rs/stdtx/latest/stdtx/stdtx/struct.Builder.html
 
-#![doc(html_root_url = "https://docs.rs/stdtx/0.5.0")]
+#![doc(html_root_url = "https://docs.rs/stdtx/0.6.0")]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 


### PR DESCRIPTION
### Changed
- Rust 2021 edition upgrade ([#889])
- Bump `k256` dependency to v0.10 ([#938])

[#889]: https://github.com/iqlusioninc/crates/pull/889
[#938]: https://github.com/iqlusioninc/crates/pull/938