### PR TITLE
Upgrade elliptic curve crates; MSRV 1.65

### DIFF
--- a/.github/workflows/bip32.yml
+++ b/.github/workflows/bip32.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.57.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - armv7a-none-eabi
@@ -50,7 +50,7 @@ jobs:
           - macos-latest
           - windows-latest
         toolchain:
-          - 1.57.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/canonical-path.yml
+++ b/.github/workflows/canonical-path.yml
@@ -25,7 +25,7 @@ jobs:
           - macos-latest
           - windows-latest
         toolchain:
-          - 1.56.0 # MSRV
+          - 1.60.0 # MSRV
           - stable
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/hkd32.yml
+++ b/.github/workflows/hkd32.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.57.0 # MSRV
+          - 1.60.0 # MSRV
           - stable
         target:
           - armv7a-none-eabi
@@ -49,7 +49,7 @@ jobs:
           - macos-latest
           - windows-latest
         toolchain:
-          - 1.57.0 # MSRV
+          - 1.60.0 # MSRV
           - stable
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/iqhttp.yml
+++ b/.github/workflows/iqhttp.yml
@@ -25,7 +25,7 @@ jobs:
           - macos-latest
           - windows-latest
         toolchain:
-          - 1.56.0 # MSRV
+          - 1.60.0 # MSRV
           - stable
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/secrecy.yml
+++ b/.github/workflows/secrecy.yml
@@ -25,7 +25,7 @@ jobs:
           - macos-latest
           - windows-latest
         toolchain:
-          - 1.56.0 # MSRV
+          - 1.60.0 # MSRV
           - stable
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/signatory.yml
+++ b/.github/workflows/signatory.yml
@@ -24,7 +24,7 @@ jobs:
           - macos-latest
           - windows-latest
         toolchain:
-          - 1.57.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/subtle-encoding.yml
+++ b/.github/workflows/subtle-encoding.yml
@@ -25,7 +25,7 @@ jobs:
           - macos-latest
           - windows-latest
         toolchain:
-          - 1.56.0 # MSRV
+          - 1.60.0 # MSRV
           - stable
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.57.0 # MSRV
+          toolchain: 1.68.0 # MSRV
           components: clippy
           override: true
           profile: minimal

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base16ct"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
@@ -28,7 +28,7 @@ checksum = "3bdca834647821e0b13d9539a8634eb62d3501b6b6c2cec1722786ee6671b851"
 
 [[package]]
 name = "bip32"
-version = "0.4.0"
+version = "0.5.0-pre"
 dependencies = [
  "bs58",
  "hex-literal",
@@ -36,7 +36,7 @@ dependencies = [
  "k256",
  "once_cell",
  "pbkdf2",
- "rand_core 0.6.3",
+ "rand_core",
  "ripemd",
  "secp256k1",
  "sha2 0.10.2",
@@ -84,12 +84,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 
 [[package]]
-name = "byteorder"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
-
-[[package]]
 name = "bytes"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,7 +91,7 @@ checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
 name = "canonical-path"
-version = "2.0.2"
+version = "2.1.0-pre"
 dependencies = [
  "tempfile",
 ]
@@ -116,9 +110,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "const-oid"
-version = "0.9.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722e23542a15cea1f65d4a1419c4cfd7a26706c70871a13a04238ca3f40f1661"
+checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
 
 [[package]]
 name = "core-foundation"
@@ -147,12 +141,12 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.8"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f2b443d17d49dad5ef0ede301c3179cc923b8822f3393b4d2c28c269dd4a122"
+checksum = "071c0f5945634bc9ba7a452f492377dd6b1993665ddb58f28704119b32f07a9a"
 dependencies = [
  "generic-array",
- "rand_core 0.6.3",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -178,22 +172,23 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.0"
+version = "4.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
+checksum = "8d4ba9852b42210c7538b75484f9daa0655e9a3ac04f693747bb0f02cf3cfe16"
 dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core 0.5.1",
+ "cfg-if",
+ "digest 0.10.6",
+ "fiat-crypto",
+ "packed_simd_2",
+ "platforms",
  "subtle",
- "zeroize",
 ]
 
 [[package]]
 name = "der"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dd2ae565c0a381dde7fade45fce95984c568bdcb4700a4fdbe3175e0380b2f"
+checksum = "bc906908ea6458456e5eaa160a9c08543ec3d1e6f71e2235cedd660cb65f9df0"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -211,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.3"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer 0.10.2",
  "crypto-common",
@@ -222,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.14.7"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85789ce7dfbd0f0624c07ef653a08bb2ebf43d3e16531361f46d36dd54334fed"
+checksum = "d1b0a1222f8072619e8a6b667a854020a03d363738303203c09468b3424a420a"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -234,42 +229,40 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.5.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
+checksum = "be522bee13fa6d8059f4903a4084aa3bd50725e18150202f0238deb615cd6371"
 dependencies = [
  "signature",
 ]
 
 [[package]]
 name = "ed25519-dalek"
-version = "1.0.1"
+version = "2.0.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+checksum = "7bd577ba9d4bcab443cac60003d8fd32c638e7024a3ec92c200d7af5d2c397ed"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "sha2 0.9.9",
- "zeroize",
+ "sha2 0.10.2",
 ]
 
 [[package]]
 name = "elliptic-curve"
-version = "0.12.3"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+checksum = "6ea5a92946e8614bb585254898bb7dd1ddad241ace60c52149e3765e34cc039d"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "der",
- "digest 0.10.3",
+ "digest 0.10.6",
  "ff",
  "generic-array",
  "group",
  "hkdf",
  "pem-rfc7468",
  "pkcs8",
- "rand_core 0.6.3",
+ "rand_core",
  "sec1",
  "subtle",
  "zeroize",
@@ -286,13 +279,19 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df689201f395c6b90dfe87127685f8dbfc083a5e779e613575d8bd7314300c3e"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core 0.6.3",
+ "rand_core",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93ace6ec7cc19c8ed33a32eaa9ea692d7faea05006b5356b9e2b668ec4bc3955"
 
 [[package]]
 name = "fnv"
@@ -412,6 +411,7 @@ checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -427,12 +427,12 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7391856def869c1c81063a03457c676fbcd419709c3dfb33d8d319de484b154d"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core 0.6.3",
+ "rand_core",
  "subtle",
 ]
 
