### PR TITLE
Fix MSRV documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ without any additional terms or conditions.
 
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/crates/blob/main/LICENSE
-[msrv-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[msrv-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
 [deps-image]: https://deps.rs/repo/github/iqlusioninc/crates/status.svg
 [deps-link]: https://deps.rs/repo/github/iqlusioninc/crates
 

--- a/bip32/README.md
+++ b/bip32/README.md
@@ -24,7 +24,7 @@ from a set of 24-words from a preset list, a.k.a. a "mnemonic".
 
 ## Minimum Supported Rust Version
 
-Rust **1.51** or newer.
+Rust **1.56** or newer.
 
 In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
 for this crate's SemVer guarantees), however when we do it will be accompanied by
@@ -54,7 +54,7 @@ without any additional terms or conditions.
 [docs-link]: https://docs.rs/bip32/
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/crates/blob/main/LICENSE
-[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
 [build-image]: https://github.com/iqlusioninc/crates/actions/workflows/bip32.yml/badge.svg

--- a/canonical-path/README.md
+++ b/canonical-path/README.md
@@ -17,7 +17,7 @@ are canonical, or at least, were canonical at the time they were created.
 
 ## Minimum Supported Rust Version
 
-Rust **1.51** or newer.
+Rust **1.56** or newer.
 
 In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
 for this crate's SemVer guarantees), however when we do it will be accompanied by
@@ -53,6 +53,6 @@ without any additional terms or conditions.
 [docs-link]: https://docs.rs/canonical-path/
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/crates/blob/main/LICENSE
-[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
 [build-image]: https://github.com/iqlusioninc/crates/actions/workflows/canonical-path.yml/badge.svg
 [build-link]: https://github.com/iqlusioninc/crates/actions/workflows/canonical-path.yml

--- a/datadog/README.md
+++ b/datadog/README.md
@@ -13,7 +13,7 @@ Client library for the [Datadog] service.
 
 ## Minimum Supported Rust Version
 
-Rust **1.51** or newer.
+Rust **1.56** or newer.
 
 In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
 for this crate's SemVer guarantees), however when we do it will be accompanied by
@@ -47,7 +47,7 @@ without any additional terms or conditions.
 [docs-link]: https://docs.rs/datadog/
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/crates/blob/main/LICENSE
-[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
 [build-image]: https://github.com/iqlusioninc/crates/actions/workflows/datadog.yml/badge.svg

--- a/hkd32/CHANGELOG.md
+++ b/hkd32/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `hmac` to v0.11 ([#704])
 - `pbkdf2` to v0.8 ([#704])
 - Rename `SEED_SIZE` to `Seed::SIZE` ([#728])
-- MSRV 1.51 ([#755])
+- MSRV 1.56 ([#755])
 - Bump `rand_core` to v0.6 ([#759])
 
 ### Removed

--- a/hkd32/README.md
+++ b/hkd32/README.md
@@ -22,7 +22,7 @@ an initial 32-bytes of input key material.
 
 ## Minimum Supported Rust Version
 
-- Rust **1.51**
+- Rust **1.56**
 
 ## License
 
@@ -51,7 +51,7 @@ without any additional terms or conditions.
 [docs-link]: https://docs.rs/hkd32/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [license-link]: https://github.com/iqlusioninc/crates/blob/main/LICENSE
-[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
 [build-image]: https://github.com/iqlusioninc/crates/actions/workflows/hkd32.yml/badge.svg
 [build-link]: https://github.com/iqlusioninc/crates/actions/workflows/hkd32.yml
 

--- a/iqhttp/README.md
+++ b/iqhttp/README.md
@@ -13,7 +13,7 @@ built-in SSL/TLS support based on [`rustls`].
 
 ## Minimum Supported Rust Version
 
-- Rust **1.51**
+- Rust **1.56**
 
 ## License
 
@@ -39,7 +39,7 @@ without any additional terms or conditions.
 [docs-link]: https://docs.rs/iqhttp/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [license-link]: https://github.com/iqlusioninc/crates/blob/main/LICENSE
-[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
 [build-image]: https://github.com/iqlusioninc/crates/actions/workflows/iqhttp.yml/badge.svg
 [build-link]: https://github.com/iqlusioninc/crates/actions/workflows/iqhttp.yml
 

--- a/secrecy/CHANGELOG.md
+++ b/secrecy/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.8.0 (2021-07-18)
 
-NOTE: This release includes an MSRV bump to Rust 1.51. Please use `secrecy = "0.7.0"`
+NOTE: This release includes an MSRV bump to Rust 1.56. Please use `secrecy = "0.7.0"`
 if you would like to support older Rust versions.
 
 ### Added
@@ -14,7 +14,7 @@ if you would like to support older Rust versions.
 
 ### Changed
 - Bump `bytes` to v1.0 ([#592])
-- Switch to `resolver = "2"`; MSRV 1.51 ([#755])
+- Switch to `resolver = "2"`; MSRV 1.56 ([#755])
 
 [#482]: https://github.com/iqlusioninc/crates/pull/482
 [#592]: https://github.com/iqlusioninc/crates/pull/592

--- a/secrecy/README.md
+++ b/secrecy/README.md
@@ -24,7 +24,7 @@ from memory when dropped.
 
 ## Minimum Supported Rust Version
 
-Rust **1.51** or newer.
+Rust **1.56** or newer.
 
 In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
 for this crate's SemVer guarantees), however when we do it will be accompanied by
@@ -66,7 +66,7 @@ without any additional terms or conditions.
 [docs-image]: https://docs.rs/secrecy/badge.svg
 [docs-link]: https://docs.rs/secrecy/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
 [build-image]: https://github.com/iqlusioninc/crates/actions/workflows/secrecy.yml/badge.svg

--- a/signatory/README.md
+++ b/signatory/README.md
@@ -25,7 +25,7 @@ The following algorithms are supported:
 
 ## Minimum Supported Rust Version
 
-Rust **1.51** or newer.
+Rust **1.56** or newer.
 
 In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
 for this crate's SemVer guarantees), however when we do it will be accompanied by
@@ -52,7 +52,7 @@ without any additional terms or conditions.
 [docs-image]: https://docs.rs/signatory/badge.svg
 [docs-link]: https://docs.rs/signatory/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
 [build-image]: https://github.com/iqlusioninc/crates/workflows/signatory/badge.svg?branch=main&event=push
 [build-link]: https://github.com/iqlusioninc/crates/actions
 

--- a/stdtx/CHANGELOG.md
+++ b/stdtx/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.5.0 (2021-06-23)
 ### Changed
-- MSRV 1.51+ ([#755])
+- MSRV 1.56+ ([#755])
 - Bump `k256` to v0.9 ([#759])
 - `rand_core` to v0.6 ([#759])
 

--- a/stdtx/README.md
+++ b/stdtx/README.md
@@ -26,7 +26,7 @@ uses the [StdTx] format without requiring upstream modifications.
 
 ## Minimum Supported Rust Version
 
-Rust **1.51** or newer.
+Rust **1.56** or newer.
 
 In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
 for this crate's SemVer guarantees), however when we do it will be accompanied by
@@ -60,7 +60,7 @@ limitations under the License.
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/crates/blob/main/LICENSE
-[msrv-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[msrv-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
 
 [//]: # (general links)
 

--- a/subtle-encoding/README.md
+++ b/subtle-encoding/README.md
@@ -21,7 +21,7 @@ Useful for encoding/decoding secret values such as cryptographic keys.
 
 ## Minimum Supported Rust Version
 
-Rust **1.51** or newer.
+Rust **1.56** or newer.
 
 In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
 for this crate's SemVer guarantees), however when we do it will be accompanied by
@@ -55,7 +55,7 @@ toplevel directory of this repository or [LICENSE-MIT] for details.
 [docs-image]: https://docs.rs/subtle-encoding/badge.svg
 [docs-link]: https://docs.rs/subtle-encoding/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
 [build-image]: https://github.com/iqlusioninc/crates/actions/workflows/subtle-encoding.yml/badge.svg


### PR DESCRIPTION
Updates all stale docs to the current MSRV of 1.56.

Closes #951