### PR TITLE
hkd32: bump RustCrypto dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,11 +45,11 @@ version = "0.6.0-pre.1"
 dependencies = [
  "bs58",
  "getrandom 0.4.3",
- "hex-literal 0.4.1",
+ "hex-literal",
  "hmac 0.13.0",
  "k256 0.14.0",
  "once_cell",
- "pbkdf2 0.13.0",
+ "pbkdf2",
  "rand_core 0.10.1",
  "ripemd",
  "secp256k1",
@@ -662,12 +662,6 @@ dependencies = [
 
 [[package]]
 name = "hex-literal"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
-
-[[package]]
-name = "hex-literal"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
@@ -676,12 +670,13 @@ checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 name = "hkd32"
 version = "0.8.0-pre"
 dependencies = [
- "hex-literal 1.1.0",
- "hmac 0.12.1",
+ "getrandom 0.4.3",
+ "hex-literal",
+ "hmac 0.13.0",
  "once_cell",
- "pbkdf2 0.12.2",
- "rand_core 0.6.4",
- "sha2 0.10.9",
+ "pbkdf2",
+ "rand_core 0.10.1",
+ "sha2 0.11.0",
  "subtle-encoding",
  "zeroize",
 ]
@@ -1023,16 +1018,6 @@ dependencies = [
  "elliptic-curve 0.13.8",
  "primeorder 0.13.6",
  "sha2 0.10.9",
-]
-
-[[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest 0.10.7",
- "hmac 0.12.1",
 ]
 
 [[package]]

--- a/bip32/Cargo.toml
+++ b/bip32/Cargo.toml
@@ -32,8 +32,8 @@ pbkdf2 = { version = "0.13", optional = true, default-features = false, features
 secp256k1-ffi = { package = "secp256k1", version = "0.33", optional = true, default-features = false }
 
 [dev-dependencies]
-hex-literal = "0.4"
 getrandom = { version = "0.4", features = ["sys_rng"] }
+hex-literal = "1"
 
 [features]
 default = ["bip39", "secp256k1", "std"]

--- a/hkd32/Cargo.toml
+++ b/hkd32/Cargo.toml
@@ -19,19 +19,19 @@ edition     = "2024"
 rust-version = "1.85"
 
 [dependencies]
-hmac = { version = "0.12", default-features = false }
-rand_core = { version = "0.6", default-features = false }
-sha2 = { version = "0.10", default-features = false }
+hmac = { version = "0.13", default-features = false }
+rand_core = { version = "0.10", default-features = false }
+sha2 = { version = "0.11", default-features = false }
 zeroize = { version = "1", default-features = false }
 
 # optional dependencies
 once_cell = { version = "1", optional = true }
-pbkdf2 = { version = "0.12", optional = true, default-features = false, features = ["hmac"] }
+pbkdf2 = { version = "0.13", optional = true, default-features = false, features = ["hmac"] }
 subtle-encoding = { version = "=0.6.0-pre", optional = true, default-features = false, path = "../subtle-encoding" }
 
 [dev-dependencies]
+getrandom = { version = "0.4", features = ["sys_rng"] }
 hex-literal = "1.1"
-rand_core = { version = "0.6", features = ["std"] }
 
 [features]
 default = ["alloc", "bech32"]
@@ -43,4 +43,3 @@ std = [ ]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/hkd32/src/key_material.rs
+++ b/hkd32/src/key_material.rs
@@ -7,8 +7,8 @@
 //! material, and is the primary type useful for deriving other keys.
 
 use crate::{Error, KEY_SIZE, path::Path};
-use hmac::{Hmac, Mac};
-use rand_core::{CryptoRng, RngCore};
+use hmac::{Hmac, KeyInit, Mac};
+use rand_core::CryptoRng;
 use sha2::Sha512;
 use zeroize::Zeroize;
 
@@ -28,7 +28,7 @@ pub struct KeyMaterial([u8; KEY_SIZE]);
 
 impl KeyMaterial {
     /// Create random key material using the operating system CSRNG
-    pub fn random(mut rng: impl RngCore + CryptoRng) -> Self {
+    pub fn random(mut rng: impl CryptoRng) -> Self {
         let mut bytes = [0u8; KEY_SIZE];
         rng.fill_bytes(&mut bytes);
         Self::new(bytes)

--- a/hkd32/src/lib.rs
+++ b/hkd32/src/lib.rs
@@ -23,10 +23,10 @@
 //! # Example
 //!
 //! ```rust
-//! use rand_core::OsRng;
+//! use getrandom::{SysRng, rand_core::UnwrapErr};
 //!
 //! // Parent key
-//! let input_key_material = hkd32::KeyMaterial::random(&mut OsRng);
+//! let input_key_material = hkd32::KeyMaterial::random(&mut UnwrapErr(SysRng));
 //!
 //! // Path to the child key
 //! let derivation_path = "/foo/bar/baz".parse::<hkd32::PathBuf>().unwrap();

--- a/hkd32/src/mnemonic/phrase.rs
+++ b/hkd32/src/mnemonic/phrase.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use crate::{Error, KEY_SIZE, KeyMaterial, Path};
 use alloc::string::String;
-use rand_core::{CryptoRng, RngCore};
+use rand_core::CryptoRng;
 use sha2::{Digest, Sha256};
 use zeroize::{Zeroize, Zeroizing};
 
@@ -35,7 +35,7 @@ pub struct Phrase {
 
 impl Phrase {
     /// Create a random BIP39 mnemonic phrase.
-    pub fn random(mut rng: impl RngCore + CryptoRng, language: Language) -> Self {
+    pub fn random(mut rng: impl CryptoRng, language: Language) -> Self {
         let mut entropy = Entropy::default();
         rng.fill_bytes(&mut entropy);
         Self::from_entropy(entropy, language)


### PR DESCRIPTION
Updates to the latest stable version of these dependencies:

- `hex-literal` v1
- `hmac` v0.12
- `sha2` v0.11.0

Also bumps to `getrandom` v0.4 and `rand_core` v0.10