### PR TITLE
bip32: Add ExtendedPublicKey::new

### DIFF
--- a/bip32/src/extended_key/public_key.rs
+++ b/bip32/src/extended_key/public_key.rs
@@ -32,6 +32,11 @@ impl<K> ExtendedPublicKey<K>
 where
     K: PublicKey,
 {
+    /// Create a new extended public key from a public key and attributes.
+    pub fn new(public_key: K, attrs: ExtendedKeyAttrs) -> Self {
+        Self { public_key, attrs }
+    }
+
     /// Obtain the non-extended public key value `K`.
     pub fn public_key(&self) -> &K {
         &self.public_key


### PR DESCRIPTION
This adds a new function to construct a `ExtendedPublicKey` the only way to construct it from a public key right now is via `TryFrom<ExtendedKey>` or `FromStr` both require extra unnecessary computation and unwraps