### PR TITLE
secrecy: use const generics, remove array impl macros

### DIFF
--- a/secrecy/src/lib.rs
+++ b/secrecy/src/lib.rs
@@ -36,6 +36,7 @@
 //! the implementation:
 //!
 //! ```rust
+//! use core::fmt;
 //! use secrecy::{CloneableSecret, DebugSecret, Secret, Zeroize};
 //!
 //! #[derive(Clone)]
@@ -49,9 +50,22 @@
 //!
 //! /// Permits cloning
 //! impl CloneableSecret for AccountNumber {}
+//! let accts = [
+//!     AccountNumber("0xa".into()),
+//!     AccountNumber("0xb".into()),
+//!     AccountNumber("0xc".into())
+//! ];
+//! let cloned_accts = accts.clone();
 //!
 //! /// Provides a `Debug` impl (by default `[[REDACTED]]`)
 //! impl DebugSecret for AccountNumber {}
+//! impl fmt::Debug for AccountNumber {
+//!     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+//!         AccountNumber::debug_secret(f)
+//!     }
+//! }
+//!
+//! assert!(format!("AccountNumbers = {:?}", accts).contains("REDACTED"));
 //!
 //! /// Use this alias when storing secret values
 //! pub type SecretAccountNumber = Secret<AccountNumber>;
@@ -186,20 +200,7 @@ pub trait CloneableSecret: Clone + Zeroize {}
 
 /// Implement `CloneableSecret` on arrays of types that impl `Clone` and
 /// `Zeroize`.
-macro_rules! impl_cloneable_secret_for_array {
-    ($($size:expr),+) => {
-        $(
-            impl<T: Clone + Zeroize> CloneableSecret for [T; $size] {}
-        )+
-     };
-}
-
-// TODO(tarcieri): const generics
-impl_cloneable_secret_for_array!(
-    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
-    27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
-    51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64
-);
+impl<T: Clone + Zeroize, const N: usize> CloneableSecret for [T; N] {}
 
 /// Expose a reference to an inner secret
 pub trait ExposeSecret<S> {
@@ -221,20 +222,7 @@ pub trait DebugSecret {
 }
 
 /// Implement `DebugSecret` on arrays of types that impl `Debug`.
-macro_rules! impl_debug_secret_for_array {
-    ($($size:expr),+) => {
-        $(
-            impl<T: Debug> DebugSecret for [T; $size] {}
-        )+
-     };
-}
-
-// TODO(tarcieri): const generics
-impl_debug_secret_for_array!(
-    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
-    27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
-    51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64
-);
+impl<T: Debug, const N: usize> DebugSecret for [T; N] {}
 
 /// Marker trait for secret types which can be [`Serialize`]-d by [`serde`].
 ///


### PR DESCRIPTION
This PR removes the `impl_cloneable_secret_for_array` and `impl_debug_secret_for_array` macros from the `secrecy` crate in favor of using `const` generics. 

The doctest in `secrecy` has been updated to illustrate the usage on a `[AccountNumber; 3]` type as well. 

I am not 100% certain that the usage is correct, but if so, I think it is also more thoroughly demonstrated now that it includes the `Debug` impl on a type which delegates to the trait's default `DebugSecret::debug_secret` method. 