### PR TITLE
Basic docs example for secrecy crate

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -19,3 +19,4 @@ contributions under the terms of the [Apache License, Version 2.0]
 * Yin Guanhao ([@sopium](https://github.com/sopium))
 * Will Speak ([@iwillspeak](https://github.com/iwillspeak))
 * Zach Reizner ([@zachreizner](https://github.com/zachreizner))
+* Rich Clubb ([@richClubb](https://github.com/richClubb))

--- a/secrecy/docs/example.md
+++ b/secrecy/docs/example.md
@@ -1,0 +1,46 @@
+# Secrecy Example
+
+This is a very simple implementation of the `secrecy` crate to get started.
+
+The idea is that the values put into the `Password` struct are easy to use for debugging / logging but you can't easily expose the secrets.
+
+```rust
+use std::fmt::{Debug, Display, Formatter, Result};
+
+use secrecy::{ExposeSecret, SecretBox};
+
+#[derive(Debug)]
+struct Password {
+    value: SecretBox<String>
+}
+
+impl Password {
+    pub fn new(value: String) -> Self {
+        Self {value: SecretBox::new(Box::new(value))}
+    }
+}
+
+impl Display for Password {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        if cfg!(debug_assertions) {
+            write!(f, "{}", self.value.expose_secret())
+        }
+        else {
+            write!(f,"REDACTED")
+        }
+    }
+}
+
+fn main() {
+
+    let basic_password: SecretBox<String> = SecretBox::new(Box::new(String::from("pass")));
+    println!("Manually typed password printed with expose_secret(): \"{}\"", basic_password.expose_secret());
+
+    /*  
+        This method would easily allow you to create logs with usernames / passwords visible for debugging
+        but have confidence that they wouldn't get printed in release builds.
+    */
+    let custom_typed_password:Password = Password::new("test".to_string());
+    println!("Custom struct password printed with traits: \"{}\"", custom_typed_password);
+}
+```


### PR DESCRIPTION
Adding in a simple docs example for the secrecy crate.

Includes a very manual declaration and a custom struct with a trait implementation