### PR TITLE
signatory v0.25.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1526,7 +1526,7 @@ dependencies = [
 
 [[package]]
 name = "signatory"
-version = "0.25.0-pre"
+version = "0.25.0"
 dependencies = [
  "ecdsa",
  "ed25519-dalek",

--- a/signatory/CHANGELOG.md
+++ b/signatory/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.25.0 (2022-05-17)
+### Changed
+- Bump `ecdsa` to v0.14 ([#994])
+- Bump `k256` to v0.11 ([#994])
+- Bump `p256` to v0.11 ([#994])
+- Bump `pkcs8` to v0.9 ([#994])
+- Bump `sha2` to v0.10 ([#994])
+- MSRV 1.57 ([#994])
+
+[#994]: https://github.com/iqlusioninc/crates/pull/994
+
 ## 0.24.0 (2022-01-05)
 ### Changed
 - Rust 2021 edition upgrade ([#889])

--- a/signatory/Cargo.toml
+++ b/signatory/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "signatory"
 description  = "Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support"
-version      = "0.25.0-pre"
+version      = "0.25.0"
 license      = "Apache-2.0 OR MIT"
 authors      = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage     = "https://github.com/iqlusioninc/crates"
@@ -9,14 +9,13 @@ repository   = "https://github.com/iqlusioninc/crates/tree/main/signatory"
 readme       = "README.md"
 categories   = ["authentication", "cryptography"]
 keywords     = ["cryptography", "ecdsa", "ed25519", "signing", "signatures"]
-autobenches  = false
 edition      = "2021"
 rust-version = "1.57"
 
 [dependencies]
 pkcs8 = { version = "0.9", features = ["alloc", "pem"] }
 rand_core = "0.6"
-signature = "1.4"
+signature = "1.5"
 zeroize = "1.4"
 
 # optional dependencies

--- a/signatory/src/lib.rs
+++ b/signatory/src/lib.rs
@@ -1,26 +1,16 @@
-//! Signatory: a multi-algorithm digital signature library.
-//!
-//! This crate provides a thread-and-object-safe API for both creating and
-//! verifying elliptic curve digital signatures, using either software-based
-//! or hardware-based providers.
-//!
-//! The following algorithms are supported:
-//!
-//! - [ecdsa]: Elliptic Curve Digital Signature Algorithm ([FIPS 186-4])
-//! - [ed25519]: Edwards Digital Signature Algorithm (EdDSA) instantiated using
-//!   the twisted Edwards form of Curve25519 ([RFC 8032]).
-//!
-//! [FIPS 186-4]: https://csrc.nist.gov/publications/detail/fips/186/4/final
-//! [RFC 8032]: https://tools.ietf.org/html/rfc8032
-
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc = include_str!("../README.md")]
 #![doc(
-    html_root_url = "https://docs.rs/signatory/0.24.0",
-    html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/crates/main/signatory/img/signatory-rustacean.png"
+    html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/crates/main/signatory/img/signatory-rustacean.svg"
 )]
-#![forbid(unsafe_code, clippy::unwrap_used)]
-#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+#![forbid(unsafe_code)]
+#![warn(
+    clippy::unwrap_used,
+    missing_docs,
+    rust_2018_idioms,
+    unused_qualifications
+)]
 
 extern crate alloc;
 


### PR DESCRIPTION
### Changed
- Bump `ecdsa` to v0.14 ([#994])
- Bump `k256` to v0.11 ([#994])
- Bump `p256` to v0.11 ([#994])
- Bump `pkcs8` to v0.9 ([#994])
- Bump `sha2` to v0.10 ([#994])
- MSRV 1.57 ([#994])

[#994]: https://github.com/iqlusioninc/crates/pull/994