### PR TITLE
stdtx v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1589,7 +1589,7 @@ dependencies = [
 
 [[package]]
 name = "stdtx"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "ecdsa",
  "eyre",

--- a/stdtx/CHANGELOG.md
+++ b/stdtx/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (2022-07-27)
+### Changed
+- Bump `k256` to v0.11; `sha2` to v0.10 ([#994])
+
+[#994]: https://github.com/iqlusioninc/crates/pull/994
+
 ## 0.6.0 (2022-01-06)
 ### Changed
 - Rust 2021 edition upgrade ([#889])

--- a/stdtx/Cargo.toml
+++ b/stdtx/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "stdtx"
 description  = "Extensible schema-driven Cosmos StdTx builder and Amino serializer"
-version      = "0.6.0" # Also update html_root_url in lib.rs when bumping this
+version      = "0.7.0" # Also update html_root_url in lib.rs when bumping this
 authors      = ["Tony Arcieri <tony@iqlusion.io>"]
 license      = "Apache-2.0"
 homepage     = "https://github.com/iqlusioninc/crates/"


### PR DESCRIPTION
### Changed
- Bump `k256` to v0.11; `sha2` to v0.10 ([#994])

[#994]: https://github.com/iqlusioninc/crates/pull/994