### PR TITLE
signatory v0.27.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1173,7 +1173,7 @@ dependencies = [
 
 [[package]]
 name = "signatory"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "ecdsa",
  "ed25519-dalek",

--- a/signatory/CHANGELOG.md
+++ b/signatory/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.27.0 (2023-04-05)
+### Changed
+- Bump `ecdsa`to v0.16 ([#1105])
+- Bump `k256` to v0.13 ([#1105])
+- Bump `p256` to v0.13 ([#1105])
+- Bump `p384` to v0.13 ([#1105])
+- Bump `ed25519-dalek` to 2.0.0-rc.2 ([#1113])
+
+[#1105]: https://github.com/iqlusioninc/crates/pull/1105
+[#1113]: https://github.com/iqlusioninc/crates/pull/1113
+
 ## 0.26.0 (2022-08-19)
 ### Added
 - `Send + Sync` bounds to inner `Box` for signer types ([#1037])

--- a/signatory/Cargo.toml
+++ b/signatory/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "signatory"
 description  = "Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support"
-version      = "0.26.0"
+version      = "0.27.0"
 license      = "Apache-2.0 OR MIT"
 authors      = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage     = "https://github.com/iqlusioninc/crates"
@@ -16,7 +16,7 @@ rust-version = "1.65"
 pkcs8 = { version = "0.10", features = ["alloc", "pem"] }
 rand_core = "0.6"
 signature = "2"
-zeroize = "1.6"
+zeroize = "1.5"
 
 # optional dependencies
 ecdsa = { version = "0.16", optional = true, features = ["pem", "pkcs8"] }
@@ -30,10 +30,10 @@ tempfile = "3"
 
 [features]
 default = ["std"]
-ed25519 = ["ed25519-dalek"]
-nistp256 = ["ecdsa", "p256"]
-nistp384 = ["ecdsa", "p384"]
-secp256k1 = ["ecdsa", "k256"]
+ed25519 = ["dep:ed25519-dalek"]
+nistp256 = ["dep:p256", "ecdsa"]
+nistp384 = ["dep:p384", "ecdsa"]
+secp256k1 = ["dep:k256", "ecdsa"]
 std = ["pkcs8/std", "rand_core/std", "signature/std"]
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
### Changed
- Bump `ecdsa`to v0.16 ([#1105])
- Bump `k256` to v0.13 ([#1105])
- Bump `p256` to v0.13 ([#1105])
- Bump `p384` to v0.13 ([#1105])
- Bump `ed25519-dalek` to 2.0.0-rc.2 ([#1113])

[#1105]: https://github.com/iqlusioninc/crates/pull/1105
[#1113]: https://github.com/iqlusioninc/crates/pull/1113