### PR TITLE
Update dependencies to pre-release candidates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,14 +68,15 @@ version = "0.5.2"
 dependencies = [
  "bs58",
  "hex-literal",
- "hmac",
+ "hmac 0.13.0-pre.4",
  "k256",
  "once_cell",
- "pbkdf2",
+ "pbkdf2 0.13.0-pre.1",
  "rand_core",
  "ripemd",
  "secp256k1",
- "sha2",
+ "sha2 0.11.0-pre.4",
+ "signature",
  "subtle",
  "zeroize",
 ]
@@ -96,12 +97,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.11.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17092d478f4fadfb35a7e082f62e49f0907fdf048801d9d706277e34f9df8a78"
+dependencies = [
+ "crypto-common 0.2.0-rc.0",
+]
+
+[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
- "sha2",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -142,6 +152,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9adcf94f05e094fca3005698822ec791cb4433ced416afda1c5ca3b8dfc05a2f"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,11 +184,12 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.5"
+version = "0.6.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+checksum = "e43027691f1c055da3da4f7d96af09fcec420d435d5616e51f29afd0811c56a7"
 dependencies = [
- "generic-array",
+ "hybrid-array",
+ "num-traits",
  "rand_core",
  "subtle",
  "zeroize",
@@ -189,6 +206,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c070b79a496dccd931229780ad5bbedd535ceff6c3565605a8e440e18e1aa2b"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ct-logs"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,13 +226,12 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+source = "git+https://github.com/dalek-cryptography/curve25519-dalek/?branch=rustcrypto-new-releases#44508ba8652ae3445608ad3c56b63ef528ddfb93"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.11.0-pre.9",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -215,8 +240,7 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek-derive"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+source = "git+https://github.com/dalek-cryptography/curve25519-dalek/?branch=rustcrypto-new-releases#44508ba8652ae3445608ad3c56b63ef528ddfb93"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -229,8 +253,19 @@ version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
- "const-oid",
- "pem-rfc7468",
+ "const-oid 0.9.6",
+ "pem-rfc7468 0.7.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d9c07d3bd80cf0935ce478d07edf7e7a5b158446757f988f3e62082227b700"
+dependencies = [
+ "const-oid 0.10.0-rc.0",
+ "pem-rfc7468 1.0.0-rc.1",
  "zeroize",
 ]
 
@@ -240,62 +275,72 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.6",
+ "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.0-pre.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf2e3d6615d99707295a9673e889bf363a04b2a466bd320c65a72536f7577379"
+dependencies = [
+ "block-buffer 0.11.0-rc.0",
+ "const-oid 0.10.0-rc.0",
+ "crypto-common 0.2.0-rc.0",
  "subtle",
 ]
 
 [[package]]
 name = "ecdsa"
-version = "0.16.9"
+version = "0.17.0-pre.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+checksum = "fad051af2b2d2f356d716138c76775929be913deb5b4ea217cd2613535936bef"
 dependencies = [
- "der",
- "digest",
+ "der 0.8.0-rc.0",
+ "digest 0.11.0-pre.9",
  "elliptic-curve",
  "rfc6979",
  "signature",
- "spki",
+ "spki 0.8.0-rc.0",
 ]
 
 [[package]]
 name = "ed25519"
-version = "2.2.3"
+version = "2.3.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+checksum = "62bcc0730fbd27c8619332efad3dfa1de229dc5859a31495ab674e0ac0f9996b"
 dependencies = [
  "signature",
 ]
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
+version = "2.2.0-pre"
+source = "git+https://github.com/dalek-cryptography/curve25519-dalek/?branch=rustcrypto-new-releases#44508ba8652ae3445608ad3c56b63ef528ddfb93"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "sha2",
+ "sha2 0.11.0-pre.4",
  "subtle",
 ]
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.8"
+version = "0.14.0-pre.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+checksum = "4ed8e96bb573517f42470775f8ef1b9cd7595de52ba7a8e19c48325a92c8fe4f"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.11.0-pre.9",
  "ff",
- "generic-array",
  "group",
  "hkdf",
- "pem-rfc7468",
- "pkcs8",
+ "hybrid-array",
+ "pem-rfc7468 1.0.0-rc.1",
+ "pkcs8 0.11.0-rc.0",
  "rand_core",
  "sec1",
  "subtle",
@@ -452,7 +497,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -518,22 +562,22 @@ name = "hkd32"
 version = "0.8.0-pre"
 dependencies = [
  "hex-literal",
- "hmac",
+ "hmac 0.12.1",
  "once_cell",
- "pbkdf2",
+ "pbkdf2 0.12.2",
  "rand_core",
- "sha2",
+ "sha2 0.10.8",
  "subtle-encoding",
  "zeroize",
 ]
 
 [[package]]
 name = "hkdf"
-version = "0.12.4"
+version = "0.13.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+checksum = "00176ff81091018d42ff82e8324f8e5adb0b7e0468d1358f653972562dbff031"
 dependencies = [
- "hmac",
+ "hmac 0.13.0-pre.4",
 ]
 
 [[package]]
@@ -542,7 +586,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0-pre.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4b1fb14e4df79f9406b434b60acef9f45c26c50062cccf1346c6103b8c47d58"
+dependencies = [
+ "digest 0.11.0-pre.9",
 ]
 
 [[package]]
@@ -578,6 +631,16 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.2.0-rc.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d306b679262030ad8813a82d4915fc04efff97776e4db7f8eb5137039d56400"
+dependencies = [
+ "typenum",
+ "zeroize",
+]
 
 [[package]]
 name = "hyper"
@@ -678,15 +741,14 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
+version = "0.14.0-pre.0"
+source = "git+https://github.com/RustCrypto/elliptic-curves#1935596875a3e657db37fa9c674672f79f094f3c"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2",
+ "sha2 0.11.0-pre.4",
  "signature",
 ]
 
