### PR TITLE
bip32: use const panic for `Prefix::from_parts_unchecked`

### DIFF
--- a/bip32/src/prefix.rs
+++ b/bip32/src/prefix.rs
@@ -6,15 +6,6 @@ use core::{
     str,
 };
 
-/// Constant panicking assertion.
-// TODO(tarcieri): use const panic when stable.
-// See: https://github.com/rust-lang/rust/issues/51999
-macro_rules! const_assert {
-    ($bool:expr, $msg:expr) => {
-        [$msg][!$bool as usize]
-    };
-}
-
 /// BIP32 extended key prefixes a.k.a. "versions" (e.g. `xpub`, `xprv`)
 ///
 /// The BIP32 spec describes these as "versions" and gives examples for
@@ -62,15 +53,18 @@ impl Prefix {
     /// The main intended use case for this function is [`Prefix`] constants
     /// such as [`Prefix::XPRV`].
     ///
+    /// # Warning
+    ///
     /// Use this function with care: No consistency check is performed! It is
     /// up to the caller to ensure that the version number matches the prefix.
+    ///
+    /// # Panics
     ///
     /// Panics if `s` is not 4 chars long, or any of the chars lie outside of
     /// the supported range: lower case (`a..=z`) or upper case (`A..=Z`)
     /// letters.
     pub const fn from_parts_unchecked(s: &str, version: Version) -> Self {
-        // TODO(tarcieri): return `Result` when const panic is stable
-        const_assert!(Self::validate_str(s).is_ok(), "invalid prefix");
+        assert!(Self::validate_str(s).is_ok(), "invalid prefix");
         let bytes = s.as_bytes();
         let chars = [bytes[0], bytes[1], bytes[2], bytes[3]];
         Self { chars, version }


### PR DESCRIPTION
Now that we're MSRV 1.57, const panic can be used because it was stabilized in that release.