### PR TITLE
signatory: ECDSA/P-384 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,6 +343,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
+ "hkdf",
  "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.3",
@@ -625,6 +626,15 @@ dependencies = [
  "sha2 0.10.2",
  "subtle-encoding 0.5.1",
  "zeroize",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
+dependencies = [
+ "hmac",
 ]
 
 [[package]]
@@ -1049,6 +1059,17 @@ name = "p256"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "sha2 0.10.2",
+]
+
+[[package]]
+name = "p384"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc8c5bf642dde52bb9e87c0ecd8ca5a76faac2eeed98dedb7c717997e1080aa"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -1524,6 +1545,7 @@ dependencies = [
  "ed25519-dalek",
  "k256",
  "p256",
+ "p384",
  "pkcs8",
  "rand_core 0.6.3",
  "signature",

--- a/signatory/Cargo.toml
+++ b/signatory/Cargo.toml
@@ -23,6 +23,7 @@ ecdsa = { version = "0.14", optional = true, features = ["pem", "pkcs8"] }
 ed25519-dalek = { version = "1", optional = true, default-features = false, features = ["u64_backend"] }
 k256 = { version = "0.11", optional = true, features = ["ecdsa", "sha256", "keccak256"] }
 p256 = { version = "0.11", optional = true, features = ["ecdsa", "sha256"] }
+p384 = { version = "0.11", optional = true, features = ["ecdsa", "sha384"] }
 
 [dev-dependencies]
 tempfile = "3"
@@ -31,6 +32,7 @@ tempfile = "3"
 default = ["std"]
 ed25519 = ["ed25519-dalek"]
 nistp256 = ["ecdsa", "p256"]
+nistp384 = ["ecdsa", "p384"]
 secp256k1 = ["ecdsa", "k256"]
 std = ["pkcs8/std", "rand_core/std", "signature/std"]
 

