### PR TITLE
Test zeroization when going out of scope

### DIFF
--- a/secrecy/Cargo.toml
+++ b/secrecy/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
-name        = "secrecy"
+name = "secrecy"
 description = """
 Wrapper types and traits for secret management which help ensure
 they aren't accidentally copied, logged, or otherwise exposed
 (as much as possible), and also ensure secrets are securely wiped
 from memory when dropped.
 """
-version     = "0.10.3"
-authors     = ["Tony Arcieri <tony@iqlusion.io>"]
-license     = "Apache-2.0 OR MIT"
-homepage    = "https://github.com/iqlusioninc/crates/"
-repository  = "https://github.com/iqlusioninc/crates/tree/main/secrecy"
-readme      = "README.md"
-categories  = ["cryptography", "memory-management", "no-std", "os"]
-keywords    = ["clear", "memory", "secret", "secure", "wipe"]
-edition     = "2021"
+version = "0.10.3"
+authors = ["Tony Arcieri <tony@iqlusion.io>"]
+license = "Apache-2.0 OR MIT"
+homepage = "https://github.com/iqlusioninc/crates/"
+repository = "https://github.com/iqlusioninc/crates/tree/main/secrecy"
+readme = "README.md"
+categories = ["cryptography", "memory-management", "no-std", "os"]
+keywords = ["clear", "memory", "secret", "secure", "wipe"]
+edition = "2021"
 rust-version = "1.60"
 
 [dependencies]
@@ -22,6 +22,9 @@ zeroize = { version = "1.6", default-features = false, features = ["alloc"] }
 
 # optional dependencies
 serde = { version = "1", optional = true, default-features = false, features = ["alloc"] }
+
+[features]
+test-allocator = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/secrecy/src/lib.rs
+++ b/secrecy/src/lib.rs
@@ -350,6 +350,7 @@ mod tests {
     mod secret_with_custom_allocator {
 
         use super::super::*;
+        use core::mem::size_of;
         use core::ptr;
 
         use std::alloc::{GlobalAlloc, Layout, System};


### PR DESCRIPTION
Test that zeroization actually occurs when a `SecretBox` goes out of scope.

Uses `unsafe` code, likely relies on UB and adds a custom allocator, hence the draft: is something like this acceptable?
