### PR TITLE
CI: add `typos` action

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -48,3 +48,9 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: crate-ci/typos@v1.29.4


### PR DESCRIPTION
Automatically check repo for typos, which should hopefully cut down on typo correction PRs:

https://github.com/crate-ci/typos