### PR TITLE
signatory: add `Send + Sync` bounds to signer `Box`es

### DIFF
--- a/signatory/src/ecdsa/nistp256.rs
+++ b/signatory/src/ecdsa/nistp256.rs
@@ -51,14 +51,14 @@ impl LoadPkcs8 for KeyRing {
 
 /// ECDSA/NIST P-256 signing key.
 pub struct SigningKey {
-    inner: Box<dyn NistP256Signer>,
+    inner: Box<dyn NistP256Signer + Send + Sync>,
 }
 
 impl SigningKey {
     /// Initialize from a provided signer object.
     ///
     /// Use [`SigningKey::from_bytes`] to initialize from a raw private key.
-    pub fn new(signer: Box<dyn NistP256Signer>) -> Self {
+    pub fn new(signer: Box<dyn NistP256Signer + Send + Sync>) -> Self {
         Self { inner: signer }
     }
 

--- a/signatory/src/ecdsa/secp256k1.rs
+++ b/signatory/src/ecdsa/secp256k1.rs
@@ -54,14 +54,14 @@ impl LoadPkcs8 for KeyRing {
 
 /// ECDSA/secp256k1 signing key.
 pub struct SigningKey {
-    inner: Box<dyn Secp256k1Signer>,
+    inner: Box<dyn Secp256k1Signer + Send + Sync>,
 }
 
 impl SigningKey {
     /// Initialize from a provided signer object.
     ///
     /// Use [`SigningKey::from_bytes`] to initialize from a raw private key.
-    pub fn new(signer: Box<dyn Secp256k1Signer>) -> Self {
+    pub fn new(signer: Box<dyn Secp256k1Signer + Send + Sync>) -> Self {
         Self { inner: signer }
     }
 

--- a/signatory/src/ed25519/sign.rs
+++ b/signatory/src/ed25519/sign.rs
@@ -12,14 +12,14 @@ use zeroize::Zeroizing;
 
 /// Ed25519 signing key.
 pub struct SigningKey {
-    inner: Box<dyn Ed25519Signer>,
+    inner: Box<dyn Ed25519Signer + Send + Sync>,
 }
 
 impl SigningKey {
     /// Initialize from a provided signer object.
     ///
     /// Use [`SigningKey::from_bytes`] to initialize from a raw private key.
-    pub fn new(signer: Box<dyn Ed25519Signer>) -> Self {
+    pub fn new(signer: Box<dyn Ed25519Signer + Send + Sync>) -> Self {
         Self { inner: signer }
     }
 


### PR DESCRIPTION
This allows the keyring types to be shared across threads