@@ -469,13 +469,13 @@ checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
 name = "hkd32"
-version = "0.7.0"
+version = "0.8.0-pre"
 dependencies = [
  "hex-literal",
  "hmac",
  "once_cell",
  "pbkdf2",
- "rand_core 0.6.3",
+ "rand_core",
  "sha2 0.10.2",
  "subtle-encoding",
  "zeroize",
@@ -496,7 +496,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.3",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "iqhttp"
-version = "0.2.0"
+version = "0.3.0-pre"
 dependencies = [
  "hyper",
  "hyper-proxy",
@@ -641,22 +641,17 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.11.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3636d281d46c3b64182eb3a0a42b7b483191a2ecc3f05301fa67403f7c9bc949"
+checksum = "955890845095ccf31ef83ad41a05aabb4d8cc23dc3cac5a9f5c89cf26dd0da75"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
+ "once_cell",
  "sha2 0.10.2",
- "sha3",
+ "signature",
 ]
-
-[[package]]
-name = "keccak"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
 
 [[package]]
 name = "lazy_static"
@@ -669,6 +664,12 @@ name = "libc"
 version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+
+[[package]]
+name = "libm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
 
 [[package]]
 name = "log"
@@ -723,9 +724,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.1"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "opaque-debug"
@@ -780,40 +781,53 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.11.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
+checksum = "7270da3e5caa82afd3deb054cc237905853813aea3859544bc082c3fe55b8d47"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "primeorder",
  "sha2 0.10.2",
 ]
 
 [[package]]
 name = "p384"
-version = "0.11.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc8c5bf642dde52bb9e87c0ecd8ca5a76faac2eeed98dedb7c717997e1080aa"
+checksum = "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "primeorder",
  "sha2 0.10.2",
 ]
 
 [[package]]
