### PR TITLE
Implement Zeroize for Secret

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -13,6 +13,7 @@ contributions under the terms of the [Apache License, Version 2.0]
 * Armin Ronacher ([@mitsuhiko](https://github.com/mitsuhiko))
 * Boats ([@withoutboats](https://github.com/withoutboats))
 * David Tolnay ([@dtolnay](https://github.com/dtolnay))
+* Eric Holk ([@eholk](https://github.com/eholk))
 * Kai Ren ([@tyranron](https://github.com/tyranron))
 * Murarth ([@murarth](https://github.com/murarth))
 * Niclas Schwarzlose ([@aticu](https://github.com/aticu))

--- a/secrecy/src/lib.rs
+++ b/secrecy/src/lib.rs
@@ -177,6 +177,15 @@ where
 {
     fn drop(&mut self) {
         // Zero the secret out from memory
+        self.zeroize();
+    }
+}
+
+impl<S> Zeroize for Secret<S>
+where
+    S: Zeroize,
+{
+    fn zeroize(&mut self) {
         self.inner_secret.zeroize();
     }
 }
@@ -281,5 +290,20 @@ where
         S: ser::Serializer,
     {
         self.expose_secret().serialize(serializer)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use zeroize::Zeroize;
+
+    use crate::{ExposeSecret, Secret};
+
+    #[test]
+    fn zeroize_secret() {
+        // Make sure we can explicitly zero out a secret
+        let mut x = Secret::new(42);
+        x.zeroize();
+        assert_eq!(*x.expose_secret(), 0);
     }
 }


### PR DESCRIPTION
Although Secret will zeroize when it is dropped or goes out of scope, sometimes we may want to be able to clear the secret sooner if we know it is no longer needed. Implementing Zeroize lets us explicitly call zeroize on Secrets.