### PR TITLE
hkd32: remove usage of `zeroize_derive`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1551,17 +1551,3 @@ name = "zeroize"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25588073e5216b50bca71d61cb8595cdb9745e87032a58c199730def2862c934"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.11",
-]

--- a/hkd32/Cargo.toml
+++ b/hkd32/Cargo.toml
@@ -22,7 +22,7 @@ rust-version = "1.60"
 hmac = { version = "0.12", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 sha2 = { version = "0.10", default-features = false }
-zeroize = { version = "1", default-features = false, features = ["zeroize_derive"] }
+zeroize = { version = "1", default-features = false }
 
 # optional dependencies
 once_cell = { version = "1", optional = true }

--- a/hkd32/src/key_material.rs
+++ b/hkd32/src/key_material.rs
@@ -23,8 +23,7 @@ use crate::mnemonic;
 ///
 /// This type provides the main key derivation functionality and is used to
 /// represent both input and output key material.
-#[derive(Clone, Zeroize)]
-#[zeroize(drop)]
+#[derive(Clone)]
 pub struct KeyMaterial([u8; KEY_SIZE]);
 
 impl KeyMaterial {
@@ -125,6 +124,12 @@ impl KeyMaterial {
     }
 }
 
+impl Drop for KeyMaterial {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
 impl From<[u8; KEY_SIZE]> for KeyMaterial {
     fn from(bytes: [u8; KEY_SIZE]) -> Self {
         Self::new(bytes)
@@ -136,5 +141,12 @@ impl<'a> TryFrom<&'a [u8]> for KeyMaterial {
 
     fn try_from(slice: &'a [u8]) -> Result<Self, Error> {
         Self::from_bytes(slice)
+    }
+}
+
+// TODO(tarcieri): remove this impl in favor of `ZeroizeOnDrop` in next breaking release
+impl Zeroize for KeyMaterial {
+    fn zeroize(&mut self) {
+        self.0.zeroize();
     }
 }

--- a/hkd32/src/pathbuf.rs
+++ b/hkd32/src/pathbuf.rs
@@ -17,9 +17,8 @@ use zeroize::Zeroize;
 ///
 /// This is the owned path type. The corresponding reference type is
 /// `hkd32::Path` (ala the corresponding types in `std`).
-#[derive(Clone, Default, Eq, Hash, PartialEq, PartialOrd, Ord, Zeroize)]
+#[derive(Clone, Default, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[repr(transparent)]
-#[zeroize(drop)]
 pub struct PathBuf(Vec<u8>);
 
 impl PathBuf {
@@ -91,6 +90,12 @@ impl Deref for PathBuf {
     }
 }
 
+impl Drop for PathBuf {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
+
 impl FromStr for PathBuf {
     type Err = Error;
 
@@ -133,6 +138,13 @@ impl ToOwned for Path {
 
     fn to_owned(&self) -> PathBuf {
         PathBuf::from_bytes(self.as_bytes()).unwrap()
+    }
+}
+
+// TODO(tarcieri): remove this impl in favor of `ZeroizeOnDrop` in next breaking release
+impl Zeroize for PathBuf {
+    fn zeroize(&mut self) {
+        self.0.zeroize();
     }
 }
 


### PR DESCRIPTION
It's being used for trivial impls of the `zeroize` traits, and in the meantime `syn` MSRV changes are breaking the crate's current MSRV.

The derived usages are trivially rewritten without the whole proc macro stack, and really these types shouldn't have `Zeroize` impls at all, but instead impl `Drop` and `ZeroizeOnDrop`.