### PR TITLE
feat: add JSON Schema support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,6 +1000,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "sct"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1021,6 +1038,7 @@ dependencies = [
 name = "secrecy"
 version = "0.10.3"
 dependencies = [
+ "schemars",
  "serde",
  "zeroize",
 ]

--- a/secrecy/Cargo.toml
+++ b/secrecy/Cargo.toml
@@ -1,28 +1,34 @@
 [package]
-name        = "secrecy"
+name = "secrecy"
 description = """
 Wrapper types and traits for secret management which help ensure
 they aren't accidentally copied, logged, or otherwise exposed
 (as much as possible), and also ensure secrets are securely wiped
 from memory when dropped.
 """
-version     = "0.10.3"
-authors     = ["Tony Arcieri <tony@iqlusion.io>"]
-license     = "Apache-2.0 OR MIT"
-homepage    = "https://github.com/iqlusioninc/crates/"
-repository  = "https://github.com/iqlusioninc/crates/tree/main/secrecy"
-readme      = "README.md"
-categories  = ["cryptography", "memory-management", "no-std", "os"]
-keywords    = ["clear", "memory", "secret", "secure", "wipe"]
-edition     = "2021"
+version = "0.10.3"
+authors = ["Tony Arcieri <tony@iqlusion.io>"]
+license = "Apache-2.0 OR MIT"
+homepage = "https://github.com/iqlusioninc/crates/"
+repository = "https://github.com/iqlusioninc/crates/tree/main/secrecy"
+readme = "README.md"
+categories = ["cryptography", "memory-management", "no-std", "os"]
+keywords = ["clear", "memory", "secret", "secure", "wipe"]
+edition = "2021"
 rust-version = "1.60"
 
 [dependencies]
 zeroize = { version = "1.6", default-features = false, features = ["alloc"] }
 
 # optional dependencies
-serde = { version = "1", optional = true, default-features = false, features = ["alloc"] }
+serde = { version = "1", optional = true, default-features = false, features = [
+    "alloc",
+] }
+schemars = { version = "0.8.22", optional = true, default-features = false }
 
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[features]
+jsonschema = ["dep:schemars"]


### PR DESCRIPTION
First of all, thank you for your wonderful work on `secrecy`!

This PR adds [JSON Schema](https://json-schema.org) support to `SecretString` and `SecretBox<T>` using [`schemars`](https://github.com/GREsau/schemars).

My use case for [JSON Schema](https://json-schema.org) is for validation of JSON configuration files used by a web server.

Here is a simplified example of how this works.

We start with a `Config` struct that uses both `SecretString` and `SecretBox`:

```rust
#[derive(Debug, Deserialize, JsonSchema)]
pub struct Config {
    pub username: SecretString,
    pub password: SecretString,
    pub number: SecretBox<u64>,
}
```

We derive [`JsonSchema`](https://docs.rs/schemars/latest/schemars/trait.JsonSchema.html) in order to add [JSON Schema](https://json-schema.org) support.

Then, we export a schema:

```rust
use std::{fs::write, path::Path};

use schemars::schema_for;
use serde_json::to_string_pretty;

use example::Config;

fn main() -> anyhow::Result<()> {
    let path = Path::new("config.schema.json");
    let schema = schema_for!(Config);
    let schema = to_string_pretty(&schema)?;
    write(path, schema)?;
    Ok(())
}
```

The schema produced looks like this:

```json
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "title": "Config",
  "type": "object",
  "required": [
    "number",
    "password",
    "username"
  ],
  "properties": {
    "number": {
      "$ref": "#/definitions/SecretBox_for_uint64"
    },
    "password": {
      "$ref": "#/definitions/SecretString"
    },
    "username": {
      "$ref": "#/definitions/SecretString"
    }
  },
  "definitions": {
    "SecretBox_for_uint64": {
      "type": "integer",
      "format": "uint64",
      "minimum": 0.0
    },
    "SecretString": {
      "type": "string"
    }
  }
}
```

We then add a `.vscode/settings.json` file registering the schema and applying it against `config.json`:

```json
{
    "json.schemas": [
        {
            "fileMatch": [
                "config.json",
            ],
            "url": "./config.schema.json",
        },
    ]
}
```

Now, the contents `config.json` are validated against the schema:

<img width="430" alt="Missing property" src="https://github.com/user-attachments/assets/b7ba4882-f5b8-4760-9c1d-7beb6f063217" />

<img width="567" alt="Incorrect type" src="https://github.com/user-attachments/assets/9bad13f5-d153-4034-83d8-e45e02f8f9e1" />

Once the validation rules are satisfied, we end up with this configuration:

```json
{
  "username": "foo",
  "password": "bar",
  "number": 123
}
```

Finally, we can deserialize the configuration using [`serde`](https://serde.rs) and use the credentials provided, as normal:

```rust
use std::{fs::read_to_string, path::Path};

use serde_json::from_str;

use example::Config;

fn main() -> anyhow::Result<()> {
    let config = read_to_string(Path::new("config.json"))?;
    let config = from_str::<Config>(config.as_str())?;
    println!("{config:?}",);
    Ok(())
}
```

I hope this is a suitable contribution to the project and would appreciate feedback if there are any improvements or fixes needed.