--- a/signatory/src/algorithm.rs
+++ b/signatory/src/algorithm.rs
@@ -14,6 +14,11 @@ pub enum Algorithm {
     #[cfg_attr(docsrs, doc(cfg(feature = "nistp256")))]
     EcdsaNistP256,
 
+    /// ECDSA with NIST P-384.
+    #[cfg(feature = "nistp384")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "nistp384")))]
+    EcdsaNistP384,
+
     /// ECDSA with secp256k1.
     #[cfg(feature = "secp256k1")]
     #[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
@@ -31,6 +36,11 @@ impl Algorithm {
     pub fn is_ecdsa(self) -> bool {
         #[cfg(feature = "nistp256")]
         if self == Algorithm::EcdsaNistP256 {
+            return true;
+        }
+
+        #[cfg(feature = "nistp384")]
+        if self == Algorithm::EcdsaNistP384 {
             return true;
         }
 
@@ -56,6 +66,11 @@ impl TryFrom<pkcs8::AlgorithmIdentifier<'_>> for Algorithm {
             #[cfg(feature = "nistp256")]
             if pkcs8_alg_id.parameters_oid() == Ok(crate::ecdsa::NistP256::OID) {
                 return Ok(Self::EcdsaNistP256);
+            }
+
+            #[cfg(feature = "nistp384")]
+            if pkcs8_alg_id.parameters_oid() == Ok(crate::ecdsa::NistP384::OID) {
+                return Ok(Self::EcdsaNistP384);
             }
 
             #[cfg(feature = "secp256k1")]

--- a/signatory/src/ecdsa.rs
+++ b/signatory/src/ecdsa.rs
@@ -4,6 +4,10 @@
 #[cfg_attr(docsrs, doc(cfg(feature = "nistp256")))]
 pub mod nistp256;
 
+#[cfg(feature = "nistp384")]
+#[cfg_attr(docsrs, doc(cfg(feature = "nistp384")))]
+pub mod nistp384;
+
 #[cfg(feature = "secp256k1")]
 #[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
 pub mod secp256k1;
@@ -16,6 +20,10 @@ pub use ecdsa::{elliptic_curve, Signature};
 #[cfg(feature = "nistp256")]
 #[cfg_attr(docsrs, doc(cfg(feature = "nistp256")))]
 pub use {self::nistp256::NistP256Signer, p256::NistP256};
+
+#[cfg(feature = "nistp384")]
+#[cfg_attr(docsrs, doc(cfg(feature = "nistp384")))]
+pub use {self::nistp384::NistP384Signer, p384::NistP384};
 
 #[cfg(feature = "secp256k1")]
 #[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]

--- a/signatory/src/ecdsa/nistp384.rs
+++ b/signatory/src/ecdsa/nistp384.rs
@@ -1,0 +1,134 @@
+//! ECDSA/NIST P-384 support.
+
+pub use p384::ecdsa::{Signature, VerifyingKey};
+
+use crate::{
+    key::{ring::LoadPkcs8, store::GeneratePkcs8},
+    Error, KeyHandle, Map, Result,
+};
+use alloc::boxed::Box;
+use core::fmt;
+use pkcs8::{DecodePrivateKey, EncodePrivateKey};
+use signature::Signer;
+
+/// ECDSA/P-384 key ring.
+#[derive(Debug, Default)]
+pub struct KeyRing {
+    keys: Map<VerifyingKey, SigningKey>,
+}
+
+impl KeyRing {
+    /// Create new ECDSA/NIST P-384 keyring.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Get the [`SigningKey`] that corresponds to the provided [`VerifyingKey`]
+    /// (i.e. public key)
+    pub fn get(&self, verifying_key: &VerifyingKey) -> Option<&SigningKey> {
+        self.keys.get(verifying_key)
+    }
+
+    /// Iterate over the keys in the keyring.
+    pub fn iter(&self) -> impl Iterator<Item = &SigningKey> {
+        self.keys.values()
+    }
+}
+
+impl LoadPkcs8 for KeyRing {
+    fn load_pkcs8(&mut self, private_key: pkcs8::PrivateKeyInfo<'_>) -> Result<KeyHandle> {
+        let signing_key = SigningKey::try_from(private_key)?;
+        let verifying_key = signing_key.verifying_key();
+
+        if self.keys.contains_key(&verifying_key) {
+            return Err(Error::DuplicateKey);
+        }
+
+        self.keys.insert(verifying_key, signing_key);
+        Ok(KeyHandle::EcdsaNistP384(verifying_key))
+    }
+}
+
+/// ECDSA/NIST P-384 signing key.
+pub struct SigningKey {
+    inner: Box<dyn NistP384Signer + Send + Sync>,
+}
+
+impl SigningKey {
+    /// Initialize from a provided signer object.
+    ///
+    /// Use [`SigningKey::from_bytes`] to initialize from a raw private key.
+    pub fn new(signer: Box<dyn NistP384Signer + Send + Sync>) -> Self {
+        Self { inner: signer }
+    }
+
+    /// Initialize from a raw scalar value (big endian).
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
+        let signing_key = p384::ecdsa::SigningKey::from_bytes(bytes)?;
+        Ok(Self::new(Box::new(signing_key)))
+    }
+
+    /// Get the verifying key that corresponds to this signing key.
+    pub fn verifying_key(&self) -> VerifyingKey {
+        self.inner.verifying_key()
+    }
+}
+
+impl DecodePrivateKey for SigningKey {}
+
+impl TryFrom<pkcs8::PrivateKeyInfo<'_>> for SigningKey {
+    type Error = pkcs8::Error;
+
+    fn try_from(private_key_info: pkcs8::PrivateKeyInfo<'_>) -> pkcs8::Result<Self> {
+        p384::ecdsa::SigningKey::try_from(private_key_info).map(|key| Self::new(Box::new(key)))
+    }
+}
+
+impl TryFrom<&[u8]> for SigningKey {
+    type Error = Error;
+
+    fn try_from(bytes: &[u8]) -> Result<Self> {
+        Self::from_bytes(bytes)
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl GeneratePkcs8 for SigningKey {
+    /// Randomly generate a new PKCS#8 private key.
+    fn generate_pkcs8() -> pkcs8::SecretDocument {
+        p384::SecretKey::random(&mut rand_core::OsRng)
+            .to_pkcs8_der()
+            .expect("DER error")
+    }
+}
+
+impl Signer<Signature> for SigningKey {
+    fn try_sign(&self, msg: &[u8]) -> signature::Result<Signature> {
+        self.inner.try_sign(msg)
+    }
+}
+
+impl fmt::Debug for SigningKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SigningKey")
+            .field("verifying_key", &self.verifying_key())
+            .finish()
+    }
+}
+
+/// ECDSA/NIST P-384 signer.
+pub trait NistP384Signer: Signer<Signature> {
+    /// Get the ECDSA verifying key for this signer
+    fn verifying_key(&self) -> VerifyingKey;
+}
+
+impl<T> NistP384Signer for T
+where
+    T: Signer<Signature>,
+    VerifyingKey: for<'a> From<&'a T>,
+{
+    fn verifying_key(&self) -> VerifyingKey {
+        self.into()
+    }
+}

--- a/signatory/src/key/handle.rs
+++ b/signatory/src/key/handle.rs
@@ -18,6 +18,11 @@ pub enum KeyHandle {
     #[cfg_attr(docsrs, doc(cfg(feature = "nistp256")))]
     EcdsaNistP256(ecdsa::nistp256::VerifyingKey),
 
+    /// ECDSA/P-384.
+    #[cfg(feature = "nistp384")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "nistp384")))]
+    EcdsaNistP384(ecdsa::nistp384::VerifyingKey),
+
     /// ECDSA/secp256k1.
     #[cfg(feature = "secp256k1")]
     #[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
@@ -36,6 +41,17 @@ impl KeyHandle {
     pub fn ecdsa_nistp256(&self) -> Option<ecdsa::nistp256::VerifyingKey> {
         match self {
             KeyHandle::EcdsaNistP256(pk) => Some(*pk),
+            #[allow(unreachable_patterns)]
+            _ => None,
+        }
+    }
+
+    /// Get ECDSA/P-384 verifying key, if this is an ECDSA/P-384 key.
+    #[cfg(feature = "nistp384")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "nistp384")))]
+    pub fn ecdsa_nistp384(&self) -> Option<ecdsa::nistp384::VerifyingKey> {
+        match self {
+            KeyHandle::EcdsaNistP384(pk) => Some(*pk),
             #[allow(unreachable_patterns)]
             _ => None,
         }


### PR DESCRIPTION
Adds a `nistp384` crate feature which provides feature-gated support for ECDSA signatures using NIST's P-384 elliptic curve.