### PR TITLE
iqhttp: add `HttpsClient::{add_header, headers_mut}`

### DIFF
--- a/iqhttp/src/lib.rs
+++ b/iqhttp/src/lib.rs
@@ -24,7 +24,7 @@ pub use self::{
     https_client::HttpsClient,
     query::Query,
 };
-pub use hyper::{self, Uri};
+pub use hyper::{self, header, HeaderMap, Uri};
 
 /// User-Agent to send in HTTP request
 pub const USER_AGENT: &str = concat!("iqhttp/", env!("CARGO_PKG_VERSION"));


### PR DESCRIPTION
Adds support for configuring HTTP headers to send as part of the request.

Uses `hyper::HeaderMap` as the internal data structure for headers, making them yet another thin wrapper around `hyper`.

This functionality existed somewhat before, but as a crate-internal feature only. This commit exposes it as a first-class feature.