### PR TITLE
bip32 v0.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bip32"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "bs58",
  "hex-literal",

--- a/bip32/CHANGELOG.md
+++ b/bip32/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.3 (2025-01-28)
+### Fixed
+- `no_std` support with `secp256k1` crate ([#1254])
+
+[#1254]: https://github.com/iqlusioninc/crates/pull/1254
+
 ## 0.5.2 (2023-07-17)
 ### Added
 - `PrivateKey::derive_tweak()` and `PublicKey::derive_tweak()` ([#1186])

--- a/bip32/Cargo.toml
+++ b/bip32/Cargo.toml
@@ -29,7 +29,7 @@ zeroize = { version = "1", default-features = false }
 k256 = { version = "0.13", optional = true, default-features = false, features = ["ecdsa", "sha256"] }
 once_cell = { version = "1", optional = true }
 pbkdf2 = { version = "0.12", optional = true, default-features = false, features = ["hmac"] }
-secp256k1-ffi = { package = "secp256k1", version = "0.27", optional = true }
+secp256k1-ffi = { package = "secp256k1", version = "0.27", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.4"
@@ -37,7 +37,7 @@ rand_core = { version = "0.6", features = ["std"] }
 
 [features]
 default = ["bip39", "secp256k1", "std"]
-alloc = ["zeroize/alloc"]
+alloc = ["secp256k1-ffi?/alloc", "zeroize/alloc"]
 bip39 = ["mnemonic", "pbkdf2", "std"]
 mnemonic = ["alloc", "once_cell"]
 secp256k1 = ["k256"]

--- a/bip32/Cargo.toml
+++ b/bip32/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bip32"
-version = "0.5.2"
+version = "0.5.3"
 description = """
 BIP32 hierarchical key derivation implemented in a generic, no_std-friendly
 manner. Supports deriving keys using the pure Rust k256 crate or the


### PR DESCRIPTION
### Fixed
- `no_std` support with `secp256k1` crate ([#1254])

[#1254]: https://github.com/iqlusioninc/crates/pull/1254
