### PR TITLE
secrecy: impl `Deserialize` for `SecretString`

### DIFF
--- a/secrecy/Cargo.toml
+++ b/secrecy/Cargo.toml
@@ -21,7 +21,7 @@ rust-version = "1.60"
 zeroize = { version = "1.6", default-features = false, features = ["alloc"] }
 
 # optional dependencies
-serde = { version = "1", optional = true, default-features = false }
+serde = { version = "1", optional = true, default-features = false, features = ["alloc"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/secrecy/src/lib.rs
+++ b/secrecy/src/lib.rs
@@ -252,6 +252,16 @@ where
 }
 
 #[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for SecretString {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        String::deserialize(deserializer).map(Into::into)
+    }
+}
+
+#[cfg(feature = "serde")]
 impl<T> Serialize for SecretBox<T>
 where
     T: Zeroize + SerializableSecret + Serialize + Sized,


### PR DESCRIPTION
It needs a special impl since `SecretBox<str>` (which `SecretString` is a type alias for) doesn't meet the `Clone` bound (i.e. `str` doesn't impl `Clone`).

Closes #1219