### PR TITLE
secrecy: disable `serde` default features

### DIFF
--- a/secrecy/Cargo.toml
+++ b/secrecy/Cargo.toml
@@ -21,7 +21,7 @@ rust-version = "1.60"
 zeroize = { version = "1.6", default-features = false, features = ["alloc"] }
 
 # optional dependencies
-serde = { version = "1", optional = true }
+serde = { version = "1", optional = true, default-features = false }
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Originally from #1170