### PR TITLE
bip32 v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ checksum = "dea908e7347a8c64e378c17e30ef880ad73e3b4498346b055c2c00ea342f3179"
 
 [[package]]
 name = "bip32"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "bs58",
  "hex-literal",

--- a/bip32/CHANGELOG.md
+++ b/bip32/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2022-05-10)
+### Changed
+- Bump `pbkdf2` to 0.11.0 ([#983])
+- Bump `hmac` to v0.12 ([#994])
+- Bump `k256` to v0.11 ([#994])
+- Bump `p256` to v0.11 ([#994])
+- Bump `pbkdf2` to v0.10 ([#994])
+- Bump `sha2` to v0.10 ([#994])
+- Replace `ripemd160` dependency with `ripemd` ([#994])
+- MSRV 1.57 ([#994], [#995])
+- Use const panic for `Prefix::from_parts_unchecked` ([#995])
+
+[#983]: https://github.com/iqlusioninc/crates/pull/983
+[#994]: https://github.com/iqlusioninc/crates/pull/994
+[#995]: https://github.com/iqlusioninc/crates/pull/995
+
 ## 0.3.0 (2022-01-05)
 ### Changed
 - Rust 2021 edition upgrade ([#889])

--- a/bip32/Cargo.toml
+++ b/bip32/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bip32"
-version = "0.4.0-pre"
+version = "0.4.0"
 description = """
 BIP32 hierarchical key derivation implemented in a generic, no_std-friendly
 manner. Supports deriving keys using the pure Rust k256 crate or the

--- a/bip32/LICENSE-MIT
+++ b/bip32/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 iqlusion
+Copyright (c) 2022 iqlusion
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/bip32/README.md
+++ b/bip32/README.md
@@ -32,7 +32,7 @@ a minor version bump.
 
 ## License
 
-Copyright © 2020-2021 iqlusion
+Copyright © 2020-2022 iqlusion
 
 **bip32.rs** is distributed under the terms of either the MIT license
 or the Apache License (Version 2.0), at your option.

--- a/bip32/src/lib.rs
+++ b/bip32/src/lib.rs
@@ -1,8 +1,13 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
-#![forbid(unsafe_code, clippy::unwrap_used)]
-#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+#![forbid(unsafe_code)]
+#![warn(
+    clippy::unwrap_used,
+    missing_docs,
+    rust_2018_idioms,
+    unused_qualifications
+)]
 
 //! ## Backends
 //! This crate provides a generic implementation of BIP32 which can be used


### PR DESCRIPTION
### Changed
- Bump `pbkdf2` to 0.11.0 ([#983])
- Bump `hmac` to v0.12 ([#994])
- Bump `k256` to v0.11 ([#994])
- Bump `p256` to v0.11 ([#994])
- Bump `pbkdf2` to v0.10 ([#994])
- Bump `sha2` to v0.10 ([#994])
- Replace `ripemd160` dependency with `ripemd` ([#994])
- MSRV 1.57 ([#994], [#995])
- Use const panic for `Prefix::from_parts_unchecked` ([#995])

[#983]: https://github.com/iqlusioninc/crates/pull/983
[#994]: https://github.com/iqlusioninc/crates/pull/994
[#995]: https://github.com/iqlusioninc/crates/pull/995