@@ -758,6 +820,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "object"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -818,26 +889,26 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.13.2"
+version = "0.14.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+checksum = "2c32c18a74d9dda1314d2f945fb3e274848822f63f264a9e4d3f783e29b3bc1f"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.11.0-pre.4",
 ]
 
 [[package]]
 name = "p384"
-version = "0.13.0"
+version = "0.14.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209"
+checksum = "99acc40dbfad9cc3dc102828f5678c8ca14f0cbf3a1f56f74c2875b5a84427af"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.11.0-pre.4",
 ]
 
 [[package]]
@@ -846,8 +917,18 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
- "hmac",
+ "digest 0.10.7",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.13.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e11753d5193f26dc27ae698e0b536b5e511b7799c5ac475ec10783f26d164a"
+dependencies = [
+ "digest 0.11.0-pre.9",
+ "hmac 0.13.0-pre.4",
 ]
 
 [[package]]
@@ -855,6 +936,15 @@ name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c1cde4770761bf6bd336f947b9ac1fe700b0a4ec5867cf66cf08597fe89e8c"
 dependencies = [
  "base64ct",
 ]
@@ -877,8 +967,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.9",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66180445f1dce533620a7743467ef85fe1c5e80cdaf7c7053609d7a2fbcdae20"
+dependencies = [
+ "der 0.8.0-rc.0",
+ "spki 0.8.0-rc.0",
 ]
 
 [[package]]
@@ -889,9 +989,9 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "primeorder"
-version = "0.13.6"
+version = "0.14.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+checksum = "9bed0c431186675ad845922b903d28c7faa2b634a6d130fb7b50bb289f5a4d52"
 dependencies = [
  "elliptic-curve",
 ]
@@ -925,11 +1025,11 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.4.0"
+version = "0.5.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+checksum = "871ee76a3eee98b0f805e5d1caf26929f4565073c580c053a55f886fc15dea49"
 dependencies = [
- "hmac",
+ "hmac 0.13.0-pre.4",
  "subtle",
 ]
 