-name = "pbkdf2"
-version = "0.11.0"
+name = "packed_simd_2"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
 dependencies = [
- "digest 0.10.3",
+ "cfg-if",
+ "libm",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0ca0b5a68607598bf3bad68f32227a8164f6254833f84eafaac409cd6746c31"
+dependencies = [
+ "digest 0.10.6",
+ "hmac",
 ]
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d159833a9105500e0398934e205e0773f0b27529557134ecfc51c27646adac"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
 dependencies = [
  "base64ct",
 ]
@@ -832,9 +846,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+checksum = "3d2820d87d2b008616e5c27212dd9e0e694fb4c6b522de06094106813328cb49"
 dependencies = [
  "der",
  "spki",
@@ -845,6 +859,21 @@ name = "pkg-config"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+
+[[package]]
+name = "platforms"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d7ddaed09e0eb771a79ab0fd64609ba0afb0a8366421957936ad14cbd13630"
+
+[[package]]
+name = "primeorder"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7613fdcc0831c10060fa69833ea8fa2caa94b6456f51e25356a885b530a2e3d0"
+dependencies = [
+ "elliptic-curve",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -866,15 +895,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.5.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-
-[[package]]
-name = "rand_core"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
@@ -899,13 +922,12 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c86280f057430a52f4861551b092a01b419b8eacefc7c995eacb9dc132fe32"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "crypto-bigint",
  "hmac",
- "zeroize",
+ "subtle",
 ]
 
 [[package]]
@@ -929,7 +951,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1facec54cb5e0dc08553501fa740091086d0259ad0067e0d4103448e4cb22ed3"
 dependencies = [
- "digest 0.10.3",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -985,9 +1007,9 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.3.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+checksum = "48518a2b5775ba8ca5b46596aae011caa431e6ce7e4a67ead66d92f08884220e"
 dependencies = [
  "base16ct",
  "der",
@@ -999,25 +1021,25 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.21.3"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c42e6f1735c5f00f51e43e28d6634141f2bcad10931b2609ddd74a86d751260"
+checksum = "4124a35fe33ae14259c490fd70fa199a32b9ce9502f2ee6bc4f81ec06fa65894"
 dependencies = [
  "secp256k1-sys",
 ]
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.4.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957da2573cde917463ece3570eab4a0b3f19de6f1646cde62e6fd3868f566036"
+checksum = "642a62736682fdd8c71da0eb273e453c8ac74e33b9fb310e22ba5b03ec7651ff"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "secrecy"
-version = "0.8.0"
+version = "0.9.0-pre"
 dependencies = [
  "bytes",
  "serde",
@@ -1072,7 +1094,7 @@ checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.3",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -1096,17 +1118,7 @@ checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.3",
-]
-
-[[package]]
-name = "sha3"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a31480366ec990f395a61b7c08122d99bd40544fdb5abcfc1b06bb29994312c"
-dependencies = [
- "digest 0.10.3",
- "keccak",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -1119,7 +1131,7 @@ dependencies = [
  "p256",
  "p384",
  "pkcs8",
- "rand_core 0.6.3",
+ "rand_core",
  "signature",
  "tempfile",
  "zeroize",
@@ -1127,12 +1139,12 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb766570a2825fa972bceff0d195727876a9cdf2460ab2e52d455dc2de47fd9"
+checksum = "8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d"
 dependencies = [
- "digest 0.10.3",
- "rand_core 0.6.3",
+ "digest 0.10.6",
+ "rand_core",
 ]
 
 [[package]]
@@ -1162,9 +1174,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spki"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+checksum = "c0445c905640145c7ea8c1993555957f65e7c46d0535b91ba501bc9bfc85522f"
 dependencies = [
  "base64ct",
  "der",
@@ -1178,7 +1190,7 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "subtle-encoding"
-version = "0.5.1"
+version = "0.6.0-pre"
 dependencies = [
  "zeroize",
 ]

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ This repository contains the following crates:
 |-------------------|----------------------------|----------------------------|----------------------------------------|
 | [bip32]           | ![][bip32-crate]           | ![][bip32-build]           | Hierarchical key derivation            |
 | [canonical‑path]  | ![][canonical-path-crate]  | ![][canonical-path-build]  | Canonical filesystem path support      |
-| [datadog]         | ![][datadog-crate]         | ![][datadog-build]         | Datadog client library                 |
 | [hkd32]           | ![][hkd32-crate]           | ![][hkd32-build]           | HMAC-based Hierarchical Key Derivation |
 | [secrecy]         | ![][secrecy-crate]         | ![][secrecy-build]         | Simple secret-keeping library          |
 | [signatory]       | ![][signatory-crate]       | ![][signatory-build]       | Signature library with ECDSA+Ed25519   |
@@ -66,8 +65,6 @@ without any additional terms or conditions.
 [bip32-crate]: https://img.shields.io/crates/v/bip32.svg
 [canonical‑path]: https://github.com/iqlusioninc/crates/tree/main/canonical-path
 [canonical-path-crate]: https://img.shields.io/crates/v/canonical-path.svg
-[datadog]: https://github.com/iqlusioninc/crates/tree/main/datadog
-[datadog-crate]: https://img.shields.io/crates/v/datadog.svg
 [hkd32]: https://github.com/iqlusioninc/crates/tree/main/hkd32
 [hkd32-crate]: https://img.shields.io/crates/v/hkd32.svg
 [secrecy]: https://github.com/iqlusioninc/crates/tree/main/secrecy
@@ -81,7 +78,6 @@ without any additional terms or conditions.
 
 [bip32-build]: https://github.com/iqlusioninc/crates/actions/workflows/bip32.yml/badge.svg
 [canonical-path-build]: https://github.com/iqlusioninc/crates/actions/workflows/canonical-path.yml/badge.svg
-[datadog-build]: https://github.com/iqlusioninc/crates/actions/workflows/datadog.yml/badge.svg
 [hkd32-build]: https://github.com/iqlusioninc/crates/actions/workflows/hkd32.yml/badge.svg
 [secrecy-build]: https://github.com/iqlusioninc/crates/actions/workflows/secrecy.yml/badge.svg
 [signatory-build]: https://github.com/iqlusioninc/crates/actions/workflows/signatory.yml/badge.svg

--- a/bip32/Cargo.toml
+++ b/bip32/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bip32"
-version = "0.4.0"
+version = "0.5.0-pre"
 description = """
 BIP32 hierarchical key derivation implemented in a generic, no_std-friendly
 manner. Supports deriving keys using the pure Rust k256 crate or the
@@ -14,7 +14,7 @@ categories = ["cryptography", "no-std"]
 keywords = ["crypto", "bip32", "bip39", "derivation", "mnemonic"]
 readme = "README.md"
 edition  = "2021"
-rust-version = "1.57"
+rust-version = "1.65"
 
 [dependencies]
 bs58 = { version = "0.4", default-features = false, features = ["check"] }
@@ -26,10 +26,10 @@ subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }
 
 # optional dependencies
-k256 = { version = "0.11", optional = true, default-features = false, features = ["ecdsa", "sha256", "keccak256"] }
+k256 = { version = "0.13", optional = true, default-features = false, features = ["ecdsa", "sha256"] }
 once_cell = { version = "1", optional = true }
-pbkdf2 = { version = "0.11", optional = true, default-features = false }
-secp256k1-ffi = { package = "secp256k1", version = "0.21", optional = true }
+pbkdf2 = { version = "0.12", optional = true, default-features = false, features = ["hmac"] }
+secp256k1-ffi = { package = "secp256k1", version = "0.26", optional = true }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/bip32/README.md
+++ b/bip32/README.md
@@ -24,7 +24,7 @@ from a set of 24-words from a preset list, a.k.a. a "mnemonic".
 
 ## Minimum Supported Rust Version
 
-Rust **1.57** or newer.
+Rust **1.65** or newer.
 
 In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
 for this crate's SemVer guarantees), however when we do it will be accompanied by
@@ -32,7 +32,7 @@ a minor version bump.
 
 ## License
 
-Copyright © 2020-2022 iqlusion
+Copyright © 2020-2023 iqlusion
 
 **bip32.rs** is distributed under the terms of either the MIT license
 or the Apache License (Version 2.0), at your option.
@@ -54,7 +54,7 @@ without any additional terms or conditions.
 [docs-link]: https://docs.rs/bip32/
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/crates/blob/main/LICENSE
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
 [build-image]: https://github.com/iqlusioninc/crates/actions/workflows/bip32.yml/badge.svg

--- a/bip32/src/error.rs
+++ b/bip32/src/error.rs
@@ -96,3 +96,11 @@ impl From<secp256k1_ffi::Error> for Error {
         Error::Crypto
     }
 }
+
+#[cfg(feature = "secp256k1-ffi")]
+#[cfg_attr(docsrs, doc(cfg(feature = "secp256k1-ffi")))]
+impl From<secp256k1_ffi::scalar::OutOfRangeError> for Error {
+    fn from(_: secp256k1_ffi::scalar::OutOfRangeError) -> Error {
+        Error::Crypto
+    }
+}

--- a/bip32/src/mnemonic/language.rs
+++ b/bip32/src/mnemonic/language.rs
@@ -11,9 +11,10 @@ use alloc::{collections::BTreeMap, vec::Vec};
 /// Supported languages.
 ///
 /// Presently only English is specified by the BIP39 standard
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 pub enum Language {
     /// English is presently the only supported language
+    #[default]
     English,
 }
 
@@ -30,12 +31,6 @@ impl Language {
         match *self {
             Language::English => &lazy::WORDMAP_ENGLISH,
         }
-    }
-}
-
-impl Default for Language {
-    fn default() -> Language {
-        Language::English
     }
 }
 

--- a/bip32/src/mnemonic/phrase.rs
+++ b/bip32/src/mnemonic/phrase.rs
@@ -11,7 +11,7 @@ use sha2::{Digest, Sha256};
 use zeroize::{Zeroize, Zeroizing};
 
 #[cfg(feature = "bip39")]
-use {super::seed::Seed, hmac::Hmac, sha2::Sha512};
+use {super::seed::Seed, sha2::Sha512};
 
 /// Number of PBKDF2 rounds to perform when deriving the seed
 #[cfg(feature = "bip39")]
@@ -135,7 +135,7 @@ impl Phrase {
     pub fn to_seed(&self, password: &str) -> Seed {
         let salt = Zeroizing::new(format!("mnemonic{}", password));
         let mut seed = [0u8; Seed::SIZE];
-        pbkdf2::pbkdf2::<Hmac<Sha512>>(
+        pbkdf2::pbkdf2_hmac::<Sha512>(
             self.phrase.as_bytes(),
             salt.as_bytes(),
             PBKDF2_ROUNDS,

--- a/bip32/src/prefix.rs
+++ b/bip32/src/prefix.rs
@@ -128,7 +128,7 @@ impl Prefix {
         let mut i = 0;
 
         while i < Self::LENGTH {
-            if matches!(s.as_bytes()[i], b'a'..=b'z' | b'A'..=b'Z') {
+            if s.as_bytes()[i].is_ascii_alphabetic() {
                 i += 1;
             } else {
                 return Err(Error::Decode);

--- a/bip32/tests/bip32_vectors.rs
+++ b/bip32/tests/bip32_vectors.rs
@@ -15,7 +15,7 @@ use hex_literal::hex;
 ///
 /// Panics if anything goes wrong.
 fn derive_xprv(seed: &[u8], path: &str) -> XPrv {
-    XPrv::derive_from_path(&seed, &path.parse().unwrap()).unwrap()
+    XPrv::derive_from_path(seed, &path.parse().unwrap()).unwrap()
 }
 
 /// BIP32 Test Vector 1
@@ -26,7 +26,7 @@ fn test_vector_1() {
 
     // Chain m
     let key_m = derive_xprv(&seed, "m");
-    assert_eq!(key_m, XPrv::new(&seed).unwrap());
+    assert_eq!(key_m, XPrv::new(seed).unwrap());
     assert_eq!(
         &*key_m.to_string(Prefix::XPRV),
         "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi"
@@ -108,7 +108,7 @@ fn test_vector_2() {
 
     // Chain m
     let key_m = derive_xprv(&seed, "m");
-    assert_eq!(key_m, XPrv::new(&seed).unwrap());
+    assert_eq!(key_m, XPrv::new(seed).unwrap());
     assert_eq!(
         &*key_m.to_string(Prefix::XPRV),
         "xprv9s21ZrQH143K31xYSDQpPDxsXRTUcvj2iNHm5NUtrGiGG5e2DtALGdso3pGz6ssrdK4PFmM8NSpSBHNqPqm55Qn3LqFtT2emdEXVYsCzC2U"
@@ -194,7 +194,7 @@ fn test_vector_3() {
 
     // Chain m
     let key_m = derive_xprv(&seed, "m");
-    assert_eq!(key_m, XPrv::new(&seed).unwrap());
+    assert_eq!(key_m, XPrv::new(seed).unwrap());
     assert_eq!(
         &*key_m.to_string(Prefix::XPRV),
         "xprv9s21ZrQH143K25QhxbucbDDuQ4naNntJRi4KUfWT7xo4EKsHt2QJDu7KXp1A3u7Bi1j8ph3EGsZ9Xvz9dGuVrtHHs7pXeTzjuxBrCmmhgC6"
@@ -227,7 +227,7 @@ fn test_vector_4() {
 
     // Chain m
     let key_m = derive_xprv(&seed, "m");
-    assert_eq!(key_m, XPrv::new(&seed).unwrap());
+    assert_eq!(key_m, XPrv::new(seed).unwrap());
     assert_eq!(
         &*key_m.to_string(Prefix::XPRV),
         "xprv9s21ZrQH143K48vGoLGRPxgo2JNkJ3J3fqkirQC2zVdk5Dgd5w14S7fRDyHH4dWNHUgkvsvNDCkvAwcSHNAQwhwgNMgZhLtQC63zxwhQmRv"

--- a/canonical-path/Cargo.toml
+++ b/canonical-path/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "canonical-path"
 description = "Path and PathBuf-like types for representing canonical filesystem paths"
-version     = "2.0.2" # Also update html_root_url in lib.rs when bumping this
+version     = "2.1.0-pre"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0"
 homepage    = "https://github.com/iqlusioninc/crates/"
@@ -10,7 +10,7 @@ readme      = "README.md"
 categories  = ["filesystem"]
 keywords    = ["filesystem", "path", "canonicalization"]
 edition     = "2021"
-rust-version = "1.56"
+rust-version = "1.60"
 
 [badges]
 maintenance = { status = "passively-maintained" }

--- a/canonical-path/README.md
+++ b/canonical-path/README.md
@@ -17,7 +17,7 @@ are canonical, or at least, were canonical at the time they were created.
 
 ## Minimum Supported Rust Version
 
-Rust **1.56** or newer.
+Rust **1.60** or newer.
 
 In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
 for this crate's SemVer guarantees), however when we do it will be accompanied by
@@ -25,7 +25,7 @@ a minor version bump.
 
 ## License
 
-Copyright © 2018-2021 iqlusion
+Copyright © 2018-2023 iqlusion
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -53,6 +53,6 @@ without any additional terms or conditions.
 [docs-link]: https://docs.rs/canonical-path/
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/crates/blob/main/LICENSE
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
 [build-image]: https://github.com/iqlusioninc/crates/actions/workflows/canonical-path.yml/badge.svg
 [build-link]: https://github.com/iqlusioninc/crates/actions/workflows/canonical-path.yml

--- a/canonical-path/src/lib.rs
+++ b/canonical-path/src/lib.rs
@@ -10,7 +10,6 @@
     unused_lifetimes,
     unused_qualifications
 )]
-#![doc(html_root_url = "https://docs.rs/canonical-path/2.0.2")]
 
 use std::{
     borrow::Borrow,
@@ -416,7 +415,7 @@ mod tests {
     #[test]
     fn reject_canonical_path_buf_symlinks() {
         let test_fixtures = TestFixtureDir::new();
-        let result = CanonicalPathBuf::new(&test_fixtures.symlink_path);
+        let result = CanonicalPathBuf::new(test_fixtures.symlink_path);
         assert!(result.is_err(), "symlinks aren't canonical paths!");
     }
 }

--- a/hkd32/Cargo.toml
+++ b/hkd32/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name        = "hkd32"
+version     = "0.8.0-pre"
 description = """
 HMAC-based Hierarchical Key Derivation: deterministically derive
 a hierarchy of symmetric keys from initial keying material through
@@ -7,7 +8,6 @@ repeated applications of the Hash-based Message Authentication Code
 (HMAC) construction. Optionally supports storing root derivation
 passwords as a 24-word mnemonic phrase (i.e. BIP39).
 """
-version    = "0.7.0"
 authors    = ["Tony Arcieri <tony@iqlusion.io>"]
 license    = "Apache-2.0 OR MIT"
 homepage   = "https://github.com/iqlusioninc/crates/"
@@ -16,7 +16,7 @@ readme     = "README.md"
 categories = ["cryptography", "no-std"]
 keywords   = ["crypto", "bip32", "bip39", "derivation", "mnemonic"]
 edition     = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [dependencies]
 hmac = { version = "0.12", default-features = false }
@@ -26,8 +26,8 @@ zeroize = { version = "1", default-features = false, features = ["zeroize_derive
 
 # optional dependencies
 once_cell = { version = "1", optional = true }
-pbkdf2 = { version = "0.11", optional = true, default-features = false }
-subtle-encoding = { version = "0.5", optional = true, default-features = false, path = "../subtle-encoding" }
+pbkdf2 = { version = "0.12", optional = true, default-features = false, features = ["hmac"] }
+subtle-encoding = { version = "=0.6.0-pre", optional = true, default-features = false, path = "../subtle-encoding" }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/hkd32/README.md
+++ b/hkd32/README.md
@@ -22,11 +22,11 @@ an initial 32-bytes of input key material.
 
 ## Minimum Supported Rust Version
 
-- Rust **1.57**
+- Rust **1.60**
 
 ## License
 
-Copyright © 2019-2021 iqlusion
+Copyright © 2019-2023 iqlusion
 
 Includes code from the `bip39` crate. Copyright © 2017-2018 Stephen Oliver,
 with contributions by Maciej Hirsz.

--- a/hkd32/src/mnemonic/phrase.rs
+++ b/hkd32/src/mnemonic/phrase.rs
@@ -11,7 +11,7 @@ use sha2::{Digest, Sha256};
 use zeroize::{Zeroize, Zeroizing};
 
 #[cfg(feature = "bip39")]
-use {super::seed::Seed, hmac::Hmac, sha2::Sha512};
+use {super::seed::Seed, sha2::Sha512};
 
 /// Number of PBKDF2 rounds to perform when deriving the seed
 #[cfg(feature = "bip39")]
@@ -146,7 +146,7 @@ impl Phrase {
     pub fn to_seed(&self, password: &str) -> Seed {
         let salt = Zeroizing::new(format!("mnemonic{}", password));
         let mut seed = [0u8; Seed::SIZE];
-        pbkdf2::pbkdf2::<Hmac<Sha512>>(
+        pbkdf2::pbkdf2_hmac::<Sha512>(
             self.phrase.as_bytes(),
             salt.as_bytes(),
             PBKDF2_ROUNDS,

--- a/iqhttp/Cargo.toml
+++ b/iqhttp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "iqhttp"
-version = "0.2.0"
+version = "0.3.0-pre"
 description = """
 iqlusion's HTTPS toolkit. Provides a high-level wrapper around hyper, with
 built-in SSL/TLS support based on rustls.
@@ -13,7 +13,7 @@ categories   = ["network-programming", "web-programming::http-client"]
 keywords     = ["api", "client", "http", "rest", "web"]
 readme       = "README.md"
 edition      = "2021"
-rust-version = "1.56"
+rust-version = "1.60"
 
 [dependencies]
 hyper = "0.14.10"

--- a/iqhttp/README.md
+++ b/iqhttp/README.md
@@ -13,7 +13,7 @@ built-in SSL/TLS support based on [`rustls`].
 
 ## Minimum Supported Rust Version
 
-Rust **1.56**
+Rust **1.60**
 
 ## License
 
@@ -41,7 +41,7 @@ without any additional terms or conditions.
 [build-link]: https://github.com/iqlusioninc/crates/actions/workflows/iqhttp.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [license-link]: https://github.com/iqlusioninc/crates/blob/main/LICENSE
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
 
 [//]: # (general links)
 

--- a/secrecy/Cargo.toml
+++ b/secrecy/Cargo.toml
@@ -6,7 +6,7 @@ they aren't accidentally copied, logged, or otherwise exposed
 (as much as possible), and also ensure secrets are securely wiped
 from memory when dropped.
 """
-version     = "0.8.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.9.0-pre" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://github.com/iqlusioninc/crates/"
@@ -15,7 +15,7 @@ readme      = "README.md"
 categories  = ["cryptography", "memory-management", "no-std", "os"]
 keywords    = ["clear", "memory", "secret", "secure", "wipe"]
 edition     = "2021"
-rust-version = "1.56"
+rust-version = "1.60"
 
 [dependencies]
 zeroize = { version = "1.4", default-features = false }

--- a/secrecy/README.md
+++ b/secrecy/README.md
@@ -24,7 +24,7 @@ from memory when dropped.
 
 ## Minimum Supported Rust Version
 
-Rust **1.56** or newer.
+Rust **1.60** or newer.
 
 In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
 for this crate's SemVer guarantees), however when we do it will be accompanied by
@@ -45,7 +45,7 @@ possible.
 
 ## License
 
-Copyright © 2019-2021 iqlusion
+Copyright © 2019-2023 iqlusion
 
 **secrecy** is distributed under the terms of either the MIT license
 or the Apache License (Version 2.0), at your option.
@@ -66,7 +66,7 @@ without any additional terms or conditions.
 [docs-image]: https://docs.rs/secrecy/badge.svg
 [docs-link]: https://docs.rs/secrecy/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
 [build-image]: https://github.com/iqlusioninc/crates/actions/workflows/secrecy.yml/badge.svg

--- a/signatory/Cargo.toml
+++ b/signatory/Cargo.toml
@@ -10,20 +10,20 @@ readme       = "README.md"
 categories   = ["authentication", "cryptography"]
 keywords     = ["cryptography", "ecdsa", "ed25519", "signing", "signatures"]
 edition      = "2021"
-rust-version = "1.57"
+rust-version = "1.65"
 
 [dependencies]
-pkcs8 = { version = "0.9", features = ["alloc", "pem"] }
+pkcs8 = { version = "0.10", features = ["alloc", "pem"] }
 rand_core = "0.6"
-signature = "1.6"
+signature = "2"
 zeroize = "1.4"
 
 # optional dependencies
-ecdsa = { version = "0.14", optional = true, features = ["pem", "pkcs8"] }
-ed25519-dalek = { version = "1", optional = true, default-features = false, features = ["u64_backend"] }
-k256 = { version = "0.11", optional = true, features = ["ecdsa", "sha256", "keccak256"] }
-p256 = { version = "0.11", optional = true, features = ["ecdsa", "sha256"] }
-p384 = { version = "0.11", optional = true, features = ["ecdsa", "sha384"] }
+ecdsa = { version = "0.16", optional = true, features = ["pem", "pkcs8"] }
+ed25519-dalek = { version = "2.0.0-pre.0", optional = true, default-features = false }
+k256 = { version = "0.13", optional = true, features = ["ecdsa", "sha256"] }
+p256 = { version = "0.13", optional = true, features = ["ecdsa", "sha256"] }
+p384 = { version = "0.13", optional = true, features = ["ecdsa", "sha384"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/signatory/README.md
+++ b/signatory/README.md
@@ -25,7 +25,7 @@ The following algorithms are supported:
 
 ## Minimum Supported Rust Version
 
-Rust **1.57** or newer.
+Rust **1.65** or newer.
 
 In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
 for this crate's SemVer guarantees), however when we do it will be accompanied by
@@ -52,7 +52,7 @@ without any additional terms or conditions.
 [docs-image]: https://docs.rs/signatory/badge.svg
 [docs-link]: https://docs.rs/signatory/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [build-image]: https://github.com/iqlusioninc/crates/workflows/signatory/badge.svg?branch=main&event=push
 [build-link]: https://github.com/iqlusioninc/crates/actions
 

--- a/signatory/src/algorithm.rs
+++ b/signatory/src/algorithm.rs
@@ -53,11 +53,11 @@ impl Algorithm {
     }
 }
 
-impl TryFrom<pkcs8::AlgorithmIdentifier<'_>> for Algorithm {
+impl TryFrom<pkcs8::AlgorithmIdentifierRef<'_>> for Algorithm {
     type Error = Error;
 
     #[allow(unused_variables)]
-    fn try_from(pkcs8_alg_id: pkcs8::AlgorithmIdentifier<'_>) -> Result<Self> {
+    fn try_from(pkcs8_alg_id: pkcs8::AlgorithmIdentifierRef<'_>) -> Result<Self> {
         #[cfg(feature = "ecdsa")]
         if pkcs8_alg_id.oid == ecdsa::elliptic_curve::ALGORITHM_OID {
             #[cfg(any(feature = "nistp256", feature = "secp256k1"))]

--- a/signatory/src/ecdsa/nistp256.rs
+++ b/signatory/src/ecdsa/nistp256.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use alloc::boxed::Box;
 use core::fmt;
-use pkcs8::{DecodePrivateKey, EncodePrivateKey};
+use pkcs8::EncodePrivateKey;
 use signature::Signer;
 
 /// ECDSA/P-256 key ring.
@@ -64,7 +64,7 @@ impl SigningKey {
 
     /// Initialize from a raw scalar value (big endian).
     pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
-        let signing_key = p256::ecdsa::SigningKey::from_bytes(bytes)?;
+        let signing_key = p256::ecdsa::SigningKey::from_slice(bytes)?;
         Ok(Self::new(Box::new(signing_key)))
     }
 
@@ -73,8 +73,6 @@ impl SigningKey {
         self.inner.verifying_key()
     }
 }
-
-impl DecodePrivateKey for SigningKey {}
 
 impl TryFrom<pkcs8::PrivateKeyInfo<'_>> for SigningKey {
     type Error = pkcs8::Error;

--- a/signatory/src/ecdsa/nistp384.rs
+++ b/signatory/src/ecdsa/nistp384.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use alloc::boxed::Box;
 use core::fmt;
-use pkcs8::{DecodePrivateKey, EncodePrivateKey};
+use pkcs8::EncodePrivateKey;
 use signature::Signer;
 
 /// ECDSA/P-384 key ring.
@@ -64,7 +64,7 @@ impl SigningKey {
 
     /// Initialize from a raw scalar value (big endian).
     pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
-        let signing_key = p384::ecdsa::SigningKey::from_bytes(bytes)?;
+        let signing_key = p384::ecdsa::SigningKey::from_slice(bytes)?;
         Ok(Self::new(Box::new(signing_key)))
     }
 
@@ -73,8 +73,6 @@ impl SigningKey {
         self.inner.verifying_key()
     }
 }
-
-impl DecodePrivateKey for SigningKey {}
 
 impl TryFrom<pkcs8::PrivateKeyInfo<'_>> for SigningKey {
     type Error = pkcs8::Error;

--- a/signatory/src/ed25519.rs
+++ b/signatory/src/ed25519.rs
@@ -16,7 +16,7 @@ pub const ALGORITHM_OID: pkcs8::ObjectIdentifier =
     pkcs8::ObjectIdentifier::new_unwrap("1.3.101.112");
 
 /// Ed25519 Algorithm Identifier.
-pub const ALGORITHM_ID: pkcs8::AlgorithmIdentifier<'static> = pkcs8::AlgorithmIdentifier {
+pub const ALGORITHM_ID: pkcs8::AlgorithmIdentifierRef<'static> = pkcs8::AlgorithmIdentifierRef {
     oid: ALGORITHM_OID,
     parameters: None,
 };

--- a/signatory/src/key/store/fs.rs
+++ b/signatory/src/key/store/fs.rs
@@ -37,10 +37,10 @@ impl FsKeyStore {
     /// Create a filesystem-backed keystore at the given path, making a new
     /// directory and setting its file permissions.
     pub fn create(dir_path: &Path) -> Result<Self> {
-        fs::create_dir_all(&dir_path)?;
+        fs::create_dir_all(dir_path)?;
 
         #[cfg(unix)]
-        fs::set_permissions(&dir_path, Permissions::from_mode(REQUIRED_DIR_MODE))?;
+        fs::set_permissions(dir_path, Permissions::from_mode(REQUIRED_DIR_MODE))?;
 
         Self::open(dir_path)
     }
@@ -101,7 +101,7 @@ impl FsKeyStore {
 
     /// Load a PKCS#8 key from the keystore.
     pub fn load(&self, name: &KeyName) -> Result<pkcs8::SecretDocument> {
-        let (label, doc) = pkcs8::SecretDocument::read_pem_file(&self.key_path(name))?;
+        let (label, doc) = pkcs8::SecretDocument::read_pem_file(self.key_path(name))?;
         pkcs8::PrivateKeyInfo::validate_pem_label(&label)?;
         Ok(doc)
     }
@@ -109,7 +109,7 @@ impl FsKeyStore {
     /// Import a PKCS#8 key into the keystore.
     pub fn store(&self, name: &KeyName, der: &pkcs8::SecretDocument) -> Result<()> {
         der.write_pem_file(
-            &self.key_path(name),
+            self.key_path(name),
             pkcs8::PrivateKeyInfo::PEM_LABEL,
             Default::default(),
         )?;
@@ -118,7 +118,7 @@ impl FsKeyStore {
 
     /// Delete a PKCS#8 key from the keystore.
     pub fn delete(&self, name: &KeyName) -> Result<()> {
-        fs::remove_file(&self.key_path(name))?;
+        fs::remove_file(self.key_path(name))?;
 
         Ok(())
     }
@@ -154,7 +154,7 @@ mod tests {
         let keystore = FsKeyStore::create_or_open(&dir.path().join("keys")).unwrap();
 
         keystore
-            .store(&EXAMPLE_KEY.parse().unwrap(), &example_key)
+            .store(&EXAMPLE_KEY.parse().unwrap(), example_key)
             .unwrap();
 
         FsStoreHandle { keystore, dir }

--- a/subtle-encoding/Cargo.toml
+++ b/subtle-encoding/Cargo.toml
@@ -6,7 +6,7 @@ which avoid data-dependent branching/table lookups and therefore
 provide "best effort" constant time. Useful for encoding/decoding
 secret values such as cryptographic keys.
 """
-version     = "0.5.1" # Also update html_root_url in lib.rs when bumping this
+version     = "0.6.0-pre" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://github.com/iqlusioninc/crates/"
@@ -15,7 +15,7 @@ readme      = "README.md"
 categories  = ["cryptography", "encoding", "no-std"]
 keywords    = ["base64", "bech32", "constant-time", "hex", "security"]
 edition     = "2021"
-rust-version = "1.56"
+rust-version = "1.60"
 
 [dependencies.zeroize]
 version = "1"

--- a/subtle-encoding/src/encoding.rs
+++ b/subtle-encoding/src/encoding.rs
@@ -158,13 +158,8 @@ mod tests {
     const TEST_DATA: &[u8] = b"Testing 1, 2, 3...";
 
     /// Dummy encoding we use to test `Encoding` methods
+    #[derive(Default)]
     struct TestEncoding {}
-
-    impl Default for TestEncoding {
-        fn default() -> Self {
-            Self {}
-        }
-    }
 
     impl Encoding for TestEncoding {
         fn encode_to_slice(&self, src: &[u8], dst: &mut [u8]) -> Result<usize, Error> {
@@ -199,6 +194,6 @@ mod tests {
     fn test_decode() {
         let encoding = TestEncoding::default();
         let encoded = encoding.encode(TEST_DATA);
-        encoding.decode(&encoded).unwrap();
+        encoding.decode(encoded).unwrap();
     }
 }


### PR DESCRIPTION
Bumps the following dependencies:

- `ecdsa` v0.16
- `ed25519-dalek` v2.0.0-pre.0
- `k256` v0.13
- `p256` v0.13
- `p384` v0.13

Includes MSRV bumps to Rust 1.65 for crates with these dependencies, and bumps to Rust 1.60 for other crates in the repo, as that's required to even be in the same workspace as a crate which uses weak/namespaced features.