### PR TITLE
fix: Don't accept empty key names

### DIFF
--- a/signatory/src/key/name.rs
+++ b/signatory/src/key/name.rs
@@ -22,6 +22,10 @@ impl KeyName {
     pub fn new(name: impl Into<String>) -> Result<Self> {
         let name = name.into();
 
+        if name.is_empty() {
+            return Err(Error::KeyNameInvalid);
+        }
+
         if !name
             .as_bytes()
             .iter()


### PR DESCRIPTION
Accepting empty key names leads to issues when key paths are created and could cause data to be leaked outside the private key store file.