@@ -950,11 +1050,10 @@ dependencies = [
 
 [[package]]
 name = "ripemd"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+version = "0.2.0-pre"
+source = "git+https://github.com/RustCrypto/hashes#4e6dd6b71c9145a2756d31c034b2c654156164f1"
 dependencies = [
- "digest",
+ "digest 0.11.0-pre.9",
 ]
 
 [[package]]
@@ -1037,14 +1136,14 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.7.3"
+version = "0.8.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+checksum = "32c98827dc6ed0ea1707286a3d14b4ad4e25e2643169cbf111568a46ff5b09f5"
 dependencies = [
  "base16ct",
- "der",
- "generic-array",
- "pkcs8",
+ "der 0.8.0-rc.0",
+ "hybrid-array",
+ "pkcs8 0.11.0-rc.0",
  "subtle",
  "zeroize",
 ]
@@ -1143,7 +1242,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1154,7 +1253,18 @@ checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0-pre.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "540c0893cce56cdbcfebcec191ec8e0f470dd1889b6e7a0b503e310a94a168f5"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.11.0-pre.9",
 ]
 
 [[package]]
@@ -1166,7 +1276,7 @@ dependencies = [
  "k256",
  "p256",
  "p384",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core",
  "signature",
  "tempfile",
@@ -1175,11 +1285,11 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.2.0"
+version = "2.3.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+checksum = "054d71959c7051b9042c26af337f05cc930575ed2604d7d3ced3158383e59734"
 dependencies = [
- "digest",
+ "digest 0.11.0-pre.9",
  "rand_core",
 ]
 
@@ -1215,7 +1325,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.9",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee3fb1c675852398475928637b3ebbdd7e1d0cc24d27b3bbc81788b4eb51e310"
+dependencies = [
+ "base64ct",
+ "der 0.8.0-rc.0",
 ]
 
 [[package]]

--- a/bip32/Cargo.toml
+++ b/bip32/Cargo.toml
@@ -18,17 +18,18 @@ rust-version = "1.65"
 
 [dependencies]
 bs58 = { version = "0.5", default-features = false, features = ["check"] }
-hmac = { version = "0.12", default-features = false }
+hmac = { version = "0.13.0-pre.4", default-features = false }
 rand_core = { version = "0.6", default-features = false }
-ripemd = { version = "0.1", default-features = false }
-sha2 = { version = "0.10", default-features = false }
+ripemd = { git = "https://github.com/RustCrypto/hashes", version = "0.2.0-pre", default-features = false }
+sha2 = { version = "0.11.0-pre.4", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }
 
 # optional dependencies
-k256 = { version = "0.13", optional = true, default-features = false, features = ["ecdsa", "sha256"] }
+k256 = {git = "https://github.com/RustCrypto/elliptic-curves", optional = true, default-features = false, features = ["ecdsa", "sha256"]}
+signature = { version = "2.3.0-pre.4", default-features = false, features = ["alloc"] }
 once_cell = { version = "1", optional = true }
-pbkdf2 = { version = "0.12", optional = true, default-features = false, features = ["hmac"] }
+pbkdf2 = { version = "0.13.0-pre.1", optional = true, default-features = false, features = ["hmac"] }
 secp256k1-ffi = { package = "secp256k1", version = "0.27", optional = true }
 
 [dev-dependencies]

--- a/bip32/src/extended_key.rs
+++ b/bip32/src/extended_key.rs
@@ -49,7 +49,9 @@ impl ExtendedKey {
         bytes[13..45].copy_from_slice(&self.attrs.chain_code);
         bytes[45..78].copy_from_slice(&self.key_bytes);
 
-        let base58_len = bs58::encode(&bytes).with_check().onto(buffer.as_mut())?;
+        let base58_len = bs58::encode(&bytes)
+            .with_check()
+            .onto(<[u8; Self::MAX_BASE58_SIZE] as AsMut<[u8]>>::as_mut(buffer))?;
         bytes.zeroize();
 
         str::from_utf8(&buffer[..base58_len]).map_err(|_| Error::Base58)

--- a/bip32/src/extended_key/private_key.rs
+++ b/bip32/src/extended_key/private_key.rs
@@ -8,7 +8,7 @@ use core::{
     fmt::{self, Debug},
     str::FromStr,
 };
-use hmac::Mac;
+use hmac::{KeyInit, Mac};
 use subtle::{Choice, ConstantTimeEq};
 use zeroize::Zeroize;
 

--- a/bip32/src/mnemonic/phrase.rs
+++ b/bip32/src/mnemonic/phrase.rs
@@ -44,7 +44,8 @@ impl Phrase {
     /// Create a new BIP39 mnemonic phrase from the given entropy
     pub fn from_entropy(entropy: Entropy, language: Language) -> Self {
         let wordlist = language.wordlist();
-        let checksum_byte = Sha256::digest(entropy.as_ref()).as_slice()[0];
+        let checksum_byte =
+            Sha256::digest(<[u8; 32] as AsRef<[u8]>>::as_ref(&entropy)).as_slice()[0];
 
         // First, create a byte iterator for the given entropy and the first byte of the
         // hash of the entropy that will serve as the checksum (up to 8 bits for biggest

--- a/bip32/src/prefix.rs
+++ b/bip32/src/prefix.rs
@@ -86,7 +86,11 @@ impl Prefix {
         bytes[..4].copy_from_slice(&version.to_be_bytes());
 
         let mut buffer = [0u8; ExtendedKey::MAX_BASE58_SIZE];
-        bs58::encode(&bytes).with_check().onto(buffer.as_mut())?;
+        bs58::encode(&bytes)
+            .with_check()
+            .onto(<[u8; ExtendedKey::MAX_BASE58_SIZE] as AsMut<[u8]>>::as_mut(
+                &mut buffer,
+            ))?;
 
         let s = str::from_utf8(&buffer[..4]).map_err(|_| Error::Base58)?;
         Self::validate_str(s)?;

--- a/bip32/src/private_key.rs
+++ b/bip32/src/private_key.rs
@@ -1,7 +1,7 @@
 //! Trait for deriving child keys on a given type.
 
 use crate::{ChainCode, ChildNumber, Error, HmacSha512, PublicKey, Result, KEY_SIZE};
-use hmac::Mac;
+use hmac::{KeyInit, Mac};
 
 #[cfg(feature = "secp256k1")]
 use crate::XPrv;

--- a/bip32/src/public_key.rs
+++ b/bip32/src/public_key.rs
@@ -3,7 +3,7 @@
 use crate::{
     ChainCode, ChildNumber, Error, HmacSha512, KeyFingerprint, PrivateKeyBytes, Result, KEY_SIZE,
 };
-use hmac::Mac;
+use hmac::{KeyInit, Mac};
 use ripemd::Ripemd160;
 use sha2::{Digest, Sha256};
 

--- a/signatory/Cargo.toml
+++ b/signatory/Cargo.toml
@@ -15,15 +15,15 @@ rust-version = "1.65"
 [dependencies]
 pkcs8 = { version = "0.10", features = ["alloc", "pem"] }
 rand_core = "0.6"
-signature = "2"
+signature = "2.3.0-pre.4"
 zeroize = "1.5"
 
 # optional dependencies
-ecdsa = { version = "0.16", optional = true, features = ["pem", "pkcs8"] }
-ed25519-dalek = { version = "2", optional = true, default-features = false }
-k256 = { version = "0.13", optional = true, features = ["ecdsa", "sha256"] }
-p256 = { version = "0.13", optional = true, features = ["ecdsa", "sha256"] }
-p384 = { version = "0.13", optional = true, features = ["ecdsa", "sha384"] }
+ecdsa = { version = "0.17.0-pre.7", optional = true, features = ["pem", "pkcs8"] }
+ed25519-dalek = { version = "2.2.0-pre", optional = true, default-features = false, git = "https://github.com/dalek-cryptography/curve25519-dalek/", branch="rustcrypto-new-releases" }
+k256 = {git = "https://github.com/RustCrypto/elliptic-curves", optional = true, features = ["ecdsa", "sha256"]}
+p256 = { version = "0.14.0-pre.1", optional = true, features = ["ecdsa", "sha256"] }
+p384 = { version = "0.14.0-pre.1", optional = true, features = ["ecdsa", "sha384"] }
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
Updates `bip32` and `signatory` crates to latest pre-release versions.
