### PR TITLE
bip32 v0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bip32"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bs58",
  "hex-literal",

--- a/bip32/CHANGELOG.md
+++ b/bip32/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.1 (2023-05-29)
+### Added
+- `ExtendedPublicKey::new` ([#1136])
+
+### Changed
+- Bump `bs58` to v0.5 ([#1139])
+
+[#1136]: https://github.com/iqlusioninc/crates/pull/1136
+[#1139]: https://github.com/iqlusioninc/crates/pull/1139
+
 ## 0.5.0 (2023-03-28)
 ### Added
 - Support for private `ExtendedKey` conversion to `ExtendedPublicKey` ([#1021])

--- a/bip32/Cargo.toml
+++ b/bip32/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bip32"
-version = "0.5.0"
+version = "0.5.1"
 description = """
 BIP32 hierarchical key derivation implemented in a generic, no_std-friendly
 manner. Supports deriving keys using the pure Rust k256 crate or the


### PR DESCRIPTION
### Added
- `ExtendedPublicKey::new` ([#1136])

### Changed
- Bump `bs58` to v0.5 ([#1139])

[#1136]: https://github.com/iqlusioninc/crates/pull/1136
[#1139]: https://github.com/iqlusioninc/crates/pull/1139