### PR TITLE
signatory v0.26.0

### DIFF
--- a/signatory/CHANGELOG.md
+++ b/signatory/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.26.0 (2022-08-19)
+### Added
+- `Send + Sync` bounds to inner `Box` for signer types ([#1037])
+- ECDSA/P-384 support ([#1039])
+
+[#1037]: https://github.com/iqlusioninc/crates/pull/1037
+[#1039]: https://github.com/iqlusioninc/crates/pull/1039
+
 ## 0.25.0 (2022-05-17)
 ### Changed
 - Bump `ecdsa` to v0.14 ([#994])

--- a/signatory/Cargo.toml
+++ b/signatory/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "signatory"
 description  = "Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support"
-version      = "0.25.0"
+version      = "0.26.0"
 license      = "Apache-2.0 OR MIT"
 authors      = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage     = "https://github.com/iqlusioninc/crates"


### PR DESCRIPTION
### Added
- `Send + Sync` bounds to inner `Box` for signer types ([#1037])
- ECDSA/P-384 support ([#1039])

[#1037]: https://github.com/iqlusioninc/crates/pull/1037
[#1039]: https://github.com/iqlusioninc/crates/pull/1039