### PR TITLE
hkd32 v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,7 +615,7 @@ checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
 name = "hkd32"
-version = "0.7.0-pre"
+version = "0.7.0"
 dependencies = [
  "hex-literal",
  "hmac",

--- a/bip32/CHANGELOG.md
+++ b/bip32/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `hmac` to v0.12 ([#994])
 - Bump `k256` to v0.11 ([#994])
 - Bump `p256` to v0.11 ([#994])
-- Bump `pbkdf2` to v0.10 ([#994])
 - Bump `sha2` to v0.10 ([#994])
 - Replace `ripemd160` dependency with `ripemd` ([#994])
 - MSRV 1.57 ([#994], [#995])

--- a/hkd32/CHANGELOG.md
+++ b/hkd32/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (2022-05-10)
+### Added
+- Impl for `std::error::Error` ([#932])
+
+### Changed
+- Rust 2021 edition upgrade ([#889])
+- Bump `pbkdf2` to 0.11.0 ([#983])
+- Bump `hmac` to v0.12 ([#994])
+- Bump `sha2` to v0.10 ([#994])
+
+[#889]: https://github.com/iqlusioninc/crates/pull/889
+[#932]: https://github.com/iqlusioninc/crates/pull/932
+[#983]: https://github.com/iqlusioninc/crates/pull/983
+[#994]: https://github.com/iqlusioninc/crates/pull/994
+
 ## 0.6.0 (2021-06-17)
 ### Added
 - `Seed::new` method ([#729])

--- a/hkd32/Cargo.toml
+++ b/hkd32/Cargo.toml
@@ -7,7 +7,7 @@ repeated applications of the Hash-based Message Authentication Code
 (HMAC) construction. Optionally supports storing root derivation
 passwords as a 24-word mnemonic phrase (i.e. BIP39).
 """
-version    = "0.7.0-pre"
+version    = "0.7.0"
 authors    = ["Tony Arcieri <tony@iqlusion.io>"]
 license    = "Apache-2.0 OR MIT"
 homepage   = "https://github.com/iqlusioninc/crates/"


### PR DESCRIPTION
### Added
- Impl for `std::error::Error` ([#932])

### Changed
- Rust 2021 edition upgrade ([#889])
- Bump `pbkdf2` to 0.11.0 ([#983])
- Bump `hmac` to v0.12 ([#994])
- Bump `sha2` to v0.10 ([#994])

[#889]: https://github.com/iqlusioninc/crates/pull/889
[#932]: https://github.com/iqlusioninc/crates/pull/932
[#983]: https://github.com/iqlusioninc/crates/pull/983
[#994]: https://github.com/iqlusioninc/crates/pull/994