### PR TITLE
secrecy: Disable default features on serde to allow no_std builds

### DIFF
--- a/secrecy/Cargo.toml
+++ b/secrecy/Cargo.toml
@@ -22,7 +22,7 @@ zeroize = { version = "1.6", default-features = false }
 
 # optional dependencies
 bytes = { version = "1", optional = true }
-serde = { version = "1", optional = true }
+serde = { version = "1", default-features = false, optional = true }
 
 [features]
 default = ["alloc"]


### PR DESCRIPTION
Fixes <https://github.com/iqlusioninc/crates/issues/1094>.

Note: This could plausibly have some implication on backwards compatibility, where people may need to turn on the default features or `std` feature on `serde` in consuming binaries.