### PR TITLE
Add `SecretBox::from_utf8` and related methods

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -16,6 +16,7 @@ contributions under the terms of the [Apache License, Version 2.0]
 * Kai Ren ([@tyranron](https://github.com/tyranron))
 * Murarth ([@murarth](https://github.com/murarth))
 * Niclas Schwarzlose ([@aticu](https://github.com/aticu))
+* Steven Dee ([@mrdomino](https://github.com/mrdomino))
 * Yin Guanhao ([@sopium](https://github.com/sopium))
 * Will Speak ([@iwillspeak](https://github.com/iwillspeak))
 * Zach Reizner ([@zachreizner](https://github.com/zachreizner))

--- a/secrecy/src/lib.rs
+++ b/secrecy/src/lib.rs
@@ -181,7 +181,7 @@ impl SecretBox<str> {
     /// See [`String::from_utf8`].
     pub fn from_utf8(buf: Vec<u8>) -> Result<Self, FromUtf8Error> {
         String::from_utf8(buf)
-            .map(SecretBox::from)
+            .map(Self::from)
             .map_err(FromUtf8Error::new)
     }
 

--- a/secrecy/src/lib.rs
+++ b/secrecy/src/lib.rs
@@ -196,7 +196,8 @@ impl SecretBox<str> {
     /// This works like [`String::from_utf8`], except that the buffer is truncated to the specified
     /// length before the string is created. Note that the allocation is not resized; if the buffer
     /// is much larger than the resulting string, this is wasteful, and it is probably better to
-    /// call [`SecretString::from`] on the slice to make a new allocation with only the needed size.
+    /// call [`str::from_utf8`] on the slice to make a new allocation with only the needed size, and
+    /// then pass that to [`SecretString::from`].
     pub fn from_utf8_box_len(
         mut other: SecretBox<[u8]>,
         len: usize,

--- a/secrecy/src/lib.rs
+++ b/secrecy/src/lib.rs
@@ -291,22 +291,19 @@ impl FromUtf8Error {
         FromUtf8Error { inner: Some(inner) }
     }
 
+    /// See [`string::FromUtf8Error::as_bytes`].
+    pub fn as_bytes(&self) -> &[u8] {
+        self.inner.as_ref().expect("unreachable").as_bytes()
+    }
+
     /// See [`string::FromUtf8Error::utf8_error`].
     pub fn utf8_error(&self) -> Utf8Error {
-        // Panic safety: `take` is only called on moves.
-        let Some(err) = &self.inner else {
-            unreachable!()
-        };
-        err.utf8_error()
+        self.inner.as_ref().expect("unreachable").utf8_error()
     }
 
     /// See [`string::FromUtf8Error::into_bytes`].
     pub fn into_bytes(mut self) -> Vec<u8> {
-        // Panic safety: `take` is only called here and on `Drop`.
-        let Some(err) = self.inner.take() else {
-            unreachable!()
-        };
-        err.into_bytes()
+        self.inner.take().expect("unreachable").into_bytes()
     }
 }
 
@@ -431,7 +428,7 @@ where
 mod tests {
     use alloc::vec;
 
-    use crate::{ExposeSecret, SecretString};
+    use crate::{ExposeSecret, SecretBox, SecretString};
     use core::str::FromStr;
 
     #[test]
@@ -442,8 +439,11 @@ mod tests {
 
     #[test]
     fn test_secret_string_from_utf8() {
-        let buf = vec![0u8];
+        let buf = vec![0];
         let secret = SecretString::from_utf8(buf).unwrap();
         assert_eq!(secret.expose_secret(), "\0");
+        let buf = SecretBox::from(vec![0x80]);
+        let err = SecretString::from_utf8_box(buf).unwrap_err();
+        assert_eq!(err.as_bytes(), &[0x80]);
     }
 }

--- a/secrecy/src/lib.rs
+++ b/secrecy/src/lib.rs
@@ -36,7 +36,7 @@
 
 extern crate alloc;
 
-use alloc::string::FromUtf8Error as _FromUtf8Error;
+use alloc::string;
 use alloc::{boxed::Box, string::String, vec::Vec};
 use core::convert::Infallible;
 use core::mem::take;
@@ -133,21 +133,19 @@ impl<S: Zeroize + Clone> SecretBox<S> {
     }
 }
 
-/// Error return from [`SecretString::from_utf8`] or [`SecretString::from_utf8_len`].
+/// A possible error value when creating a [`SecretString`] from a UTF-8 byte vector.
 ///
-/// This is like [`FromUtf8Error`] except it zeroizes its buffer on [`Drop`].
-///
-/// [`FromUtf8Error`]: _FromUtf8Error
+/// This is like [`string::FromUtf8Error`] except it zeroizes its buffer on [`Drop`].
 pub struct FromUtf8Error {
-    inner: Option<_FromUtf8Error>,
+    inner: Option<string::FromUtf8Error>,
 }
 
 impl FromUtf8Error {
-    fn new(inner: _FromUtf8Error) -> Self {
+    fn new(inner: string::FromUtf8Error) -> Self {
         FromUtf8Error { inner: Some(inner) }
     }
 
-    /// See [`utf8_error`][_FromUtf8Error::utf8_error].
+    /// See [`string::FromUtf8Error::utf8_error`].
     pub fn utf8_error(&self) -> Utf8Error {
         // Panic safety: `take` is only called on moves.
         let Some(err) = &self.inner else {
@@ -156,7 +154,7 @@ impl FromUtf8Error {
         err.utf8_error()
     }
 
-    /// See [`into_bytes`][_FromUtf8Error::into_bytes].
+    /// See [`string::FromUtf8Error::into_bytes`].
     pub fn into_bytes(mut self) -> Vec<u8> {
         // Panic safety: `take` is only called here and on `Drop`.
         let Some(err) = self.inner.take() else {
@@ -175,26 +173,37 @@ impl Drop for FromUtf8Error {
 }
 
 impl SecretBox<str> {
+    /// Create a [`SecretString`] from a UTF-8 byte buffer.
+    ///
     /// See [`String::from_utf8`].
-    pub fn from_utf8(mut other: SecretBox<[u8]>) -> Result<Self, FromUtf8Error> {
-        Self::try_from(take(&mut other.inner_secret).into_vec())
-    }
-
-    /// Like [`String::from_utf8`], except the buffer is truncated to `len` first.
-    pub fn from_utf8_len(mut other: SecretBox<[u8]>, len: usize) -> Result<Self, FromUtf8Error> {
-        let mut buf = take(&mut other.inner_secret).into_vec();
-        buf.truncate(len);
-        Self::try_from(buf)
-    }
-}
-
-impl TryFrom<Vec<u8>> for SecretBox<str> {
-    type Error = FromUtf8Error;
-
-    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
-        String::from_utf8(value)
+    pub fn from_utf8(buf: Vec<u8>) -> Result<Self, FromUtf8Error> {
+        String::from_utf8(buf)
             .map(SecretBox::from)
             .map_err(FromUtf8Error::new)
+    }
+
+    /// Create a [`SecretString`] from a <code>[SecretBox]&lt;\[u8]&gt;</code>.
+    ///
+    /// This works like [`String::from_utf8`], i.e., it does not allocate but rather takes
+    /// ownership of the backing buffer. Note that the result will have the whole buffer’s
+    /// contents; to perform truncation, see [`SecretString::from_utf8_box_len`].
+    pub fn from_utf8_box(mut other: SecretBox<[u8]>) -> Result<Self, FromUtf8Error> {
+        Self::from_utf8(take(&mut other.inner_secret).into_vec())
+    }
+
+    /// Create a [`SecretString`] from a portion of a <code>[SecretBox]&lt;\[u8]&gt;</code>.
+    ///
+    /// This works like [`String::from_utf8`], except that the buffer is truncated to the specified
+    /// length before the string is created. Note that the allocation is not resized; if the buffer
+    /// is much larger than the resulting string, this is wasteful, and it is probably better to
+    /// call [`SecretString::from`] on the slice to make a new allocation with only the needed size.
+    pub fn from_utf8_box_len(
+        mut other: SecretBox<[u8]>,
+        len: usize,
+    ) -> Result<Self, FromUtf8Error> {
+        let mut buf = take(&mut other.inner_secret).into_vec();
+        buf.truncate(len);
+        Self::from_utf8(buf)
     }
 }
 

--- a/secrecy/src/lib.rs
+++ b/secrecy/src/lib.rs
@@ -36,14 +36,17 @@
 
 extern crate alloc;
 
-use alloc::string;
-use alloc::{boxed::Box, string::String, vec::Vec};
-use core::convert::Infallible;
-use core::mem::take;
-use core::str::{FromStr, Utf8Error};
+use alloc::{
+    boxed::Box,
+    string::{self, String},
+    vec::Vec,
+};
 use core::{
     any,
+    convert::Infallible,
     fmt::{self, Debug},
+    mem,
+    str::{FromStr, Utf8Error},
 };
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
@@ -188,7 +191,7 @@ impl SecretBox<str> {
     /// ownership of the backing buffer. Note that the result will have the whole buffer’s
     /// contents; to perform truncation, see [`SecretString::from_utf8_box_len`].
     pub fn from_utf8_box(mut other: SecretBox<[u8]>) -> Result<Self, FromUtf8Error> {
-        Self::from_utf8(take(&mut other.inner_secret).into_vec())
+        Self::from_utf8(mem::take(&mut other.inner_secret).into_vec())
     }
 
     /// Create a [`SecretString`] from a portion of a <code>[SecretBox]&lt;\[u8]&gt;</code>.
@@ -202,7 +205,7 @@ impl SecretBox<str> {
         mut other: SecretBox<[u8]>,
         len: usize,
     ) -> Result<Self, FromUtf8Error> {
-        let mut buf = take(&mut other.inner_secret).into_vec();
+        let mut buf = mem::take(&mut other.inner_secret).into_vec();
         buf.truncate(len);
         Self::from_utf8(buf)
     }

--- a/secrecy/src/lib.rs
+++ b/secrecy/src/lib.rs
@@ -44,6 +44,7 @@ use alloc::{
 use core::{
     any,
     convert::Infallible,
+    error::Error,
     fmt::{self, Debug},
     mem,
     str::{FromStr, Utf8Error},
@@ -136,81 +137,6 @@ impl<S: Zeroize + Clone> SecretBox<S> {
     }
 }
 
-/// A possible error value when creating a [`SecretString`] from a UTF-8 byte vector.
-///
-/// This is like [`string::FromUtf8Error`] except it zeroizes its buffer on [`Drop`].
-pub struct FromUtf8Error {
-    inner: Option<string::FromUtf8Error>,
-}
-
-impl FromUtf8Error {
-    fn new(inner: string::FromUtf8Error) -> Self {
-        FromUtf8Error { inner: Some(inner) }
-    }
-
-    /// See [`string::FromUtf8Error::utf8_error`].
-    pub fn utf8_error(&self) -> Utf8Error {
-        // Panic safety: `take` is only called on moves.
-        let Some(err) = &self.inner else {
-            unreachable!()
-        };
-        err.utf8_error()
-    }
-
-    /// See [`string::FromUtf8Error::into_bytes`].
-    pub fn into_bytes(mut self) -> Vec<u8> {
-        // Panic safety: `take` is only called here and on `Drop`.
-        let Some(err) = self.inner.take() else {
-            unreachable!()
-        };
-        err.into_bytes()
-    }
-}
-
-impl Drop for FromUtf8Error {
-    fn drop(&mut self) {
-        if let Some(inner) = self.inner.take() {
-            inner.into_bytes().zeroize();
-        }
-    }
-}
-
-impl SecretBox<str> {
-    /// Create a [`SecretString`] from a UTF-8 byte buffer.
-    ///
-    /// See [`String::from_utf8`].
-    pub fn from_utf8(buf: Vec<u8>) -> Result<Self, FromUtf8Error> {
-        String::from_utf8(buf)
-            .map(Self::from)
-            .map_err(FromUtf8Error::new)
-    }
-
-    /// Create a [`SecretString`] from a <code>[SecretBox]&lt;\[u8]&gt;</code>.
-    ///
-    /// This works like [`String::from_utf8`], i.e., it does not allocate but rather takes
-    /// ownership of the backing buffer. Note that the result will have the whole buffer’s
-    /// contents; to perform truncation, see [`SecretString::from_utf8_box_len`].
-    pub fn from_utf8_box(mut other: SecretBox<[u8]>) -> Result<Self, FromUtf8Error> {
-        Self::from_utf8(mem::take(&mut other.inner_secret).into_vec())
-    }
-
-    /// Create a [`SecretString`] from a portion of a <code>[SecretBox]&lt;\[u8]&gt;</code>.
-    ///
-    /// This works like [`String::from_utf8`], except that the buffer is truncated to the specified
-    /// length before the string is created. Note that the allocation is not resized; if the buffer
-    /// is much larger than the resulting string, this is wasteful, and it is probably better to
-    /// call [`str::from_utf8`] on the slice to make a new allocation with only the needed size, and
-    /// then pass that to [`SecretString::from`].
-    pub fn from_utf8_box_len(
-        mut other: SecretBox<[u8]>,
-        len: usize,
-    ) -> Result<Self, FromUtf8Error> {
-        let mut buf = mem::take(&mut other.inner_secret).into_vec();
-        buf.truncate(len);
-        Self::from_utf8(buf)
-    }
-}
-
 impl<S: Zeroize + Default> Default for SecretBox<S> {
     fn default() -> Self {
         Self {
@@ -294,6 +220,50 @@ where
 /// Notably it has a [`From<String>`] impl which is the preferred method for construction.
 pub type SecretString = SecretBox<str>;
 
+/// A possible error value when creating a [`SecretString`] from a UTF-8 byte vector.
+///
+/// This is like [`string::FromUtf8Error`] except it zeroizes its buffer on [`Drop`].
+#[derive(Clone, Debug)]
+pub struct FromUtf8Error {
+    inner: Option<string::FromUtf8Error>,
+}
+
+impl SecretString {
+    /// Create a [`SecretString`] from a UTF-8 byte buffer.
+    ///
+    /// See [`String::from_utf8`].
+    pub fn from_utf8(buf: Vec<u8>) -> Result<Self, FromUtf8Error> {
+        String::from_utf8(buf)
+            .map(Self::from)
+            .map_err(FromUtf8Error::new)
+    }
+
+    /// Create a [`SecretString`] from a <code>[SecretBox]&lt;\[u8]&gt;</code>.
+    ///
+    /// This works like [`String::from_utf8`], i.e., it does not allocate but rather takes
+    /// ownership of the backing buffer. Note that the result will have the whole buffer’s
+    /// contents; to perform truncation, see [`SecretString::from_utf8_box_len`].
+    pub fn from_utf8_box(mut other: SecretBox<[u8]>) -> Result<Self, FromUtf8Error> {
+        Self::from_utf8(mem::take(&mut other.inner_secret).into_vec())
+    }
+
+    /// Create a [`SecretString`] from a portion of a <code>[SecretBox]&lt;\[u8]&gt;</code>.
+    ///
+    /// This works like [`String::from_utf8`], except that the buffer is truncated to the specified
+    /// length before the string is created. Note that the allocation is not resized; if the buffer
+    /// is much larger than the resulting string, this is wasteful, and it is probably better to
+    /// call [`str::from_utf8`] on the slice to make a new allocation with only the needed size, and
+    /// then pass that to [`SecretString::from`].
+    pub fn from_utf8_box_len(
+        mut other: SecretBox<[u8]>,
+        len: usize,
+    ) -> Result<Self, FromUtf8Error> {
+        let mut buf = mem::take(&mut other.inner_secret).into_vec();
+        buf.truncate(len);
+        Self::from_utf8(buf)
+    }
+}
+
 impl From<String> for SecretString {
     fn from(s: String) -> Self {
         Self::from(s.into_boxed_str())
@@ -313,6 +283,46 @@ impl FromStr for SecretString {
         Ok(Self::from(s))
     }
 }
+
+impl FromUtf8Error {
+    fn new(inner: string::FromUtf8Error) -> Self {
+        FromUtf8Error { inner: Some(inner) }
+    }
+
+    /// See [`string::FromUtf8Error::utf8_error`].
+    pub fn utf8_error(&self) -> Utf8Error {
+        // Panic safety: `take` is only called on moves.
+        let Some(err) = &self.inner else {
+            unreachable!()
+        };
+        err.utf8_error()
+    }
+
+    /// See [`string::FromUtf8Error::into_bytes`].
+    pub fn into_bytes(mut self) -> Vec<u8> {
+        // Panic safety: `take` is only called here and on `Drop`.
+        let Some(err) = self.inner.take() else {
+            unreachable!()
+        };
+        err.into_bytes()
+    }
+}
+
+impl Drop for FromUtf8Error {
+    fn drop(&mut self) {
+        if let Some(inner) = self.inner.take() {
+            inner.into_bytes().zeroize();
+        }
+    }
+}
+
+impl fmt::Display for FromUtf8Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self.inner.as_ref().unwrap(), f)
+    }
+}
+
+impl Error for FromUtf8Error {}
 
 impl Clone for SecretString {
     fn clone(&self) -> Self {
@@ -417,6 +427,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec;
+
     use crate::{ExposeSecret, SecretString};
     use core::str::FromStr;
 
@@ -424,5 +436,12 @@ mod tests {
     fn test_secret_string_from_str() {
         let secret = SecretString::from_str("test").unwrap();
         assert_eq!(secret.expose_secret(), "test");
+    }
+
+    #[test]
+    fn test_secret_string_from_utf8() {
+        let buf = vec![0u8];
+        let secret = SecretString::from_utf8(buf).unwrap();
+        assert_eq!(secret.expose_secret(), "\0");
     }
 }

--- a/secrecy/src/lib.rs
+++ b/secrecy/src/lib.rs
@@ -231,7 +231,9 @@ pub struct FromUtf8Error {
 impl SecretString {
     /// Create a [`SecretString`] from a UTF-8 byte buffer.
     ///
-    /// See [`String::from_utf8`].
+    /// See [`String::from_utf8`]. If the passed buffer contains secret data, this should be
+    /// preferred to `String::from_utf8` as that function does not ensure that the buffer is
+    /// zeroized on error.
     pub fn from_utf8(buf: Vec<u8>) -> Result<Self, FromUtf8Error> {
         String::from_utf8(buf)
             .map(Self::from)

--- a/secrecy/src/lib.rs
+++ b/secrecy/src/lib.rs
@@ -149,6 +149,7 @@ impl FromUtf8Error {
 
     /// See [`utf8_error`][_FromUtf8Error::utf8_error].
     pub fn utf8_error(&self) -> Utf8Error {
+        // Panic safety: `take` is only called on moves.
         let Some(err) = &self.inner else {
             unreachable!()
         };

--- a/secrecy/src/lib.rs
+++ b/secrecy/src/lib.rs
@@ -223,7 +223,7 @@ pub type SecretString = SecretBox<str>;
 /// A possible error value when creating a [`SecretString`] from a UTF-8 byte vector.
 ///
 /// This is like [`string::FromUtf8Error`] except it zeroizes its buffer on [`Drop`].
-#[derive(Clone, Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct FromUtf8Error {
     inner: Option<string::FromUtf8Error>,
 }

--- a/secrecy/src/lib.rs
+++ b/secrecy/src/lib.rs
@@ -36,9 +36,11 @@
 
 extern crate alloc;
 
+use alloc::string::FromUtf8Error as _FromUtf8Error;
 use alloc::{boxed::Box, string::String, vec::Vec};
 use core::convert::Infallible;
-use core::str::FromStr;
+use core::mem::take;
+use core::str::{FromStr, Utf8Error};
 use core::{
     any,
     fmt::{self, Debug},
@@ -128,6 +130,70 @@ impl<S: Zeroize + Clone> SecretBox<S> {
         };
         data.zeroize();
         Ok(secret)
+    }
+}
+
+/// Error return from [`SecretString::from_utf8`] or [`SecretString::from_utf8_len`].
+///
+/// This is like [`FromUtf8Error`] except it zeroizes its buffer on [`Drop`].
+///
+/// [`FromUtf8Error`]: _FromUtf8Error
+pub struct FromUtf8Error {
+    inner: Option<_FromUtf8Error>,
+}
+
+impl FromUtf8Error {
+    fn new(inner: _FromUtf8Error) -> Self {
+        FromUtf8Error { inner: Some(inner) }
+    }
+
+    /// See [`utf8_error`][_FromUtf8Error::utf8_error].
+    pub fn utf8_error(&self) -> Utf8Error {
+        let Some(err) = &self.inner else {
+            unreachable!()
+        };
+        err.utf8_error()
+    }
+
+    /// See [`into_bytes`][_FromUtf8Error::into_bytes].
+    pub fn into_bytes(mut self) -> Vec<u8> {
+        // Panic safety: `take` is only called here and on `Drop`.
+        let Some(err) = self.inner.take() else {
+            unreachable!()
+        };
+        err.into_bytes()
+    }
+}
+
+impl Drop for FromUtf8Error {
+    fn drop(&mut self) {
+        if let Some(inner) = self.inner.take() {
+            inner.into_bytes().zeroize();
+        }
+    }
+}
+
+impl SecretBox<str> {
+    /// See [`String::from_utf8`].
+    pub fn from_utf8(mut other: SecretBox<[u8]>) -> Result<Self, FromUtf8Error> {
+        Self::try_from(take(&mut other.inner_secret).into_vec())
+    }
+
+    /// Like [`String::from_utf8`], except the buffer is truncated to `len` first.
+    pub fn from_utf8_len(mut other: SecretBox<[u8]>, len: usize) -> Result<Self, FromUtf8Error> {
+        let mut buf = take(&mut other.inner_secret).into_vec();
+        buf.truncate(len);
+        Self::try_from(buf)
+    }
+}
+
+impl TryFrom<Vec<u8>> for SecretBox<str> {
+    type Error = FromUtf8Error;
+
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        String::from_utf8(value)
+            .map(SecretBox::from)
+            .map_err(FromUtf8Error::new)
     }
 }
 


### PR DESCRIPTION
These methods allow converting a `SecretBox<[u8]>` into a `SecretString` without creating a new allocation. Also adds a new `FromUtf8Error` type, similar to (and in fact wrapping) the one returned by `String::from_utf8`, except that this one zeroizes its buffer on return.

I made the choice here to provide this functionality via functions declared directly on `impl SecretString` (i.e., `impl SecretBox<str>`) rather than via, say, `impl TryFrom<Vec<u8>> for SecretString`. Either approach would probably work; two arguments in favor of the one taken:

1. This follows the existing `String` API.
2. We would not be able to implement `from_utf8_box_len`, except maybe via a contrived `TryFrom<(SecretBox<[u8]>, usize)>`.