### PR TITLE
bip32 v0.6.0-rc.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bip32"
-version = "0.6.0-pre.1"
+version = "0.6.0-rc.0"
 dependencies = [
  "bip39",
  "bs58",

--- a/bip32/Cargo.toml
+++ b/bip32/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bip32"
-version = "0.6.0-pre.1"
+version = "0.6.0-rc.0"
 description = """
 BIP32 hierarchical key derivation implemented in a generic, no_std-friendly
 manner. Supports deriving keys using the pure Rust k256 crate or the


### PR DESCRIPTION
Release candidate with all dependencies upgraded and API changes we intend to ship in the next release.