### PR TITLE
bip32: have `ExtendedPrivateKey::{new, derive_from_path}` borrow `seed`

### DIFF
--- a/bip32/src/extended_key/private_key.rs
+++ b/bip32/src/extended_key/private_key.rs
@@ -51,9 +51,9 @@ where
 
     /// Derive a child key from the given [`DerivationPath`].
     #[cfg(feature = "alloc")]
-    pub fn derive_from_path<S>(seed: S, path: &DerivationPath) -> Result<Self>
+    pub fn derive_from_path<S>(seed: &S, path: &DerivationPath) -> Result<Self>
     where
-        S: AsRef<[u8]>,
+        S: AsRef<[u8]> + ?Sized,
     {
         path.iter().fold(Self::new(seed), |maybe_key, child_num| {
             maybe_key.and_then(|key| key.derive_child(child_num))
@@ -61,9 +61,9 @@ where
     }
 
     /// Create the root extended key for the given seed value.
-    pub fn new<S>(seed: S) -> Result<Self>
+    pub fn new<S>(seed: &S) -> Result<Self>
     where
-        S: AsRef<[u8]>,
+        S: AsRef<[u8]> + ?Sized,
     {
         if ![16, 32, 64].contains(&seed.as_ref().len()) {
             return Err(Error::SeedLength);

--- a/bip32/tests/bip32_vectors.rs
+++ b/bip32/tests/bip32_vectors.rs
@@ -26,7 +26,7 @@ fn test_vector_1() {
 
     // Chain m
     let key_m = derive_xprv(&seed, "m");
-    assert_eq!(key_m, XPrv::new(seed).unwrap());
+    assert_eq!(key_m, XPrv::new(&seed).unwrap());
     assert_eq!(
         &*key_m.to_string(Prefix::XPRV),
         "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi"
@@ -110,7 +110,7 @@ fn test_vector_2() {
 
     // Chain m
     let key_m = derive_xprv(&seed, "m");
-    assert_eq!(key_m, XPrv::new(seed).unwrap());
+    assert_eq!(key_m, XPrv::new(&seed).unwrap());
     assert_eq!(
         &*key_m.to_string(Prefix::XPRV),
         "xprv9s21ZrQH143K31xYSDQpPDxsXRTUcvj2iNHm5NUtrGiGG5e2DtALGdso3pGz6ssrdK4PFmM8NSpSBHNqPqm55Qn3LqFtT2emdEXVYsCzC2U"
@@ -200,7 +200,7 @@ fn test_vector_3() {
 
     // Chain m
     let key_m = derive_xprv(&seed, "m");
-    assert_eq!(key_m, XPrv::new(seed).unwrap());
+    assert_eq!(key_m, XPrv::new(&seed).unwrap());
     assert_eq!(
         &*key_m.to_string(Prefix::XPRV),
         "xprv9s21ZrQH143K25QhxbucbDDuQ4naNntJRi4KUfWT7xo4EKsHt2QJDu7KXp1A3u7Bi1j8ph3EGsZ9Xvz9dGuVrtHHs7pXeTzjuxBrCmmhgC6"
@@ -233,7 +233,7 @@ fn test_vector_4() {
 
     // Chain m
     let key_m = derive_xprv(&seed, "m");
-    assert_eq!(key_m, XPrv::new(seed).unwrap());
+    assert_eq!(key_m, XPrv::new(&seed).unwrap());
     assert_eq!(
         &*key_m.to_string(Prefix::XPRV),
         "xprv9s21ZrQH143K48vGoLGRPxgo2JNkJ3J3fqkirQC2zVdk5Dgd5w14S7fRDyHH4dWNHUgkvsvNDCkvAwcSHNAQwhwgNMgZhLtQC63zxwhQmRv"


### PR DESCRIPTION
Borrows the seed value rather than consuming it, which makes it possible to e.g. zeroize if desired.