### PR TITLE
add array support for secrecy

### DIFF
--- a/secrecy/src/lib.rs
+++ b/secrecy/src/lib.rs
@@ -206,6 +206,23 @@ where
     }
 }
 
+/// A secret array type
+///
+/// This is a type alias for [`SecretBox<[S; N]>``]
+///
+/// Notably it has a [`From<[S; N]>`] impl which is the preferred method for construction.
+pub type SecretArray<S, const N: usize> = SecretBox<[S; N]>;
+
+impl<S, const N: usize> From<[S; N]> for SecretArray<S, N>
+where
+    S: Zeroize,
+    [S; N]: Zeroize,
+{
+    fn from(array: [S; N]) -> Self {
+        Self::from(Box::new(array))
+    }
+}
+
 /// Secret string type.
 ///
 /// This is a type alias for [`SecretBox<str>`] which supports some helpful trait impls.
@@ -257,6 +274,8 @@ impl CloneableSecret for u32 {}
 impl CloneableSecret for u64 {}
 impl CloneableSecret for u128 {}
 impl CloneableSecret for usize {}
+
+impl<const N: usize, T> CloneableSecret for [T; N] where T: CloneableSecret {}
 
 /// Expose a reference to an inner secret
 pub trait ExposeSecret<S: ?Sized> {


### PR DESCRIPTION
We have some code where we are using fixed length arrays and would like for those to remain secret. This PR adds the ability to do the following

```rust
struct MySecret {
  // normal secret box
  inner_regular: SecretBox<[u8; 32]>,
  // helper type
  inner_with_helper_type: SecretArray<u8, 32>,
}
```

Adds the ability to use `[S; N]` as a secret. Notably, `CloneableSecret` was not implemented for `[S; N]`

Adds a new helper type called `SecretArray` that is just `SecretBox<[S; N]>`