### PR TITLE
mintscan v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "mintscan"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "iqhttp",
  "serde",

--- a/iqhttp/LICENSE-MIT
+++ b/iqhttp/LICENSE-MIT
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2021 iqlusion
+Copyright (c) 2021-2022 iqlusion
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/mintscan/CHANGELOG.md
+++ b/mintscan/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2022-04-23)
+### Added
+- `Referer` header ([#982])
+
+### Changed
+- Bump `iqhttp` dependency to v0.2.0 ([#984]) 
+
+[#982]: https://github.com/iqlusioninc/crates/pull/982
+[#984]: https://github.com/iqlusioninc/crates/pull/984
+
 ## 0.3.0 (2021-10-29)
 ### Changed
 - Bump `tendermint` crate from 0.22.0 to 0.23.0 ([#897])

--- a/mintscan/Cargo.toml
+++ b/mintscan/Cargo.toml
@@ -1,17 +1,15 @@
 [package]
-name = "mintscan"
-version = "0.3.0" # Also update html_root_url in lib.rs when bumping this
-description = """
-API client for the Mintscan Cosmos explorer by Cosmostation
-"""
-authors = ["Tony Arcieri <tony@iqlusion.io>", ]
-homepage = "https://github.com/iqlusioninc/crates/"
-repository = "https://github.com/iqlusioninc/crates/tree/main/mintscan"
-license = "Apache-2.0 OR MIT"
-categories = ["api-bindings", "cryptography::cryptocurrencies"]
-keywords = ["api", "client", "cosmos", "explorer", "tendermint"]
-readme = "README.md"
-edition = "2021"
+name         = "mintscan"
+version      = "0.4.0"
+description  = "API client for the Mintscan Cosmos explorer by Cosmostation"
+authors      = ["Tony Arcieri <tony@iqlusion.io>", ]
+homepage     = "https://github.com/iqlusioninc/crates/"
+repository   = "https://github.com/iqlusioninc/crates/tree/main/mintscan"
+license      = "Apache-2.0 OR MIT"
+categories   = ["api-bindings", "cryptography::cryptocurrencies"]
+keywords     = ["api", "client", "cosmos", "explorer", "tendermint"]
+readme       = "README.md"
+edition      = "2021"
 rust-version = "1.56"
 
 [dependencies]

--- a/mintscan/LICENSE-MIT
+++ b/mintscan/LICENSE-MIT
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2021 iqlusion
+Copyright (c) 2021-2022 iqlusion
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/mintscan/README.md
+++ b/mintscan/README.md
@@ -12,11 +12,11 @@ API client for the [Mintscan] Cosmos explorer by [Cosmostation].
 
 ## Minimum Supported Rust Version
 
-- Rust **1.56**
+Rust **1.56**
 
 ## License
 
-Copyright © 2021 iqlusion
+Copyright © 2021-2022 iqlusion
 
 **mintscan.rs** is distributed under the terms of either the MIT license
 or the Apache License (Version 2.0), at your option.

--- a/mintscan/src/lib.rs
+++ b/mintscan/src/lib.rs
@@ -1,11 +1,11 @@
-//! API client for the [Mintscan] Cosmos explorer by [Cosmostation].
-//!
-//! [Mintscan]: https://www.mintscan.io/
-//! [Cosmostation]: https://www.cosmostation.io/
-
-#![doc(html_root_url = "https://docs.rs/mintscan/0.3.0")]
-#![forbid(unsafe_code, clippy::unwrap_used)]
-#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+#![doc = include_str!("../README.md")]
+#![forbid(unsafe_code)]
+#![warn(
+    clippy::unwrap_used,
+    missing_docs,
+    rust_2018_idioms,
+    unused_qualifications
+)]
 
 pub mod coin;
 pub mod v1;


### PR DESCRIPTION
### Added
- `Referer` header ([#982])

### Changed
- Bump `iqhttp` dependency to v0.2.0 ([#984]) 

[#982]: https://github.com/iqlusioninc/crates/pull/982
[#984]: https://github.com/iqlusioninc/crates/pull/984